### PR TITLE
Implement posterior predictive forecast planning

### DIFF
--- a/src/wanamaker/forecast/__init__.py
+++ b/src/wanamaker/forecast/__init__.py
@@ -12,3 +12,17 @@ v1 deliberately ships scenario comparison rather than constrained inverse
 optimization (deferred to v1.1, BRD/PRD §4.2). User-driven scenarios keep
 the human in control of strategic decisions.
 """
+
+from wanamaker.forecast.posterior_predictive import (
+    ExtrapolationFlag,
+    ForecastResult,
+    PosteriorPredictiveEngine,
+    forecast,
+)
+
+__all__ = [
+    "ExtrapolationFlag",
+    "ForecastResult",
+    "PosteriorPredictiveEngine",
+    "forecast",
+]

--- a/src/wanamaker/forecast/posterior_predictive.py
+++ b/src/wanamaker/forecast/posterior_predictive.py
@@ -1,7 +1,320 @@
-"""Posterior-predictive forecasting (FR-5.1 mode 2)."""
+"""Posterior-predictive forecasting (FR-5.1 mode 2).
+
+This module owns the downstream forecasting contract: future plans are
+validated against the engine-neutral ``PosteriorSummary`` so forecast warnings
+can be produced without reaching into an engine-native posterior object.
+Sampling remains the engine's job through ``posterior_predictive``.
+"""
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
 
-def forecast(posterior, future_spend, seed: int):  # noqa: ANN001
-    raise NotImplementedError("Phase 1: posterior-predictive forecast")
+import pandas as pd
+
+from wanamaker.engine.base import Posterior
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+
+PERIOD_COLUMN_CANDIDATES = ("period", "date", "week", "month")
+LONG_PLAN_COLUMNS = {"period", "channel", "spend"}
+CHANNEL_COLUMN = "channel"
+
+
+class PosteriorPredictiveEngine(Protocol):
+    """Minimum engine surface needed for posterior predictive forecasting."""
+
+    def posterior_predictive(
+        self,
+        posterior_summary: PosteriorSummary,
+        new_data: pd.DataFrame,
+        seed: int,
+    ) -> PredictiveSummary:
+        """Draw target samples for ``new_data`` using ``posterior_summary`` context."""
+        ...
+
+
+@dataclass(frozen=True)
+class ExtrapolationFlag:
+    """One plan cell outside the historical observed spend range."""
+
+    period: str
+    channel: str
+    planned_spend: float
+    observed_spend_min: float
+    observed_spend_max: float
+    direction: str
+
+
+@dataclass(frozen=True)
+class ForecastResult(PredictiveSummary):
+    """Predictive summary plus forecast-specific warning metadata.
+
+    ``ForecastResult`` subclasses ``PredictiveSummary`` so existing consumers
+    that only need period means and HDIs can use it directly. The extra fields
+    are for CLI/report layers that need to show extrapolation warnings and note
+    channels whose saturation was not identifiable from training data.
+    """
+
+    extrapolation_flags: list[ExtrapolationFlag] = field(default_factory=list)
+    spend_invariant_channels: list[str] = field(default_factory=list)
+
+    @property
+    def extrapolated_periods(self) -> list[str]:
+        """Return unique period labels that contain any extrapolated spend."""
+        return list(dict.fromkeys(flag.period for flag in self.extrapolation_flags))
+
+
+@dataclass(frozen=True)
+class _ForecastPlan:
+    periods: list[str]
+    data: pd.DataFrame
+
+
+def forecast(
+    posterior_summary: PosteriorSummary,
+    future_spend: str | Path | pd.DataFrame,
+    seed: int,
+    engine: PosteriorPredictiveEngine,
+) -> ForecastResult:
+    """Forecast the target metric for a future spend plan.
+
+    Args:
+        posterior_summary: Engine-neutral summary from a completed fit. A bare
+            ``Posterior`` is deliberately rejected because it does not carry the
+            observed spend ranges needed for extrapolation warnings.
+        future_spend: Future plan as either a CSV path or a ``DataFrame``. Wide
+            format is ``period,<channel_1>,<channel_2>,...``. Transposed wide
+            format is ``channel,<period_1>,<period_2>,...``. Long format is
+            ``period,channel,spend``.
+        seed: Explicit posterior-predictive seed.
+        engine: Engine implementation that can draw posterior predictive
+            samples from the summary and normalized future plan.
+
+    Returns:
+        A ``ForecastResult`` containing point estimates, HDIs, and warning
+        metadata for extrapolated or spend-invariant channels.
+
+    Raises:
+        TypeError: If ``posterior_summary`` is a bare ``Posterior`` or if
+            ``future_spend`` is not a supported type.
+        ValueError: If the summary lacks channel spend ranges, the plan is
+            malformed, or the engine returns a summary with incompatible length.
+    """
+    if isinstance(posterior_summary, Posterior):
+        raise TypeError(
+            "forecast requires a PosteriorSummary, not a bare Posterior. "
+            "Downstream forecast logic needs observed spend ranges from summary.json."
+        )
+    if not isinstance(posterior_summary, PosteriorSummary):
+        raise TypeError("posterior_summary must be a PosteriorSummary")
+
+    channel_ranges = _channel_ranges(posterior_summary)
+    channels = list(channel_ranges)
+    plan = _load_plan(future_spend, channels)
+    flags = _extrapolation_flags(plan, channel_ranges)
+    spend_invariant_channels = [
+        c.channel for c in posterior_summary.channel_contributions if c.spend_invariant
+    ]
+
+    predictive = engine.posterior_predictive(posterior_summary, plan.data, seed)
+    _validate_predictive(predictive, plan.periods)
+
+    return ForecastResult(
+        periods=list(predictive.periods),
+        mean=list(predictive.mean),
+        hdi_low=list(predictive.hdi_low),
+        hdi_high=list(predictive.hdi_high),
+        interval_mass=predictive.interval_mass,
+        extrapolation_flags=flags,
+        spend_invariant_channels=spend_invariant_channels,
+    )
+
+
+def _channel_ranges(
+    posterior_summary: PosteriorSummary,
+) -> dict[str, ChannelContributionSummary]:
+    ranges = {
+        contribution.channel: contribution
+        for contribution in posterior_summary.channel_contributions
+    }
+    if not ranges:
+        raise ValueError(
+            "PosteriorSummary.channel_contributions is empty; cannot validate "
+            "future spend ranges for forecast."
+        )
+    return ranges
+
+
+def _load_plan(
+    future_spend: str | Path | pd.DataFrame,
+    required_channels: list[str],
+) -> _ForecastPlan:
+    if isinstance(future_spend, (str, Path)):
+        raw = pd.read_csv(future_spend)
+    elif isinstance(future_spend, pd.DataFrame):
+        raw = future_spend.copy()
+    else:
+        raise TypeError("future_spend must be a CSV path or pandas DataFrame")
+
+    if raw.empty:
+        raise ValueError("future spend plan has no rows")
+
+    if _is_long_plan(raw):
+        normalized = _normalize_long_plan(raw)
+    elif _is_channel_rows_plan(raw):
+        normalized = _normalize_channel_rows_plan(raw, required_channels)
+    else:
+        normalized = raw
+    period_column = _period_column(normalized)
+
+    if period_column is None:
+        periods = [str(i) for i in range(len(normalized))]
+        data = normalized.copy()
+        data.insert(0, "period", periods)
+        period_column = "period"
+    else:
+        periods = normalized[period_column].astype(str).tolist()
+        data = normalized.copy()
+        if period_column != "period":
+            data = data.rename(columns={period_column: "period"})
+            period_column = "period"
+
+    _validate_channels(data, required_channels, period_column)
+    for channel in required_channels:
+        data[channel] = pd.to_numeric(data[channel], errors="raise")
+        if data[channel].isna().any():
+            raise ValueError(f"future spend plan contains missing values for {channel!r}")
+        if (data[channel] < 0).any():
+            raise ValueError(f"future spend plan contains negative spend for {channel!r}")
+
+    return _ForecastPlan(periods=periods, data=data[["period", *required_channels]])
+
+
+def _is_long_plan(data: pd.DataFrame) -> bool:
+    return LONG_PLAN_COLUMNS.issubset({str(column).lower() for column in data.columns})
+
+
+def _is_channel_rows_plan(data: pd.DataFrame) -> bool:
+    columns = {str(column).lower() for column in data.columns}
+    return CHANNEL_COLUMN in columns and "spend" not in columns
+
+
+def _normalize_long_plan(data: pd.DataFrame) -> pd.DataFrame:
+    lower_to_original = {str(column).lower(): column for column in data.columns}
+    period_col = lower_to_original["period"]
+    channel_col = lower_to_original["channel"]
+    spend_col = lower_to_original["spend"]
+    duplicates = data.duplicated(subset=[period_col, channel_col])
+    if duplicates.any():
+        duplicated_rows = data.loc[duplicates, [period_col, channel_col]].to_dict("records")
+        raise ValueError(f"future spend plan has duplicate period/channel rows: {duplicated_rows}")
+    pivoted = data.pivot(index=period_col, columns=channel_col, values=spend_col)
+    pivoted = pivoted.reset_index()
+    pivoted.columns = [str(column) for column in pivoted.columns]
+    return pivoted
+
+
+def _normalize_channel_rows_plan(
+    data: pd.DataFrame,
+    required_channels: list[str],
+) -> pd.DataFrame:
+    lower_to_original = {str(column).lower(): column for column in data.columns}
+    channel_col = lower_to_original[CHANNEL_COLUMN]
+    duplicate_channels = data[channel_col].duplicated()
+    if duplicate_channels.any():
+        duplicates = data.loc[duplicate_channels, channel_col].astype(str).tolist()
+        raise ValueError(f"future spend plan has duplicate channel rows: {duplicates}")
+
+    indexed = data.set_index(channel_col)
+    missing = sorted(set(required_channels) - set(map(str, indexed.index)))
+    if missing:
+        raise ValueError(f"future spend plan is missing channel rows: {missing}")
+    extras = sorted(set(map(str, indexed.index)) - set(required_channels))
+    if extras:
+        raise ValueError(f"future spend plan has unrecognized channel rows: {extras}")
+
+    transposed = indexed.loc[required_channels].transpose().reset_index()
+    transposed = transposed.rename(columns={"index": "period"})
+    transposed.columns = [str(column) for column in transposed.columns]
+    return transposed
+
+
+def _period_column(data: pd.DataFrame) -> str | None:
+    lower_to_original = {str(column).lower(): str(column) for column in data.columns}
+    for candidate in PERIOD_COLUMN_CANDIDATES:
+        if candidate in lower_to_original:
+            return lower_to_original[candidate]
+    return None
+
+
+def _validate_channels(
+    data: pd.DataFrame,
+    required_channels: list[str],
+    period_column: str,
+) -> None:
+    columns = set(map(str, data.columns))
+    required = set(required_channels)
+    missing = sorted(required - columns)
+    if missing:
+        raise ValueError(f"future spend plan is missing channel columns: {missing}")
+    extras = sorted(columns - required - {period_column})
+    if extras:
+        raise ValueError(f"future spend plan has unrecognized columns: {extras}")
+
+
+def _extrapolation_flags(
+    plan: _ForecastPlan,
+    channel_ranges: dict[str, ChannelContributionSummary],
+) -> list[ExtrapolationFlag]:
+    flags: list[ExtrapolationFlag] = []
+    for _, row in plan.data.iterrows():
+        period = str(row["period"])
+        for channel, summary in channel_ranges.items():
+            planned = float(row[channel])
+            if planned > summary.observed_spend_max:
+                flags.append(
+                    ExtrapolationFlag(
+                        period=period,
+                        channel=channel,
+                        planned_spend=planned,
+                        observed_spend_min=summary.observed_spend_min,
+                        observed_spend_max=summary.observed_spend_max,
+                        direction="above_historical_max",
+                    )
+                )
+            elif planned < summary.observed_spend_min:
+                flags.append(
+                    ExtrapolationFlag(
+                        period=period,
+                        channel=channel,
+                        planned_spend=planned,
+                        observed_spend_min=summary.observed_spend_min,
+                        observed_spend_max=summary.observed_spend_max,
+                        direction="below_historical_min",
+                    )
+                )
+    return flags
+
+
+def _validate_predictive(predictive: Any, periods: list[str]) -> None:
+    if not isinstance(predictive, PredictiveSummary):
+        raise TypeError("engine.posterior_predictive must return a PredictiveSummary")
+    expected = len(periods)
+    lengths = {
+        "periods": len(predictive.periods),
+        "mean": len(predictive.mean),
+        "hdi_low": len(predictive.hdi_low),
+        "hdi_high": len(predictive.hdi_high),
+    }
+    bad = {name: length for name, length in lengths.items() if length != expected}
+    if bad:
+        raise ValueError(
+            "engine.posterior_predictive returned lengths that do not match "
+            f"the future plan ({expected} rows): {bad}"
+        )

--- a/tests/unit/test_forecast_posterior_predictive.py
+++ b/tests/unit/test_forecast_posterior_predictive.py
@@ -1,0 +1,229 @@
+"""Unit tests for posterior-predictive forecast planning (issue #20)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wanamaker.engine.base import Posterior
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+from wanamaker.forecast.posterior_predictive import (
+    ForecastResult,
+    forecast,
+)
+
+
+@dataclass
+class FakeEngine:
+    calls: list[tuple[PosteriorSummary, pd.DataFrame, int]] = field(default_factory=list)
+
+    def posterior_predictive(
+        self,
+        posterior_summary: PosteriorSummary,
+        new_data: pd.DataFrame,
+        seed: int,
+    ) -> PredictiveSummary:
+        self.calls.append((posterior_summary, new_data.copy(), seed))
+        scale = 1.0 + (seed % 7) * 0.01
+        mean = [
+            float(row.search * 2.0 + row.tv * 0.5) * scale
+            for row in new_data.itertuples(index=False)
+        ]
+        return PredictiveSummary(
+            periods=new_data["period"].astype(str).tolist(),
+            mean=mean,
+            hdi_low=[value - 1.0 for value in mean],
+            hdi_high=[value + 1.0 for value in mean],
+        )
+
+
+def _summary() -> PosteriorSummary:
+    return PosteriorSummary(
+        channel_contributions=[
+            ChannelContributionSummary(
+                channel="search",
+                mean_contribution=100.0,
+                hdi_low=80.0,
+                hdi_high=120.0,
+                observed_spend_min=10.0,
+                observed_spend_max=50.0,
+            ),
+            ChannelContributionSummary(
+                channel="tv",
+                mean_contribution=200.0,
+                hdi_low=150.0,
+                hdi_high=250.0,
+                observed_spend_min=100.0,
+                observed_spend_max=100.0,
+                spend_invariant=True,
+            ),
+        ]
+    )
+
+
+def _wide_plan() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "period": ["2026-01-05", "2026-01-12", "2026-01-19"],
+            "search": [20.0, 75.0, 5.0],
+            "tv": [100.0, 100.0, 120.0],
+        }
+    )
+
+
+def test_forecast_calls_engine_with_summary_plan_and_seed() -> None:
+    summary = _summary()
+    engine = FakeEngine()
+
+    result = forecast(summary, _wide_plan(), seed=123, engine=engine)
+
+    assert isinstance(result, PredictiveSummary)
+    assert isinstance(result, ForecastResult)
+    assert result.periods == ["2026-01-05", "2026-01-12", "2026-01-19"]
+    assert len(engine.calls) == 1
+    called_summary, called_plan, called_seed = engine.calls[0]
+    assert called_summary is summary
+    assert called_seed == 123
+    assert list(called_plan.columns) == ["period", "search", "tv"]
+
+
+def test_forecast_flags_periods_above_historical_max() -> None:
+    result = forecast(_summary(), _wide_plan(), seed=0, engine=FakeEngine())
+
+    above_max = [
+        flag for flag in result.extrapolation_flags
+        if flag.direction == "above_historical_max"
+    ]
+    assert [(flag.period, flag.channel) for flag in above_max] == [
+        ("2026-01-12", "search"),
+        ("2026-01-19", "tv"),
+    ]
+    assert result.extrapolated_periods == ["2026-01-12", "2026-01-19"]
+
+
+def test_forecast_flags_periods_below_historical_min() -> None:
+    result = forecast(_summary(), _wide_plan(), seed=0, engine=FakeEngine())
+
+    below_min = [
+        flag for flag in result.extrapolation_flags
+        if flag.direction == "below_historical_min"
+    ]
+    assert [(flag.period, flag.channel) for flag in below_min] == [
+        ("2026-01-19", "search")
+    ]
+
+
+def test_forecast_records_spend_invariant_channels() -> None:
+    result = forecast(_summary(), _wide_plan(), seed=0, engine=FakeEngine())
+
+    assert result.spend_invariant_channels == ["tv"]
+
+
+def test_forecast_accepts_csv_path(tmp_path: Path) -> None:
+    path = tmp_path / "plan.csv"
+    _wide_plan().to_csv(path, index=False)
+
+    result = forecast(_summary(), path, seed=0, engine=FakeEngine())
+
+    assert result.periods == ["2026-01-05", "2026-01-12", "2026-01-19"]
+
+
+def test_forecast_accepts_long_channel_period_plan() -> None:
+    long_plan = pd.DataFrame(
+        {
+            "period": ["2026-01-05", "2026-01-05", "2026-01-12", "2026-01-12"],
+            "channel": ["search", "tv", "search", "tv"],
+            "spend": [20.0, 100.0, 30.0, 100.0],
+        }
+    )
+    engine = FakeEngine()
+
+    result = forecast(_summary(), long_plan, seed=0, engine=engine)
+
+    assert result.periods == ["2026-01-05", "2026-01-12"]
+    assert engine.calls[0][1]["search"].tolist() == pytest.approx([20.0, 30.0])
+    assert engine.calls[0][1]["tv"].tolist() == pytest.approx([100.0, 100.0])
+
+
+def test_forecast_accepts_channel_rows_period_columns_plan() -> None:
+    channel_rows = pd.DataFrame(
+        {
+            "channel": ["search", "tv"],
+            "2026-01-05": [20.0, 100.0],
+            "2026-01-12": [30.0, 100.0],
+        }
+    )
+    engine = FakeEngine()
+
+    result = forecast(_summary(), channel_rows, seed=0, engine=engine)
+
+    assert result.periods == ["2026-01-05", "2026-01-12"]
+    assert engine.calls[0][1]["search"].tolist() == pytest.approx([20.0, 30.0])
+    assert engine.calls[0][1]["tv"].tolist() == pytest.approx([100.0, 100.0])
+
+
+def test_forecast_rejects_bare_posterior() -> None:
+    with pytest.raises(TypeError, match="PosteriorSummary"):
+        forecast(  # type: ignore[arg-type]
+            Posterior(raw=object()),
+            _wide_plan(),
+            seed=0,
+            engine=FakeEngine(),
+        )
+
+
+def test_forecast_rejects_missing_channel() -> None:
+    plan = _wide_plan().drop(columns=["tv"])
+
+    with pytest.raises(ValueError, match="missing channel"):
+        forecast(_summary(), plan, seed=0, engine=FakeEngine())
+
+
+def test_forecast_rejects_extra_channel() -> None:
+    plan = _wide_plan().assign(display=[1.0, 2.0, 3.0])
+
+    with pytest.raises(ValueError, match="unrecognized columns"):
+        forecast(_summary(), plan, seed=0, engine=FakeEngine())
+
+
+def test_forecast_rejects_negative_spend() -> None:
+    plan = _wide_plan()
+    plan.loc[0, "search"] = -1.0
+
+    with pytest.raises(ValueError, match="negative spend"):
+        forecast(_summary(), plan, seed=0, engine=FakeEngine())
+
+
+def test_forecast_is_reproducible_for_same_engine_and_seed() -> None:
+    plan = _wide_plan()
+    first = forecast(_summary(), plan, seed=44, engine=FakeEngine())
+    second = forecast(_summary(), plan, seed=44, engine=FakeEngine())
+
+    assert first == second
+
+
+def test_forecast_validates_engine_output_length() -> None:
+    class BadEngine:
+        def posterior_predictive(
+            self,
+            posterior_summary: PosteriorSummary,
+            new_data: pd.DataFrame,
+            seed: int,
+        ) -> PredictiveSummary:
+            del posterior_summary, new_data, seed
+            return PredictiveSummary(
+                periods=["2026-01-05"],
+                mean=[1.0],
+                hdi_low=[0.0],
+                hdi_high=[2.0],
+            )
+
+    with pytest.raises(ValueError, match="do not match"):
+        forecast(_summary(), _wide_plan(), seed=0, engine=BadEngine())


### PR DESCRIPTION
Fixes #20.

## Summary
- Replace the posterior-predictive forecast stub with a `PosteriorSummary`-first forecast API.
- Add `ForecastResult`, a `PredictiveSummary` subclass carrying extrapolation flags and spend-invariant channel metadata.
- Validate future spend plans against `ChannelContributionSummary.observed_spend_min` / `observed_spend_max`.
- Support period-row, long `period,channel,spend`, and transposed channel-row plan CSV shapes.
- Reject bare `Posterior` inputs so downstream forecast logic cannot skip the spend-range context in `summary.json`.

## Design notes
- The forecast layer normalizes and validates the plan, then delegates sampling to `engine.posterior_predictive(summary, new_data, seed)`.
- Extrapolation flags cover both above historical max and below historical min; the issue specifically called out above-max periods, while the PRD describes the full observed range.
- Spend-invariant channels are surfaced on the result for CLI/report/scenario warning language. The user plan is not silently rewritten.

## Validation
- `python -m pytest tests\unit\test_forecast_posterior_predictive.py -q` -> 13 passed
- `python -m pytest tests\unit -q` -> 414 passed
- `python -m pytest tests\test_no_network_in_core.py -q` -> 1 passed
- `python -m ruff check src\wanamaker\forecast tests\unit\test_forecast_posterior_predictive.py` -> passed

## Remaining integration work
Issue #23 still needs to wire CLI artifact loading and actual persisted posterior execution. This PR provides the forecast planning/validation contract that command can call.