### PR TITLE
Implement Trust Card computation

### DIFF
--- a/src/wanamaker/trust_card/__init__.py
+++ b/src/wanamaker/trust_card/__init__.py
@@ -14,5 +14,27 @@ from wanamaker.trust_card.card import (
     TrustDimension,
     TrustStatus,
 )
+from wanamaker.trust_card.compute import (
+    PriorSensitivityResult,
+    build_trust_card,
+    convergence_dimension,
+    holdout_accuracy_dimension,
+    lift_test_consistency_dimension,
+    prior_sensitivity_dimension,
+    refresh_stability_dimension,
+    saturation_identifiability_dimension,
+)
 
-__all__ = ["TrustCard", "TrustDimension", "TrustStatus"]
+__all__ = [
+    "PriorSensitivityResult",
+    "TrustCard",
+    "TrustDimension",
+    "TrustStatus",
+    "build_trust_card",
+    "convergence_dimension",
+    "holdout_accuracy_dimension",
+    "lift_test_consistency_dimension",
+    "prior_sensitivity_dimension",
+    "refresh_stability_dimension",
+    "saturation_identifiability_dimension",
+]

--- a/src/wanamaker/trust_card/card.py
+++ b/src/wanamaker/trust_card/card.py
@@ -13,10 +13,10 @@ v1 dimensions (FR-5.4):
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 
 
-class TrustStatus(str, Enum):
+class TrustStatus(StrEnum):
     PASS = "pass"
     MODERATE = "moderate"
     WEAK = "weak"
@@ -32,3 +32,21 @@ class TrustDimension:
 @dataclass(frozen=True)
 class TrustCard:
     dimensions: list[TrustDimension]
+
+    def dimension(self, name: str) -> TrustDimension | None:
+        """Return one dimension by name, or ``None`` when absent."""
+        return next((dimension for dimension in self.dimensions if dimension.name == name), None)
+
+    @property
+    def has_weak_dimension(self) -> bool:
+        """Whether any dimension should trigger hedged report language."""
+        return any(dimension.status == TrustStatus.WEAK for dimension in self.dimensions)
+
+    @property
+    def weak_dimension_names(self) -> list[str]:
+        """Names of dimensions with ``weak`` status, for report templates."""
+        return [
+            dimension.name
+            for dimension in self.dimensions
+            if dimension.status == TrustStatus.WEAK
+        ]

--- a/src/wanamaker/trust_card/compute.py
+++ b/src/wanamaker/trust_card/compute.py
@@ -1,0 +1,338 @@
+"""Trust Card computation (FR-5.4).
+
+This module converts completed fit artifacts into the six v1 Trust Card
+dimensions. It is deliberately deterministic and template-friendly: every
+dimension returns a status plus a plain-English explanation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+from wanamaker.engine.summary import ChannelContributionSummary, PosteriorSummary
+from wanamaker.model.spec import LiftPrior
+from wanamaker.refresh.classify import unexplained_fraction
+from wanamaker.refresh.diff import RefreshDiff
+from wanamaker.trust_card.card import TrustCard, TrustDimension, TrustStatus
+
+CONVERGENCE_RHAT_PASS = 1.01
+CONVERGENCE_RHAT_MODERATE = 1.05
+CONVERGENCE_ESS_PASS = 400.0
+CONVERGENCE_ESS_MODERATE = 100.0
+HOLDOUT_WAPE_PASS = 0.10
+HOLDOUT_WAPE_MODERATE = 0.20
+REFRESH_UNEXPLAINED_PASS = 0.10
+REFRESH_UNEXPLAINED_MODERATE = 0.25
+PRIOR_SHIFT_PASS = 0.10
+PRIOR_SHIFT_MODERATE = 0.25
+SPEND_CV_THRESHOLD = 0.10
+NORMAL_95_Z = 1.959963984540054
+
+
+@dataclass(frozen=True)
+class PriorSensitivityResult:
+    """Summary of a prior-sensitivity refit.
+
+    ``max_relative_shift`` is the largest posterior mean movement observed
+    under a prior perturbation, expressed relative to the original posterior
+    magnitude. For example, ``0.12`` means the largest movement was 12%.
+    """
+
+    max_relative_shift: float
+
+
+def build_trust_card(
+    summary: PosteriorSummary,
+    *,
+    holdout_actuals: Sequence[float] | None = None,
+    refresh_diff: RefreshDiff | None = None,
+    prior_sensitivity: PriorSensitivityResult | float | None = None,
+    spend_cv_by_channel: Mapping[str, float] | None = None,
+    lift_test_priors: Mapping[str, LiftPrior] | None = None,
+) -> TrustCard:
+    """Build a v1 Trust Card from completed fit artifacts.
+
+    Args:
+        summary: Engine-neutral posterior summary from the completed fit.
+        holdout_actuals: Actual target values for the same periods as
+            ``summary.in_sample_predictive`` when that predictive summary is
+            being used as a held-out-period prediction.
+        refresh_diff: Optional diff against a previous run. When absent, the
+            refresh-stability dimension is omitted.
+        prior_sensitivity: Optional prior sensitivity result. When absent, the
+            dimension is included as ``moderate`` because the check has not yet
+            been run.
+        spend_cv_by_channel: Optional coefficient of variation by channel,
+            usually from the data diagnostic.
+        lift_test_priors: Optional lift-test priors keyed by channel. When
+            absent or empty, the lift-test consistency dimension is omitted.
+
+    Returns:
+        Trust card with deterministic v1 dimensions.
+    """
+    dimensions = [
+        convergence_dimension(summary),
+        holdout_accuracy_dimension(summary, holdout_actuals),
+        prior_sensitivity_dimension(prior_sensitivity),
+        saturation_identifiability_dimension(summary.channel_contributions, spend_cv_by_channel),
+    ]
+
+    if refresh_diff is not None:
+        dimensions.append(refresh_stability_dimension(refresh_diff))
+    if lift_test_priors:
+        dimensions.append(
+            lift_test_consistency_dimension(summary.channel_contributions, lift_test_priors)
+        )
+
+    return TrustCard(dimensions=dimensions)
+
+
+def convergence_dimension(summary: PosteriorSummary) -> TrustDimension:
+    """Assess sampler convergence from ``ConvergenceSummary``."""
+    convergence = summary.convergence
+    if convergence is None:
+        return TrustDimension(
+            name="convergence",
+            status=TrustStatus.WEAK,
+            explanation="Convergence diagnostics are missing.",
+        )
+
+    r_hat = convergence.max_r_hat
+    ess = convergence.min_ess_bulk
+    divergences = convergence.n_divergences
+
+    if r_hat is None or ess is None:
+        return TrustDimension(
+            name="convergence",
+            status=TrustStatus.MODERATE,
+            explanation="R-hat or ESS was not available; review sampler output manually.",
+        )
+
+    if r_hat < CONVERGENCE_RHAT_PASS and ess > CONVERGENCE_ESS_PASS and divergences == 0:
+        return TrustDimension(
+            name="convergence",
+            status=TrustStatus.PASS,
+            explanation=(
+                f"Sampler diagnostics passed: max R-hat {r_hat:.3f}, "
+                f"min ESS {ess:.0f}, divergences {divergences}."
+            ),
+        )
+
+    if r_hat <= CONVERGENCE_RHAT_MODERATE and ess >= CONVERGENCE_ESS_MODERATE:
+        return TrustDimension(
+            name="convergence",
+            status=TrustStatus.MODERATE,
+            explanation=(
+                f"Sampler diagnostics are mixed: max R-hat {r_hat:.3f}, "
+                f"min ESS {ess:.0f}, divergences {divergences}."
+            ),
+        )
+
+    return TrustDimension(
+        name="convergence",
+        status=TrustStatus.WEAK,
+        explanation=(
+            f"Sampler diagnostics are weak: max R-hat {r_hat:.3f}, "
+            f"min ESS {ess:.0f}, divergences {divergences}."
+        ),
+    )
+
+
+def holdout_accuracy_dimension(
+    summary: PosteriorSummary,
+    actuals: Sequence[float] | None,
+) -> TrustDimension:
+    """Assess held-out predictive accuracy using WAPE."""
+    predictive = summary.in_sample_predictive
+    if predictive is None or actuals is None:
+        return TrustDimension(
+            name="holdout_accuracy",
+            status=TrustStatus.MODERATE,
+            explanation="Holdout accuracy was not evaluated for this run.",
+        )
+
+    y_true = np.asarray(actuals, dtype=float)
+    y_pred = np.asarray(predictive.mean, dtype=float)
+    if y_true.shape != y_pred.shape:
+        raise ValueError(
+            "holdout_actuals must have the same length as PredictiveSummary.mean "
+            f"({len(y_true)} != {len(y_pred)})"
+        )
+    denominator = float(np.sum(np.abs(y_true)))
+    if denominator == 0.0:
+        return TrustDimension(
+            name="holdout_accuracy",
+            status=TrustStatus.MODERATE,
+            explanation="Holdout actuals sum to zero, so WAPE is undefined.",
+        )
+
+    wape = float(np.sum(np.abs(y_true - y_pred)) / denominator)
+    if wape <= HOLDOUT_WAPE_PASS:
+        status = TrustStatus.PASS
+    elif wape <= HOLDOUT_WAPE_MODERATE:
+        status = TrustStatus.MODERATE
+    else:
+        status = TrustStatus.WEAK
+
+    return TrustDimension(
+        name="holdout_accuracy",
+        status=status,
+        explanation=f"Holdout WAPE is {wape:.1%}.",
+    )
+
+
+def refresh_stability_dimension(refresh_diff: RefreshDiff) -> TrustDimension:
+    """Assess refresh stability from the fraction of unexplained movements."""
+    fraction = unexplained_fraction(refresh_diff.movements)
+    n_movements = len(refresh_diff.movements)
+
+    if fraction <= REFRESH_UNEXPLAINED_PASS:
+        status = TrustStatus.PASS
+    elif fraction <= REFRESH_UNEXPLAINED_MODERATE:
+        status = TrustStatus.MODERATE
+    else:
+        status = TrustStatus.WEAK
+
+    return TrustDimension(
+        name="refresh_stability",
+        status=status,
+        explanation=(
+            f"{fraction:.1%} of {n_movements} parameter movement(s) were unexplained."
+        ),
+    )
+
+
+def prior_sensitivity_dimension(
+    prior_sensitivity: PriorSensitivityResult | float | None,
+) -> TrustDimension:
+    """Assess posterior stability under perturbed priors."""
+    if prior_sensitivity is None:
+        return TrustDimension(
+            name="prior_sensitivity",
+            status=TrustStatus.MODERATE,
+            explanation="Prior sensitivity was not evaluated for this run.",
+        )
+
+    shift = (
+        float(prior_sensitivity.max_relative_shift)
+        if isinstance(prior_sensitivity, PriorSensitivityResult)
+        else float(prior_sensitivity)
+    )
+
+    if shift <= PRIOR_SHIFT_PASS:
+        status = TrustStatus.PASS
+    elif shift <= PRIOR_SHIFT_MODERATE:
+        status = TrustStatus.MODERATE
+    else:
+        status = TrustStatus.WEAK
+
+    return TrustDimension(
+        name="prior_sensitivity",
+        status=status,
+        explanation=f"Maximum posterior shift under prior perturbation was {shift:.1%}.",
+    )
+
+
+def saturation_identifiability_dimension(
+    channel_contributions: Sequence[ChannelContributionSummary],
+    spend_cv_by_channel: Mapping[str, float] | None,
+) -> TrustDimension:
+    """Assess whether channel saturation can be learned from observed spend."""
+    weak_channels = []
+    moderate_channels = []
+    cv_by_channel = spend_cv_by_channel or {}
+
+    for contribution in channel_contributions:
+        cv = cv_by_channel.get(contribution.channel)
+        if contribution.spend_invariant or (cv is not None and cv < SPEND_CV_THRESHOLD):
+            weak_channels.append(contribution.channel)
+        elif cv is None:
+            moderate_channels.append(contribution.channel)
+
+    if weak_channels:
+        names = ", ".join(sorted(weak_channels))
+        return TrustDimension(
+            name="saturation_identifiability",
+            status=TrustStatus.WEAK,
+            explanation=(
+                f"Saturation is weakly identified for: {names}. "
+                "Spend variation is too limited to estimate curve shape from data."
+            ),
+        )
+
+    if moderate_channels:
+        return TrustDimension(
+            name="saturation_identifiability",
+            status=TrustStatus.MODERATE,
+            explanation=(
+                "Spend variation diagnostics were unavailable for "
+                f"{len(moderate_channels)} channel(s); identifiability is only partially assessed."
+            ),
+        )
+
+    return TrustDimension(
+        name="saturation_identifiability",
+        status=TrustStatus.PASS,
+        explanation="All channel spend series have enough variation for saturation checks.",
+    )
+
+
+def lift_test_consistency_dimension(
+    channel_contributions: Sequence[ChannelContributionSummary],
+    lift_test_priors: Mapping[str, LiftPrior],
+) -> TrustDimension:
+    """Compare posterior ROI intervals to supplied lift-test estimates."""
+    contributions = {contribution.channel: contribution for contribution in channel_contributions}
+    weak = []
+    moderate = []
+    missing = []
+
+    for channel, prior in lift_test_priors.items():
+        contribution = contributions.get(channel)
+        if contribution is None:
+            missing.append(channel)
+            continue
+
+        lift_low = prior.mean_roi - NORMAL_95_Z * prior.sd_roi
+        lift_high = prior.mean_roi + NORMAL_95_Z * prior.sd_roi
+        posterior_low = contribution.roi_hdi_low
+        posterior_high = contribution.roi_hdi_high
+        overlaps = posterior_low <= lift_high and lift_low <= posterior_high
+        posterior_mean_in_lift_interval = lift_low <= contribution.roi_mean <= lift_high
+
+        if not overlaps:
+            weak.append(channel)
+        elif not posterior_mean_in_lift_interval:
+            moderate.append(channel)
+
+    if weak:
+        names = ", ".join(sorted(weak))
+        return TrustDimension(
+            name="lift_test_consistency",
+            status=TrustStatus.WEAK,
+            explanation=f"Posterior ROI does not overlap lift-test intervals for: {names}.",
+        )
+
+    if moderate or missing:
+        details = []
+        if moderate:
+            details.append(
+                "posterior means outside lift-test intervals: "
+                f"{', '.join(sorted(moderate))}"
+            )
+        if missing:
+            details.append(f"no posterior ROI summary: {', '.join(sorted(missing))}")
+        return TrustDimension(
+            name="lift_test_consistency",
+            status=TrustStatus.MODERATE,
+            explanation="Lift-test consistency is mixed (" + "; ".join(details) + ").",
+        )
+
+    return TrustDimension(
+        name="lift_test_consistency",
+        status=TrustStatus.PASS,
+        explanation="Posterior ROI intervals are consistent with supplied lift tests.",
+    )

--- a/tests/unit/test_trust_card_compute.py
+++ b/tests/unit/test_trust_card_compute.py
@@ -1,0 +1,339 @@
+"""Unit tests for Trust Card computation (issue #19)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    ConvergenceSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+from wanamaker.model.spec import LiftPrior
+from wanamaker.refresh.classify import MovementClass
+from wanamaker.refresh.diff import ParameterMovement, RefreshDiff
+from wanamaker.trust_card import (
+    PriorSensitivityResult,
+    TrustStatus,
+    build_trust_card,
+    convergence_dimension,
+    holdout_accuracy_dimension,
+    lift_test_consistency_dimension,
+    prior_sensitivity_dimension,
+    refresh_stability_dimension,
+    saturation_identifiability_dimension,
+)
+from wanamaker.trust_card.card import TrustCard, TrustDimension
+
+
+def _summary(
+    convergence: ConvergenceSummary | None = None,
+    predictive: PredictiveSummary | None = None,
+    contributions: list[ChannelContributionSummary] | None = None,
+) -> PosteriorSummary:
+    return PosteriorSummary(
+        convergence=convergence,
+        in_sample_predictive=predictive,
+        channel_contributions=contributions or [],
+    )
+
+
+def _convergence(
+    r_hat: float | None = 1.005,
+    ess: float | None = 500.0,
+    divergences: int = 0,
+) -> ConvergenceSummary:
+    return ConvergenceSummary(
+        max_r_hat=r_hat,
+        min_ess_bulk=ess,
+        n_divergences=divergences,
+        n_chains=4,
+        n_draws=1000,
+    )
+
+
+def _predictive(values: list[float]) -> PredictiveSummary:
+    return PredictiveSummary(
+        periods=[str(i) for i in range(len(values))],
+        mean=values,
+        hdi_low=[value - 1.0 for value in values],
+        hdi_high=[value + 1.0 for value in values],
+    )
+
+
+def _contribution(
+    channel: str,
+    roi_mean: float = 2.0,
+    roi_low: float = 1.5,
+    roi_high: float = 2.5,
+    spend_invariant: bool = False,
+) -> ChannelContributionSummary:
+    return ChannelContributionSummary(
+        channel=channel,
+        mean_contribution=100.0,
+        hdi_low=80.0,
+        hdi_high=120.0,
+        roi_mean=roi_mean,
+        roi_hdi_low=roi_low,
+        roi_hdi_high=roi_high,
+        observed_spend_min=10.0,
+        observed_spend_max=100.0,
+        spend_invariant=spend_invariant,
+    )
+
+
+def _movement(cls: MovementClass) -> ParameterMovement:
+    return ParameterMovement(
+        name="channel.search.roi",
+        previous_mean=1.0,
+        current_mean=1.1,
+        previous_ci=(0.5, 1.5),
+        current_ci=(0.6, 1.6),
+        movement_class=cls,
+    )
+
+
+class TestTrustCardHelpers:
+    def test_has_weak_dimension(self) -> None:
+        card = TrustCard(
+            [
+                TrustDimension("convergence", TrustStatus.PASS, "ok"),
+                TrustDimension("holdout_accuracy", TrustStatus.WEAK, "bad"),
+            ]
+        )
+
+        assert card.has_weak_dimension is True
+        assert card.weak_dimension_names == ["holdout_accuracy"]
+        assert card.dimension("convergence") is not None
+        assert card.dimension("missing") is None
+
+
+class TestConvergenceDimension:
+    def test_pass(self) -> None:
+        result = convergence_dimension(_summary(_convergence()))
+
+        assert result.status == TrustStatus.PASS
+        assert result.name == "convergence"
+
+    def test_moderate_for_degraded_but_usable_diagnostics(self) -> None:
+        result = convergence_dimension(_summary(_convergence(r_hat=1.03, ess=250.0)))
+
+        assert result.status == TrustStatus.MODERATE
+
+    def test_weak_for_bad_rhat(self) -> None:
+        result = convergence_dimension(_summary(_convergence(r_hat=1.08, ess=500.0)))
+
+        assert result.status == TrustStatus.WEAK
+
+    def test_moderate_when_rhat_unavailable(self) -> None:
+        result = convergence_dimension(_summary(_convergence(r_hat=None)))
+
+        assert result.status == TrustStatus.MODERATE
+
+    def test_weak_when_missing(self) -> None:
+        result = convergence_dimension(_summary(convergence=None))
+
+        assert result.status == TrustStatus.WEAK
+
+
+class TestHoldoutAccuracyDimension:
+    def test_pass_for_low_wape(self) -> None:
+        result = holdout_accuracy_dimension(
+            _summary(predictive=_predictive([100.0, 110.0])),
+            actuals=[100.0, 100.0],
+        )
+
+        assert result.status == TrustStatus.PASS
+        assert "WAPE" in result.explanation
+
+    def test_moderate_when_not_evaluated(self) -> None:
+        result = holdout_accuracy_dimension(_summary(), actuals=None)
+
+        assert result.status == TrustStatus.MODERATE
+
+    def test_weak_for_high_wape(self) -> None:
+        result = holdout_accuracy_dimension(
+            _summary(predictive=_predictive([50.0, 50.0])),
+            actuals=[100.0, 100.0],
+        )
+
+        assert result.status == TrustStatus.WEAK
+
+    def test_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="same length"):
+            holdout_accuracy_dimension(
+                _summary(predictive=_predictive([100.0])),
+                actuals=[100.0, 110.0],
+            )
+
+
+class TestRefreshStabilityDimension:
+    def test_pass_for_low_unexplained_fraction(self) -> None:
+        diff = RefreshDiff(
+            previous_run_id="a",
+            current_run_id="b",
+            movements=[_movement(MovementClass.WITHIN_PRIOR_CI)] * 10,
+        )
+
+        result = refresh_stability_dimension(diff)
+
+        assert result.status == TrustStatus.PASS
+
+    def test_moderate_for_some_unexplained_movements(self) -> None:
+        diff = RefreshDiff(
+            previous_run_id="a",
+            current_run_id="b",
+            movements=[
+                _movement(MovementClass.UNEXPLAINED),
+                *_movement_list(MovementClass.WITHIN_PRIOR_CI, 4),
+            ],
+        )
+
+        result = refresh_stability_dimension(diff)
+
+        assert result.status == TrustStatus.MODERATE
+
+    def test_weak_for_many_unexplained_movements(self) -> None:
+        diff = RefreshDiff(
+            previous_run_id="a",
+            current_run_id="b",
+            movements=[
+                _movement(MovementClass.UNEXPLAINED),
+                _movement(MovementClass.UNEXPLAINED),
+                _movement(MovementClass.WITHIN_PRIOR_CI),
+            ],
+        )
+
+        result = refresh_stability_dimension(diff)
+
+        assert result.status == TrustStatus.WEAK
+
+
+class TestPriorSensitivityDimension:
+    def test_moderate_when_missing(self) -> None:
+        assert prior_sensitivity_dimension(None).status == TrustStatus.MODERATE
+
+    def test_pass_for_small_shift(self) -> None:
+        result = prior_sensitivity_dimension(PriorSensitivityResult(max_relative_shift=0.05))
+
+        assert result.status == TrustStatus.PASS
+
+    def test_moderate_for_mid_shift(self) -> None:
+        assert prior_sensitivity_dimension(0.15).status == TrustStatus.MODERATE
+
+    def test_weak_for_large_shift(self) -> None:
+        assert prior_sensitivity_dimension(0.40).status == TrustStatus.WEAK
+
+
+class TestSaturationIdentifiabilityDimension:
+    def test_pass_when_all_channels_have_variation(self) -> None:
+        result = saturation_identifiability_dimension(
+            [_contribution("search"), _contribution("tv")],
+            {"search": 0.3, "tv": 0.2},
+        )
+
+        assert result.status == TrustStatus.PASS
+
+    def test_weak_for_spend_invariant_channel(self) -> None:
+        result = saturation_identifiability_dimension(
+            [_contribution("tv", spend_invariant=True)],
+            {"tv": 0.0},
+        )
+
+        assert result.status == TrustStatus.WEAK
+        assert "tv" in result.explanation
+
+    def test_weak_for_low_cv_channel(self) -> None:
+        result = saturation_identifiability_dimension(
+            [_contribution("display")],
+            {"display": 0.02},
+        )
+
+        assert result.status == TrustStatus.WEAK
+
+    def test_moderate_when_cv_unavailable(self) -> None:
+        result = saturation_identifiability_dimension([_contribution("search")], None)
+
+        assert result.status == TrustStatus.MODERATE
+
+
+class TestLiftTestConsistencyDimension:
+    def test_pass_when_intervals_overlap_and_mean_inside_lift_interval(self) -> None:
+        result = lift_test_consistency_dimension(
+            [_contribution("search", roi_mean=2.0, roi_low=1.8, roi_high=2.2)],
+            {"search": LiftPrior(mean_roi=2.0, sd_roi=0.2)},
+        )
+
+        assert result.status == TrustStatus.PASS
+
+    def test_moderate_when_intervals_overlap_but_mean_outside_lift_interval(self) -> None:
+        result = lift_test_consistency_dimension(
+            [_contribution("search", roi_mean=2.6, roi_low=2.2, roi_high=2.7)],
+            {"search": LiftPrior(mean_roi=2.0, sd_roi=0.2)},
+        )
+
+        assert result.status == TrustStatus.MODERATE
+
+    def test_weak_when_intervals_do_not_overlap(self) -> None:
+        result = lift_test_consistency_dimension(
+            [_contribution("search", roi_mean=4.0, roi_low=3.8, roi_high=4.2)],
+            {"search": LiftPrior(mean_roi=2.0, sd_roi=0.2)},
+        )
+
+        assert result.status == TrustStatus.WEAK
+
+    def test_moderate_when_posterior_summary_missing_channel(self) -> None:
+        result = lift_test_consistency_dimension(
+            [_contribution("tv")],
+            {"search": LiftPrior(mean_roi=2.0, sd_roi=0.2)},
+        )
+
+        assert result.status == TrustStatus.MODERATE
+
+
+class TestBuildTrustCard:
+    def test_builds_expected_core_dimensions(self) -> None:
+        card = build_trust_card(
+            _summary(
+                convergence=_convergence(),
+                predictive=_predictive([100.0, 110.0]),
+                contributions=[_contribution("search")],
+            ),
+            holdout_actuals=[100.0, 100.0],
+            prior_sensitivity=0.05,
+            spend_cv_by_channel={"search": 0.2},
+        )
+
+        names = [dimension.name for dimension in card.dimensions]
+        assert names == [
+            "convergence",
+            "holdout_accuracy",
+            "prior_sensitivity",
+            "saturation_identifiability",
+        ]
+        assert card.has_weak_dimension is False
+
+    def test_includes_optional_refresh_and_lift_dimensions(self) -> None:
+        card = build_trust_card(
+            _summary(
+                convergence=_convergence(),
+                contributions=[_contribution("search", roi_mean=2.0)],
+            ),
+            prior_sensitivity=0.05,
+            spend_cv_by_channel={"search": 0.2},
+            refresh_diff=RefreshDiff(
+                previous_run_id="a",
+                current_run_id="b",
+                movements=[_movement(MovementClass.WITHIN_PRIOR_CI)],
+            ),
+            lift_test_priors={"search": LiftPrior(mean_roi=2.0, sd_roi=0.2)},
+        )
+
+        names = [dimension.name for dimension in card.dimensions]
+        assert "refresh_stability" in names
+        assert "lift_test_consistency" in names
+
+
+def _movement_list(cls: MovementClass, count: int) -> list[ParameterMovement]:
+    return [_movement(cls) for _ in range(count)]


### PR DESCRIPTION
Fixes #19.

## Summary
- Add deterministic Trust Card computation for all v1 dimensions:
  - convergence
  - holdout accuracy
  - refresh stability
  - prior sensitivity
  - saturation identifiability
  - lift-test consistency
- Add small `TrustCard` helpers for report/template code: `dimension`, `has_weak_dimension`, and `weak_dimension_names`.
- Export the computation API from `wanamaker.trust_card`.
- Add focused unit tests for pass/moderate/weak behavior on each dimension and for the top-level builder.

## Design notes
- Refresh stability and lift-test consistency are included only when their inputs are provided.
- Prior sensitivity is reported as `moderate` when the refit/perturbation result is unavailable, so reports do not silently treat an unrun check as a pass.
- Holdout accuracy uses WAPE when actuals are supplied.
- Saturation identifiability uses `spend_invariant` plus optional spend CV diagnostics.

## Validation
- `python -m pytest tests\unit\test_trust_card_compute.py tests\unit\test_artifact_schemas.py tests\test_no_network_in_core.py -q` -> 73 passed
- `python -m pytest tests\unit -q` -> 401 passed
- `python -m ruff check src\wanamaker\trust_card tests\unit\test_trust_card_compute.py` -> passed

## Remaining integration work
This PR implements the computation layer. Persisting the computed card from `wanamaker fit`/`report`, full synthetic-benchmark verification, and prior-sensitivity refit orchestration remain downstream integration work as the engine/report flows mature.