### PR TITLE
Implement scenario comparison (FR-5.2)

### DIFF
--- a/src/wanamaker/forecast/scenarios.py
+++ b/src/wanamaker/forecast/scenarios.py
@@ -8,6 +8,140 @@ reallocation recommendations.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
 
-def compare_scenarios(posterior, plans, seed: int):  # noqa: ANN001
-    raise NotImplementedError("Phase 1: scenario comparison")
+import pandas as pd
+
+from wanamaker.engine.base import FitResult
+from wanamaker.engine.pymc import PyMCEngine
+from wanamaker.engine.summary import PosteriorSummary
+from wanamaker.forecast.posterior_predictive import (
+    ExtrapolationFlag,
+    ForecastResult,
+    PosteriorPredictiveEngine,
+    forecast,
+)
+
+
+@dataclass(frozen=True)
+class ScenarioComparisonResult:
+    """Outcome of forecasting a single scenario."""
+
+    plan_name: str
+    expected_outcome_mean: float
+    expected_outcome_hdi_low: float
+    expected_outcome_hdi_high: float
+    total_spend_by_channel: dict[str, float]
+    extrapolation_flags: list[ExtrapolationFlag] = field(default_factory=list)
+    spend_invariant_channels: list[str] = field(default_factory=list)
+
+
+def compare_scenarios(
+    posterior: Any,
+    plans: list[str | Path | pd.DataFrame],
+    seed: int,
+) -> list[ScenarioComparisonResult]:
+    """Rank multiple budget plans with uncertainty (FR-5.2).
+
+    Args:
+        posterior: Either a ``FitResult`` containing the posterior summary and raw
+            posterior, or a duck-typed test object that exposes ``.summary`` and
+            ``.posterior_predictive``.
+        plans: List of future spend plans (CSVs or DataFrames).
+        seed: Random seed for posterior predictive sampling.
+
+    Returns:
+        List of ``ScenarioComparisonResult`` ranked by descending expected outcome.
+    """
+    if isinstance(posterior, FitResult):
+        posterior_summary = posterior.summary
+        actual_posterior = posterior.posterior
+        pymc_engine = PyMCEngine()
+
+        class _Adapter(PosteriorPredictiveEngine):
+            def posterior_predictive(
+                self,
+                summary: PosteriorSummary,
+                new_data: pd.DataFrame,
+                seed: int,
+            ) -> Any:
+                return pymc_engine.posterior_predictive(actual_posterior, new_data, seed)
+
+        engine = _Adapter()
+    elif hasattr(posterior, "summary") and hasattr(posterior, "posterior_predictive"):
+        posterior_summary = posterior.summary
+
+        class _MockAdapter(PosteriorPredictiveEngine):
+            def posterior_predictive(
+                self,
+                summary: PosteriorSummary,
+                new_data: pd.DataFrame,
+                seed: int,
+            ) -> Any:
+                return posterior.posterior_predictive(summary, new_data, seed)
+
+        engine = _MockAdapter()
+    else:
+        raise TypeError(
+            "compare_scenarios requires a FitResult or a test mock exposing "
+            "summary and posterior_predictive."
+        )
+
+    results: list[ScenarioComparisonResult] = []
+
+    for i, plan in enumerate(plans):
+        if isinstance(plan, (str, Path)):
+            plan_name = Path(plan).stem
+            data = pd.read_csv(plan)
+        elif isinstance(plan, pd.DataFrame):
+            plan_name = f"Plan {i + 1}"
+            data = plan.copy()
+        else:
+            raise TypeError("plan must be a CSV path or pandas DataFrame")
+
+        channel_names = [
+            c.channel for c in posterior_summary.channel_contributions
+        ]
+
+        normalized_spend = {}
+        for c in channel_names:
+            if c in data.columns:
+                normalized_spend[c] = float(pd.to_numeric(data[c], errors="coerce").sum())
+            else:
+                lower_cols = {str(col).lower(): col for col in data.columns}
+                if "channel" in lower_cols and "spend" in lower_cols:
+                    channel_col = lower_cols["channel"]
+                    spend_col = lower_cols["spend"]
+                    channel_spend = data[data[channel_col] == c][spend_col]
+                    normalized_spend[c] = float(pd.to_numeric(channel_spend, errors="coerce").sum())
+                elif "channel" in lower_cols:
+                    channel_col = lower_cols["channel"]
+                    row = data[data[channel_col] == c]
+                    if not row.empty:
+                        numeric_row = row.drop(columns=[channel_col]).apply(pd.to_numeric, errors="coerce")
+                        row_spend = numeric_row.sum(axis=1).values[0]
+                        normalized_spend[c] = float(row_spend)
+                    else:
+                        normalized_spend[c] = 0.0
+
+        forecast_result = forecast(posterior_summary, plan, seed, engine)
+
+        expected_outcome_mean = sum(forecast_result.mean)
+        expected_outcome_hdi_low = sum(forecast_result.hdi_low)
+        expected_outcome_hdi_high = sum(forecast_result.hdi_high)
+
+        results.append(
+            ScenarioComparisonResult(
+                plan_name=plan_name,
+                expected_outcome_mean=expected_outcome_mean,
+                expected_outcome_hdi_low=expected_outcome_hdi_low,
+                expected_outcome_hdi_high=expected_outcome_hdi_high,
+                total_spend_by_channel=normalized_spend,
+                extrapolation_flags=forecast_result.extrapolation_flags,
+                spend_invariant_channels=forecast_result.spend_invariant_channels,
+            )
+        )
+
+    return sorted(results, key=lambda x: x.expected_outcome_mean, reverse=True)

--- a/tests/unit/test_compare_scenarios.py
+++ b/tests/unit/test_compare_scenarios.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+from wanamaker.forecast.posterior_predictive import ExtrapolationFlag
+from wanamaker.forecast.scenarios import ScenarioComparisonResult, compare_scenarios
+
+
+@dataclass
+class MockFitResultContext:
+    """Mocks the interface expected by `compare_scenarios` for duck-typing."""
+
+    summary: PosteriorSummary
+    seed_used: int | None = None
+
+    def posterior_predictive(
+        self,
+        summary: PosteriorSummary,
+        new_data: pd.DataFrame,
+        seed: int,
+    ) -> PredictiveSummary:
+        self.seed_used = seed
+
+        # We will use the sum of "search" and "tv" to generate a totally deterministic result
+        # Plan 1 vs Plan 2 should yield different means based on data
+        # For simplicity, mean = sum of spend
+        search_spend = new_data.get("search", pd.Series(dtype=float)).fillna(0)
+        tv_spend = new_data.get("tv", pd.Series(dtype=float)).fillna(0)
+
+        mean_series = search_spend * 2.0 + tv_spend * 0.5
+
+        return PredictiveSummary(
+            periods=new_data["period"].astype(str).tolist(),
+            mean=mean_series.tolist(),
+            hdi_low=(mean_series * 0.8).tolist(),
+            hdi_high=(mean_series * 1.2).tolist(),
+        )
+
+
+def _summary() -> PosteriorSummary:
+    return PosteriorSummary(
+        channel_contributions=[
+            ChannelContributionSummary(
+                channel="search",
+                mean_contribution=100.0,
+                hdi_low=80.0,
+                hdi_high=120.0,
+                observed_spend_min=10.0,
+                observed_spend_max=50.0,
+            ),
+            ChannelContributionSummary(
+                channel="tv",
+                mean_contribution=200.0,
+                hdi_low=150.0,
+                hdi_high=250.0,
+                observed_spend_min=100.0,
+                observed_spend_max=100.0,
+                spend_invariant=True,
+            ),
+        ]
+    )
+
+
+def test_compare_scenarios_ranking() -> None:
+    plan1 = pd.DataFrame({
+        "period": ["2026-01-01"],
+        "search": [20.0],
+        "tv": [100.0],
+    })
+
+    plan2 = pd.DataFrame({
+        "period": ["2026-01-01"],
+        "search": [40.0], # higher search spend = higher outcome (40*2 + 100*0.5 = 130 vs 20*2 + 100*0.5 = 90)
+        "tv": [100.0],
+    })
+
+    posterior = MockFitResultContext(summary=_summary())
+
+    results = compare_scenarios(posterior, [plan1, plan2], seed=42)
+
+    assert len(results) == 2
+    assert results[0].plan_name == "Plan 2" # Sorted descending by mean
+    assert results[1].plan_name == "Plan 1"
+
+    assert results[0].expected_outcome_mean == 130.0
+    assert results[1].expected_outcome_mean == 90.0
+
+    assert results[0].total_spend_by_channel["search"] == 40.0
+    assert results[1].total_spend_by_channel["search"] == 20.0
+
+
+def test_extrapolation_warnings() -> None:
+    plan_extrapolates = pd.DataFrame({
+        "period": ["2026-01-01"],
+        "search": [60.0], # Max is 50.0
+        "tv": [100.0],
+    })
+
+    posterior = MockFitResultContext(summary=_summary())
+
+    results = compare_scenarios(posterior, [plan_extrapolates], seed=42)
+    res = results[0]
+
+    assert len(res.extrapolation_flags) == 1
+    flag = res.extrapolation_flags[0]
+    assert flag.channel == "search"
+    assert flag.direction == "above_historical_max"
+    assert flag.planned_spend == 60.0
+
+
+def test_spend_invariant_warnings() -> None:
+    plan = pd.DataFrame({
+        "period": ["2026-01-01"],
+        "search": [20.0],
+        "tv": [100.0],
+    })
+
+    posterior = MockFitResultContext(summary=_summary())
+
+    results = compare_scenarios(posterior, [plan], seed=42)
+    res = results[0]
+
+    # TV is spend invariant in _summary()
+    assert res.spend_invariant_channels == ["tv"]


### PR DESCRIPTION
Implemented `compare_scenarios` function to support evaluating multiple budget plans as defined in FR-5.2. Adds the `ScenarioComparisonResult` dataclass to hold structured comparison summaries. Wrote comprehensive tests addressing ranking, spend flags, and invariant warnings.

---
*PR created automatically by Jules for task [286463617403916583](https://jules.google.com/task/286463617403916583) started by @mbagalman*