### PR TITLE
Write analyst guide and quickstart

### DIFF
--- a/benchmark_data/public_example.yaml
+++ b/benchmark_data/public_example.yaml
@@ -1,0 +1,41 @@
+data:
+  csv_path: benchmark_data/public_example.csv
+  date_column: week
+  target_column: revenue
+  spend_columns:
+    - paid_search
+    - paid_social
+    - linear_tv
+    - ctv
+    - online_video
+    - display
+    - affiliate
+    - email
+  control_columns:
+    - price_index
+    - promo_flag
+    - holiday_flag
+    - macro_index
+
+channels:
+  - name: paid_search
+    category: paid_search
+  - name: paid_social
+    category: paid_social
+  - name: linear_tv
+    category: linear_tv
+  - name: ctv
+    category: ctv
+  - name: online_video
+    category: video
+  - name: display
+    category: display_programmatic
+  - name: affiliate
+    category: affiliate
+  - name: email
+    category: email_crm
+
+run:
+  seed: 20260430
+  runtime_mode: quick
+  artifact_dir: .wanamaker

--- a/docs/analyst_guide.md
+++ b/docs/analyst_guide.md
@@ -1,42 +1,275 @@
 # Analyst's Guide
 
-This page will explain MMM concepts for the primary Wanamaker user: a marketing analyst
-who is comfortable with Python but is not a Bayesian specialist.
+This guide is for marketing analysts who know the business, can work with CSVs
+and Python tools, and want a useful MMM without becoming Bayesian specialists.
 
-## Planned Sections
+Wanamaker is built around one idea: the model should help you make better
+marketing decisions while being honest about what the data can and cannot tell
+you.
 
-### What MMM Is
+## What MMM Is
 
-Marketing mix modeling estimates how aggregate marketing activity relates to aggregate
-business outcomes over time.
+Marketing mix modeling estimates how aggregate marketing activity relates to
+aggregate business outcomes over time.
 
-### Adstock
+A typical Wanamaker dataset has one row per week and columns like:
 
-Adstock captures carryover: advertising seen in one period can affect later periods.
+- revenue or another target metric
+- spend by marketing channel
+- controls such as promotions, holidays, price, or macro indicators
 
-### Saturation
+The model learns a relationship between those inputs and the target. The useful
+outputs are not just fitted lines. The useful outputs are questions like:
 
-Saturation captures diminishing returns: each additional dollar may produce less
-incremental response than the previous dollar.
+- Which channels appear to contribute the most?
+- Which channels have uncertain estimates?
+- What happens if I compare one future spend plan to another?
+- Did the model's historical estimates change after a refresh?
+- Is the model trustworthy enough for the decision in front of me?
 
-### Credible Intervals
+MMM works best when marketing activity changes over time. If a channel spends
+the same amount every week, the model has little evidence about how response
+changes with spend. Wanamaker will still fit where possible, but it should not
+pretend that flat spend can reveal a full response curve.
 
-Credible intervals express posterior uncertainty. They should be read as uncertainty in
-the model's estimate, not as a promise about the future.
+## What MMM Is Not
 
-### The Trust Card
+MMM is not a receipt-level attribution system. It does not follow individual
+people across channels. It uses aggregate data.
 
-The Trust Card will summarize whether a fitted model is credible enough to use for
-decisions.
+MMM is also not proof that one channel caused every sale assigned to it. It is
+a statistical estimate based on historical variation, controls, and assumptions.
+Good MMM narrows uncertainty. It does not eliminate it.
 
-### Refresh Accountability
+Wanamaker intentionally avoids language like "the model knows" or "the model
+proved." The right question is usually:
 
-Refresh reports will explain how and why historical estimates changed when new data is
-added.
+> Is this estimate strong enough to support this decision?
 
-## To Be Completed
+## The Basic Workflow
 
-- Worked examples
-- Common pitfalls
-- Links from concepts to report outputs
+The core workflow is:
 
+1. Prepare a weekly CSV and YAML config.
+2. Run `wanamaker diagnose`.
+3. Fix blockers or understand warnings.
+4. Run `wanamaker fit`.
+5. Run `wanamaker report`.
+6. Use `forecast` or `compare-scenarios` for future plans.
+7. When new data arrives, run `refresh` and read the diff.
+
+The readiness diagnostic is not paperwork. It is part of the modeling workflow.
+Most bad MMM decisions start before sampling begins, with data that cannot
+support the question being asked.
+
+## Adstock
+
+Advertising often has carryover. A TV campaign, video campaign, or podcast buy
+can affect customers after the week when the money was spent. Adstock is the
+model's way of representing that carryover.
+
+For example, if a channel has short carryover, this week's spend mostly affects
+this week's outcome. If it has longer carryover, some effect remains in later
+weeks.
+
+Wanamaker supports:
+
+- **Geometric adstock**, the default. It is simple and stable.
+- **Weibull adstock**, available as a per-channel override when the channel's
+  carryover shape needs more flexibility.
+
+Do not interpret adstock half-life too literally. It is useful as a summary of
+carryover, but it is estimated from noisy aggregate data. Treat it as a model
+parameter with uncertainty, not as a physical law.
+
+## Saturation
+
+Saturation means diminishing returns. The first dollars in a channel may be
+more productive than later dollars. At some point, more spend may still help,
+but each additional dollar adds less.
+
+Wanamaker uses Hill saturation curves to model this behavior. The report should
+distinguish the part of a response curve supported by observed spend from the
+part that extrapolates beyond history.
+
+This distinction matters. A model can draw a curve beyond the spend levels it
+has seen, but that does not mean the business has tested that spend range.
+
+When a channel has nearly constant spend, Wanamaker flags saturation
+identifiability risk. In plain English:
+
+> The model may estimate that the channel contributes to revenue, but it cannot
+> learn much about what would happen at meaningfully different spend levels.
+
+## Credible Intervals
+
+Wanamaker reports credible intervals for estimates such as ROI, contribution,
+and forecasts.
+
+A 95% credible interval means that, given the model and data, most posterior
+mass lies in that range. It is not a guarantee that next quarter's outcome will
+fall there. It is also not a promise that the model includes every possible
+source of business risk.
+
+Use intervals to calibrate confidence:
+
+- A narrow interval entirely above zero is stronger evidence.
+- A wide interval means the estimate could change materially.
+- A channel with high expected ROI and very wide uncertainty may be a good
+  experiment candidate, not an automatic budget winner.
+
+The mean is only one part of the decision. The interval tells you how much faith
+to put in that mean.
+
+## The Trust Card
+
+The Trust Card is Wanamaker's summary of model credibility. It does not say
+"good model" or "bad model" as a single score. It names the dimensions that
+matter.
+
+The v1 Trust Card dimensions are:
+
+| Dimension | What It Checks | Why It Matters |
+|---|---|---|
+| Convergence | Whether sampling diagnostics look stable | Bad sampling can make estimates unreliable |
+| Holdout accuracy | Whether predictions matched held-out data | A model that cannot predict withheld data deserves caution |
+| Refresh stability | Whether historical estimates changed for explainable reasons | Refreshes should not silently rewrite history |
+| Prior sensitivity | Whether results move too much when priors are perturbed | Prior-driven results need careful language |
+| Saturation identifiability | Whether channel spend variation can support response curves | Flat spend cannot identify saturation |
+| Lift-test consistency | Whether posterior ROI agrees with calibration evidence | Experiments should inform estimates |
+
+Status values are:
+
+- `pass`: no major concern found
+- `moderate`: use the result, but read the explanation
+- `weak`: do not rely on the affected output without additional evidence
+
+Weak status should change how you act. For example, a weak saturation
+identifiability flag should make you cautious about reallocating budget into or
+out of that channel based on curve shape.
+
+## Reading the Executive Summary
+
+The executive summary is deterministic text generated from model statistics.
+There are no LLM calls in product output.
+
+Read the summary in this order:
+
+1. What are the strongest findings?
+2. Which findings are explicitly hedged?
+3. Which Trust Card dimensions explain the hedges?
+4. What decision is supported now?
+5. What decision needs more evidence?
+
+If the summary says a channel is "likely" contributing, that is different from
+saying the channel's exact ROI is known. If the summary says Wanamaker cannot
+estimate saturation for a channel, do not use that channel's curve as a budget
+allocation tool.
+
+## Forecasts and Scenario Comparison
+
+Forecasting asks:
+
+> What does the model expect if I use this future spend plan?
+
+Scenario comparison asks:
+
+> Among the plans I supplied, which looks better, and how uncertain is that
+> ranking?
+
+Wanamaker's v1 scenario comparison is user-driven. You provide plans. The tool
+ranks them with uncertainty and flags extrapolation beyond historical spend
+ranges.
+
+This is deliberately more conservative than automatic budget optimization.
+The user remains in control of the strategic options being evaluated.
+
+## Refresh Workflow
+
+Refresh is one of Wanamaker's headline features. When new data arrives, you can
+re-run the model and compare the new estimates to the prior run.
+
+A refresh diff should answer:
+
+- Which historical estimates changed?
+- How much did they change?
+- Are the movements explainable?
+- Did the change affect the decision?
+
+Movement classes include:
+
+| Class | Meaning |
+|---|---|
+| Within prior credible interval | Expected movement; usually not a concern |
+| Improved holdout accuracy | Larger movement, but new fit appears better |
+| Unexplained | Trust risk; investigate before acting |
+| User-induced | Driven by config or prior changes |
+| Weakly identified | Expected instability in a weak channel |
+
+The point is not to freeze history. New data should be allowed to update the
+model. The point is to prevent historical estimates from silently changing with
+no explanation.
+
+## Common Pitfalls
+
+### Too Little History
+
+MMM needs enough variation over enough time. Fewer than 52 weekly observations
+is usually fragile, and fewer than 26 is usually not recommended.
+
+### Flat Spend
+
+If a channel spends almost the same amount every week, the model cannot learn
+how response changes at different spend levels.
+
+### Collinear Channels
+
+If two channels always move together, the model may struggle to separate their
+effects. Wanamaker can still fit, but individual channel estimates may be less
+stable.
+
+### Target Leakage
+
+Do not include controls that are mechanically derived from the target. A
+conversion rate, revenue-derived metric, or post-outcome operational measure can
+make the model look better while making the marketing estimates worse.
+
+### Overreading ROI Rankings
+
+A channel with the highest mean ROI is not always the best place to move budget.
+Look at the interval, saturation identifiability, historical spend range, and
+operational reality.
+
+### Treating Extrapolation as Evidence
+
+If a future plan spends far above anything in history, the forecast is partly an
+extrapolation. Wanamaker should flag this clearly. Treat it as a reason to stage
+or test, not as proof.
+
+## Practical Decision Rules
+
+Use these defaults unless there is a strong reason not to:
+
+- Fix blockers before fitting.
+- Treat warnings as report language, not as noise.
+- Do not make large reallocations involving spend-invariant channels.
+- Prefer scenario comparison over automatic optimization.
+- If a recommended plan is far from historical behavior, stage the move and
+  refresh after new data arrives.
+- Use experiments when a high-value decision depends on a wide interval.
+
+## What To Bring To A Review Meeting
+
+For a stakeholder meeting, bring:
+
+- the executive summary
+- the Trust Card
+- top channel contributions and ROI intervals
+- any scenario comparison output
+- any refresh diff if this is not the first run
+- a short list of decisions the model supports now
+- a short list of decisions that need more evidence
+
+The best Wanamaker meeting should not end with "the model said so." It should
+end with a clear decision, a clear uncertainty statement, and a clear next
+measurement step.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,33 +1,241 @@
 # Quickstart
 
-This page will become the end-to-end tutorial for a first Wanamaker analysis.
+This tutorial walks through a first Wanamaker analysis using the public example
+dataset included in the repository.
 
-## Target Outcome
+The goal is to go from installation to a first Markdown report. The report is
+not a final business recommendation by itself. It is the starting point for
+reading channel estimates, uncertainty, and the Trust Card.
 
-A new user should be able to install Wanamaker, run the public example dataset, and produce
-an executive summary in under 30 minutes.
+## What You Need
 
-## Planned Workflow
+- Python 3.11 or newer
+- A local checkout of the Wanamaker repository
+- A terminal in the repository root
+
+The public example uses synthetic, anonymized weekly marketing data. It is safe
+to inspect and commit publicly.
+
+## Install
+
+For development or source checkout usage:
+
+```bash
+pip install -e ".[dev]"
+```
+
+If you only want to build documentation:
+
+```bash
+pip install -e ".[docs]"
+```
+
+The Bayesian engine dependencies can take longer to install than the rest of the
+package. That is normal.
+
+## Inspect The Example Files
+
+The quickstart uses:
+
+```text
+benchmark_data/public_example.csv
+benchmark_data/public_example_metadata.json
+benchmark_data/public_example.yaml
+```
+
+The CSV has one row per week. The key columns are:
+
+| Type | Columns |
+|---|---|
+| Date | `week` |
+| Target | `revenue` |
+| Media spend | `paid_search`, `paid_social`, `linear_tv`, `ctv`, `online_video`, `display`, `affiliate`, `email` |
+| Controls | `price_index`, `promo_flag`, `holiday_flag`, `macro_index` |
+
+The YAML config tells Wanamaker which columns are media channels, which columns
+are controls, and which runtime tier to use.
+
+## Step 1: Run The Readiness Diagnostic
+
+Start by checking whether the data is suitable for MMM:
 
 ```bash
 wanamaker diagnose benchmark_data/public_example.csv --config benchmark_data/public_example.yaml
+```
+
+The diagnostic looks for common problems such as:
+
+- insufficient history
+- missing values
+- irregular dates
+- low spend variation
+- collinearity
+- too many predictors for the amount of history
+- target leakage
+- structural breaks
+
+Expected result for the public example: the command should finish without
+blockers. Warnings are possible as checks evolve; read them before fitting.
+
+Readiness levels are:
+
+| Level | Meaning |
+|---|---|
+| `ready` | No blockers or major warnings found |
+| `usable_with_warnings` | Fit is possible, but some outputs need caution |
+| `diagnostic_only` | Useful for understanding data, not for decisions |
+| `not_recommended` | Do not fit until the data problem is fixed |
+
+## Step 2: Fit The Model
+
+Run a quick fit:
+
+```bash
 wanamaker fit --config benchmark_data/public_example.yaml
+```
+
+The config uses `runtime_mode: quick` so the tutorial is practical on a laptop.
+For real decision support, use the default or full runtime after the workflow is
+working.
+
+At the end, Wanamaker prints a run ID and an artifact directory, for example:
+
+```text
+Done. Run ID: 1a2b3c4d_20260430T120000Z
+  .wanamaker/runs/1a2b3c4d_20260430T120000Z
+```
+
+Copy the run ID for the next step.
+
+The run directory contains files such as:
+
+| File | Purpose |
+|---|---|
+| `manifest.json` | Run ID, fingerprint, seed, engine, readiness level |
+| `config.yaml` | Snapshot of the config used for the run |
+| `data_hash.txt` | Hash of the input CSV |
+| `posterior.nc` | Engine-native posterior draws |
+| `summary.json` | Engine-neutral posterior summary |
+| `timestamp.txt` | Fit timestamp |
+| `engine.txt` | Engine name and version |
+
+## Step 3: Render The Report
+
+Use the run ID from the fit command:
+
+```bash
 wanamaker report --run-id <run_id>
 ```
 
-## What This Tutorial Will Cover
+By default, this writes:
 
-- Preparing a weekly aggregate marketing CSV
-- Running the readiness diagnostic
-- Reading warnings before fitting
-- Fitting the Bayesian model
-- Rendering the executive summary and Trust Card
-- Finding artifacts under `.wanamaker/`
+```text
+.wanamaker/runs/<run_id>/report.md
+```
 
-## To Be Completed
+The report includes:
 
-- Public example dataset
-- Example YAML config
-- Expected command output
-- Troubleshooting notes for common data issues
+- an executive summary
+- channel contribution and ROI language
+- uncertainty-aware wording
+- the Model Trust Card
 
+The executive summary is deterministic template output. Wanamaker does not use
+LLM calls to generate product reports.
+
+## Step 4: Read The Trust Card
+
+Before using the results, read the Trust Card.
+
+Pay special attention to any dimension marked `weak`:
+
+- convergence
+- holdout accuracy
+- refresh stability
+- prior sensitivity
+- saturation identifiability
+- lift-test consistency
+
+A weak dimension does not always mean the whole model is useless. It means the
+affected output needs caution. For example, weak saturation identifiability
+means you should not make strong reallocation decisions based on that channel's
+response curve.
+
+## Step 5: Compare Future Plans
+
+Once you have a fitted run, you can compare user-supplied future spend plans.
+Each plan should use the same channel names as the training data.
+
+Example wide-format plan:
+
+```csv
+period,paid_search,paid_social,linear_tv,ctv,online_video,display,affiliate,email
+2026-01-05,21000,16000,30000,15000,12000,8500,6000,2800
+2026-01-12,21000,16000,30000,15000,12000,8500,6000,2800
+```
+
+Forecast one plan:
+
+```bash
+wanamaker forecast --run-id <run_id> --plan path/to/plan.csv
+```
+
+Compare multiple plans:
+
+```bash
+wanamaker compare-scenarios --run-id <run_id> --plans path/to/base.csv path/to/test.csv
+```
+
+Scenario comparison is not automatic optimization. You provide the candidate
+plans. Wanamaker ranks them with uncertainty and flags extrapolation beyond the
+historical spend ranges seen in the training data.
+
+## Step 6: Refresh When New Data Arrives
+
+After more weeks of data are available, update the CSV and run:
+
+```bash
+wanamaker refresh --config benchmark_data/public_example.yaml
+```
+
+Refresh uses light posterior anchoring and writes a diff report. The diff shows
+which historical estimates moved and whether the movement looks expected,
+user-induced, weakly identified, or unexplained.
+
+Use refresh to avoid silently rewriting history. A changed estimate is not
+automatically bad, but it should be visible and explainable.
+
+## Troubleshooting
+
+### The diagnostic says the data is not recommended
+
+Do not jump straight to `--skip-validation`. Read the blockers first. Common
+causes are too little history, missing target values, duplicate dates, or a
+structural break.
+
+### Fit is slow
+
+Start with `runtime_mode: quick` in the YAML config. Once the workflow works,
+move to `standard` for normal analysis and `full` for final decision support.
+
+### A channel has weak saturation identifiability
+
+Check whether spend changed enough in history. Flat spend can support a rough
+contribution estimate, but it cannot support a confident response curve.
+
+### Scenario comparison flags extrapolation
+
+The plan is outside the spend range the model observed. Treat the result as a
+staged test candidate, not as proof that the full move is safe.
+
+### The report language is cautious
+
+That is intentional. Wanamaker changes wording when uncertainty is high or the
+Trust Card flags a risk. Cautious language is a feature, not a failure.
+
+## Next Reading
+
+- [Analyst's Guide](analyst_guide.md)
+- [What Wanamaker Tells Your CMO](cmo_guide.md)
+- [Privacy and Data Handling](privacy.md)
+- [Technical Architecture](architecture.md)


### PR DESCRIPTION
Fixes #34.

## Summary
- Replaces the Analyst's Guide stub with practical guidance on MMM interpretation, adstock, saturation, credible intervals, Trust Card results, refresh diffs, and common pitfalls.
- Replaces the Quickstart stub with an end-to-end public-example workflow from install through diagnose, fit, report, scenario comparison, and refresh.
- Adds `benchmark_data/public_example.yaml` so the documented quickstart has a concrete config file to point at.

## Notes
- Kept this scoped to documentation and the example YAML only.
- Did not touch Issue #33's CI/network-isolation area.

## Validation
- `python -c "from pathlib import Path; from wanamaker.config import load_config; cfg=load_config(Path('benchmark_data/public_example.yaml')); print(cfg.data.target_column); print(len(cfg.channels)); print(cfg.run.runtime_mode)"`
- `python -m mkdocs build --strict` (passes; emits only the upstream Material for MkDocs warning about MkDocs 2.0).