### PR TITLE
Implement lift-test calibration wiring

### DIFF
--- a/src/wanamaker/data/io.py
+++ b/src/wanamaker/data/io.py
@@ -12,6 +12,15 @@ import pandas as pd
 
 from wanamaker.config import DataConfig
 
+LIFT_TEST_REQUIRED_COLUMNS = {
+    "channel",
+    "test_start",
+    "test_end",
+    "lift_estimate",
+    "ci_lower",
+    "ci_upper",
+}
+
 
 def load_input_csv(config: DataConfig) -> pd.DataFrame:
     """Load the input CSV described by ``config``.
@@ -46,5 +55,61 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
 
     Required columns: channel, test_start, test_end, lift_estimate,
     ci_lower, ci_upper.
+
+    The returned frame preserves the required column names, parses test dates,
+    converts numeric lift fields to floats, and rejects ambiguous duplicate
+    channel rows. Conversion from confidence intervals to ``LiftPrior`` objects
+    is handled by ``wanamaker.model.builder``.
+
+    Args:
+        path: Path to the lift-test CSV.
+
+    Returns:
+        Validated lift-test results, one row per channel.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        ValueError: If required columns are missing, dates/numbers cannot be
+            parsed, intervals are invalid, or a channel appears more than once.
     """
-    raise NotImplementedError("Phase 1: lift-test calibration loader")
+    df = pd.read_csv(path)
+    missing = LIFT_TEST_REQUIRED_COLUMNS - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"lift-test CSV {path} is missing required columns: {sorted(missing)}"
+        )
+
+    out = df[
+        ["channel", "test_start", "test_end", "lift_estimate", "ci_lower", "ci_upper"]
+    ].copy()
+    out["channel"] = out["channel"].astype(str).str.strip()
+    if bool((out["channel"] == "").any()):
+        raise ValueError(f"lift-test CSV {path} contains blank channel names")
+
+    duplicates = sorted(out.loc[out["channel"].duplicated(), "channel"].unique())
+    if duplicates:
+        raise ValueError(
+            f"lift-test CSV {path} contains duplicate channel rows: {duplicates}"
+        )
+
+    for column in ("test_start", "test_end"):
+        out[column] = pd.to_datetime(out[column], errors="raise")
+
+    bad_date_order = out["test_end"] < out["test_start"]
+    if bool(bad_date_order.any()):
+        channels = sorted(out.loc[bad_date_order, "channel"].tolist())
+        raise ValueError(
+            f"lift-test CSV {path} has test_end before test_start for channels: {channels}"
+        )
+
+    for column in ("lift_estimate", "ci_lower", "ci_upper"):
+        out[column] = pd.to_numeric(out[column], errors="raise")
+
+    bad_intervals = out["ci_upper"] <= out["ci_lower"]
+    if bool(bad_intervals.any()):
+        channels = sorted(out.loc[bad_intervals, "channel"].tolist())
+        raise ValueError(
+            f"lift-test CSV {path} has ci_upper <= ci_lower for channels: {channels}"
+        )
+
+    return out

--- a/src/wanamaker/engine/pymc.py
+++ b/src/wanamaker/engine/pymc.py
@@ -185,6 +185,7 @@ class PyMCEngine:
         coords = {"time": np.arange(len(data), dtype=np.int64)}
         channels = list(getattr(model_spec, "channels", []))
         control_columns = list(getattr(model_spec, "control_columns", []))
+        lift_test_priors = dict(getattr(model_spec, "lift_test_priors", {}))
 
         # Data-adaptive scale for priors whose natural magnitude is proportional
         # to the target.  Using 2 × std for the intercept gives a weakly
@@ -230,9 +231,11 @@ class PyMCEngine:
                     sigma=priors.hill_alpha_sigma,
                 )
                 saturated = _hill_saturation_tensor(pt, adstocked, ec50, slope)
-                coefficient = pm.HalfNormal(
-                    f"channel__{channel.name}__coefficient",
-                    sigma=target_std,
+                coefficient = _coefficient_prior(
+                    pm=pm,
+                    name=f"channel__{channel.name}__coefficient",
+                    lift_prior=lift_test_priors.get(channel.name),
+                    default_sigma=target_std,
                 )
                 contribution = pm.Deterministic(
                     f"contribution__{channel.name}",
@@ -376,6 +379,19 @@ def _hill_saturation_tensor(pt: Any, spend: Any, ec50: Any, slope: Any) -> Any:
     numerator = pt.power(positive_spend, slope)
     denominator = numerator + pt.power(ec50, slope) + 1e-12
     return numerator / denominator
+
+
+def _coefficient_prior(pm: Any, name: str, lift_prior: Any | None, default_sigma: float) -> Any:
+    """Return the channel coefficient prior, optionally calibrated by lift tests."""
+    if lift_prior is None:
+        return pm.HalfNormal(name, sigma=default_sigma)
+
+    return pm.TruncatedNormal(
+        name,
+        mu=float(lift_prior.mean_roi),
+        sigma=float(lift_prior.sd_roi),
+        lower=0.0,
+    )
 
 
 def _log_positive_median(values: NDArray[np.float64]) -> float:

--- a/src/wanamaker/model/builder.py
+++ b/src/wanamaker/model/builder.py
@@ -14,10 +14,15 @@ Separation of concerns:
 
 from __future__ import annotations
 
+import math
+
 from wanamaker.config import WanamakerConfig
+from wanamaker.data.io import load_lift_test_csv
 from wanamaker.data.taxonomy import DEFAULT_CHANNEL_CATEGORIES
 from wanamaker.model.priors import default_priors_for_category
-from wanamaker.model.spec import ChannelSpec, ModelSpec
+from wanamaker.model.spec import ChannelSpec, LiftPrior, ModelSpec
+
+_NORMAL_95_Z = 1.959963984540054
 
 
 def build_model_spec(cfg: WanamakerConfig) -> ModelSpec:
@@ -70,6 +75,7 @@ def build_model_spec(cfg: WanamakerConfig) -> ModelSpec:
         ch.name: default_priors_for_category(ch.category)
         for ch in cfg.channels
     }
+    lift_test_priors = _load_lift_test_priors(cfg)
 
     return ModelSpec(
         channels=channel_specs,
@@ -77,5 +83,36 @@ def build_model_spec(cfg: WanamakerConfig) -> ModelSpec:
         date_column=cfg.data.date_column,
         control_columns=list(cfg.data.control_columns),
         channel_priors=channel_priors,
+        lift_test_priors=lift_test_priors,
         runtime_mode=cfg.run.runtime_mode,
     )
+
+
+def _load_lift_test_priors(cfg: WanamakerConfig) -> dict[str, LiftPrior]:
+    if cfg.data.lift_test_csv is None:
+        return {}
+
+    channel_names = {channel.name for channel in cfg.channels}
+    lift_tests = load_lift_test_csv(cfg.data.lift_test_csv)
+    unknown = sorted(set(lift_tests["channel"]) - channel_names)
+    if unknown:
+        raise ValueError(
+            "lift-test CSV contains channels that are not configured: "
+            f"{unknown}. Add them to channels or remove the lift-test rows."
+        )
+
+    priors: dict[str, LiftPrior] = {}
+    for row in lift_tests.itertuples(index=False):
+        interval_width = float(row.ci_upper) - float(row.ci_lower)
+        sd_roi = interval_width / (2.0 * _NORMAL_95_Z)
+        if not math.isfinite(sd_roi) or sd_roi <= 0.0:
+            raise ValueError(
+                f"lift-test CSV produced a non-positive prior sd for channel {row.channel!r}"
+            )
+        priors[str(row.channel)] = LiftPrior(
+            mean_roi=float(row.lift_estimate),
+            sd_roi=sd_roi,
+            confidence=0.95,
+        )
+
+    return priors

--- a/src/wanamaker/model/spec.py
+++ b/src/wanamaker/model/spec.py
@@ -41,11 +41,11 @@ PyMC, NumPyro, or Stan code without leakage between layers.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Literal
 
 from wanamaker.model.priors import ChannelPriors
-
 
 # ---------------------------------------------------------------------------
 # Per-channel structural spec
@@ -106,6 +106,13 @@ class LiftPrior:
     mean_roi: float
     sd_roi: float
     confidence: float = 0.95
+
+    def __post_init__(self) -> None:
+        """Validate lift-prior uncertainty."""
+        if not math.isfinite(self.sd_roi) or self.sd_roi <= 0.0:
+            raise ValueError(f"sd_roi must be strictly positive; got {self.sd_roi!r}")
+        if not 0.0 < self.confidence < 1.0:
+            raise ValueError(f"confidence must be in (0, 1); got {self.confidence!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_lift_test_calibration.py
+++ b/tests/unit/test_lift_test_calibration.py
@@ -1,0 +1,191 @@
+"""Unit tests for lift-test calibration wiring (issue #16)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wanamaker.config import ChannelConfig, DataConfig, WanamakerConfig
+from wanamaker.data.io import load_lift_test_csv
+from wanamaker.engine.pymc import _coefficient_prior
+from wanamaker.model.builder import build_model_spec
+
+
+def _write_lift_csv(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "lift_tests.csv"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _config(tmp_path: Path, lift_test_csv: Path | None = None) -> WanamakerConfig:
+    data_csv = tmp_path / "data.csv"
+    data_csv.write_text(
+        "week,revenue,search,tv\n2024-01-01,100,10,20\n2024-01-08,110,12,22\n",
+        encoding="utf-8",
+    )
+    return WanamakerConfig(
+        data=DataConfig(
+            csv_path=data_csv,
+            date_column="week",
+            target_column="revenue",
+            spend_columns=["search", "tv"],
+            lift_test_csv=lift_test_csv,
+        ),
+        channels=[
+            ChannelConfig(name="search", category="paid_search"),
+            ChannelConfig(name="tv", category="linear_tv"),
+        ],
+    )
+
+
+def test_load_lift_test_csv_parses_dates_and_numeric_fields(tmp_path: Path) -> None:
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
+    )
+
+    df = load_lift_test_csv(path)
+
+    assert list(df.columns) == [
+        "channel",
+        "test_start",
+        "test_end",
+        "lift_estimate",
+        "ci_lower",
+        "ci_upper",
+    ]
+    assert df.loc[0, "channel"] == "search"
+    assert pd.api.types.is_datetime64_any_dtype(df["test_start"])
+    assert df.loc[0, "lift_estimate"] == pytest.approx(2.0)
+
+
+def test_load_lift_test_csv_requires_all_columns(tmp_path: Path) -> None:
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower\n"
+        "search,2024-01-01,2024-01-14,2.0,1.2\n",
+    )
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        load_lift_test_csv(path)
+
+
+def test_load_lift_test_csv_rejects_duplicate_channel_rows(tmp_path: Path) -> None:
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n"
+        "search,2024-02-01,2024-02-14,2.2,1.4,3.0\n",
+    )
+
+    with pytest.raises(ValueError, match="duplicate channel"):
+        load_lift_test_csv(path)
+
+
+def test_load_lift_test_csv_rejects_invalid_interval(tmp_path: Path) -> None:
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,2.8,1.2\n",
+    )
+
+    with pytest.raises(ValueError, match="ci_upper <= ci_lower"):
+        load_lift_test_csv(path)
+
+
+def test_build_model_spec_converts_lift_tests_to_priors(tmp_path: Path) -> None:
+    lift_csv = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.216014,2.783986\n",
+    )
+
+    spec = build_model_spec(_config(tmp_path, lift_csv))
+
+    assert set(spec.lift_test_priors) == {"search"}
+    prior = spec.lift_test_priors["search"]
+    assert prior.mean_roi == pytest.approx(2.0)
+    assert prior.sd_roi == pytest.approx(0.4, rel=1e-6)
+    assert prior.confidence == pytest.approx(0.95)
+
+
+def test_build_model_spec_rejects_lift_test_for_unknown_channel(tmp_path: Path) -> None:
+    lift_csv = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "social,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
+    )
+
+    with pytest.raises(ValueError, match="not configured"):
+        build_model_spec(_config(tmp_path, lift_csv))
+
+
+def test_lift_tests_do_not_modify_adstock_or_saturation_priors(tmp_path: Path) -> None:
+    base = build_model_spec(_config(tmp_path))
+    lift_csv = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
+    )
+    calibrated = build_model_spec(_config(tmp_path, lift_csv))
+
+    assert calibrated.channel_priors == base.channel_priors
+    assert calibrated.lift_test_priors["search"].mean_roi == pytest.approx(2.0)
+
+
+class _FakePM:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, float]]] = []
+
+    def HalfNormal(self, name: str, **kwargs: float) -> str:  # noqa: N802
+        self.calls.append(("HalfNormal", name, kwargs))
+        return "half-normal"
+
+    def TruncatedNormal(self, name: str, **kwargs: float) -> str:  # noqa: N802
+        self.calls.append(("TruncatedNormal", name, kwargs))
+        return "truncated-normal"
+
+
+def test_pymc_coefficient_prior_uses_lift_prior_when_present(tmp_path: Path) -> None:
+    lift_csv = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.216014,2.783986\n",
+    )
+    spec = build_model_spec(_config(tmp_path, lift_csv))
+    fake_pm = _FakePM()
+
+    result = _coefficient_prior(
+        pm=fake_pm,
+        name="channel__search__coefficient",
+        lift_prior=spec.lift_test_priors["search"],
+        default_sigma=99.0,
+    )
+
+    assert result == "truncated-normal"
+    assert fake_pm.calls == [
+        (
+            "TruncatedNormal",
+            "channel__search__coefficient",
+            {"mu": pytest.approx(2.0), "sigma": pytest.approx(0.4), "lower": 0.0},
+        )
+    ]
+
+
+def test_pymc_coefficient_prior_uses_default_without_lift_prior() -> None:
+    fake_pm = _FakePM()
+
+    result = _coefficient_prior(
+        pm=fake_pm,
+        name="channel__tv__coefficient",
+        lift_prior=None,
+        default_sigma=10.0,
+    )
+
+    assert result == "half-normal"
+    assert fake_pm.calls == [
+        ("HalfNormal", "channel__tv__coefficient", {"sigma": 10.0})
+    ]

--- a/tests/unit/test_model_spec.py
+++ b/tests/unit/test_model_spec.py
@@ -11,9 +11,10 @@ Verifies the contract that all engines depend on:
 from __future__ import annotations
 
 import math
+
 import pytest
 
-from wanamaker.model.priors import ChannelPriors, default_priors_for_category
+from wanamaker.model.priors import default_priors_for_category
 from wanamaker.model.spec import (
     AnchoredPrior,
     ChannelSpec,
@@ -22,7 +23,6 @@ from wanamaker.model.spec import (
     ModelSpec,
     SeasonalitySpec,
 )
-
 
 # ---------------------------------------------------------------------------
 # ChannelSpec
@@ -64,6 +64,14 @@ class TestLiftPrior:
     def test_custom_confidence(self) -> None:
         lp = LiftPrior(mean_roi=1.0, sd_roi=0.2, confidence=0.90)
         assert lp.confidence == 0.90
+
+    def test_rejects_non_positive_sd(self) -> None:
+        with pytest.raises(ValueError, match="sd_roi"):
+            LiftPrior(mean_roi=1.0, sd_roi=0.0)
+
+    def test_rejects_invalid_confidence(self) -> None:
+        with pytest.raises(ValueError, match="confidence"):
+            LiftPrior(mean_roi=1.0, sd_roi=0.2, confidence=1.0)
 
     def test_is_frozen(self) -> None:
         lp = LiftPrior(mean_roi=1.0, sd_roi=0.2)


### PR DESCRIPTION
Fixes #16.

## Summary
- Implement `load_lift_test_csv` validation for lift-test calibration files.
- Convert lift-test confidence intervals into `LiftPrior` objects when building `ModelSpec`.
- Apply lift priors to PyMC channel coefficients only, leaving adstock and saturation priors unchanged.
- Add focused unit tests for loader validation, builder conversion, `LiftPrior` validation, and backend prior selection without running a full sampler.

## Validation
- `python -m pytest tests\unit\test_lift_test_calibration.py tests\unit\test_model_spec.py tests\unit\test_fit_command.py tests\unit\test_pymc_engine.py -q` -> 88 passed
- `python -m ruff check src\wanamaker\data\io.py src\wanamaker\model\builder.py src\wanamaker\model\spec.py src\wanamaker\engine\pymc.py tests\unit\test_lift_test_calibration.py tests\unit\test_model_spec.py` -> passed

## Note
This verifies the calibration wiring and coefficient-prior substitution. Full posterior-shift and benchmark acceptance should run with the engine benchmark suite once those jobs are enabled.