### PR TITLE
Add generated API reference docs

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,23 +1,270 @@
 # API Reference
 
-This page is a placeholder for the generated public API reference.
+This page documents the public command-line, YAML, and Python API surface.
 
-## Planned Coverage
+Generated Python sections use `mkdocstrings` and the Google-style docstrings in
+`src/wanamaker`. Public names are shown; private helpers are omitted.
 
-- CLI commands and options
-- YAML configuration schema
-- Public Python functions and dataclasses
-- Engine abstraction interfaces
-- Artifact and summary types
+## CLI Reference
 
-## Planned Tooling
+All commands run locally. The core commands do not make network calls.
 
-The API reference is expected to use `mkdocstrings` or a similar generator once the
-public API surface is stable enough to document automatically.
+### `wanamaker diagnose`
 
-## To Be Completed
+Run the pre-flight data readiness diagnostic.
 
-- Configure API documentation generation
-- Add examples for every CLI command
-- Ensure public functions have complete Google-style docstrings
+```bash
+wanamaker diagnose benchmark_data/public_example.csv --config benchmark_data/public_example.yaml
+```
 
+| Argument or option | Type | Default | Description |
+|---|---|---|---|
+| `data` | path | required | CSV file to inspect. |
+| `--config`, `-c` | path | none | Optional YAML config. When supplied, spend and control column checks run. |
+| `--date-column`, `-d` | string | inferred | Date column name when no config is supplied. |
+| `--target-column`, `-t` | string | inferred | Numeric target column name when no config is supplied. |
+
+Exit code is non-zero when the readiness level is `diagnostic_only` or
+`not_recommended`.
+
+### `wanamaker fit`
+
+Fit the Bayesian model and write a versioned run directory.
+
+```bash
+wanamaker fit --config benchmark_data/public_example.yaml
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--config`, `-c` | path | required | YAML config file. |
+| `--skip-validation` | flag | false | Hidden expert flag. Bypasses readiness checks and records the skip in artifacts. |
+
+The command prints a run ID. Use that run ID with `report`, `forecast`, and
+`compare-scenarios`.
+
+### `wanamaker report`
+
+Render the executive summary and Model Trust Card for a completed run.
+
+```bash
+wanamaker report --run-id <run_id>
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--run-id` | string | required | Existing run ID under the artifact directory. |
+| `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
+| `--output` | path | `<run_dir>/report.md` | Markdown report path. |
+
+### `wanamaker forecast`
+
+Forecast the target metric under one future spend plan.
+
+```bash
+wanamaker forecast --run-id <run_id> --plan path/to/plan.csv
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--run-id` | string | required | Existing fitted run ID. |
+| `--plan` | path | required | CSV future spend plan. |
+| `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
+| `--seed` | integer | run seed | Override posterior-predictive sampling seed. |
+| `--output` | path | `<run_dir>/forecast_<plan>.md` | Markdown forecast report path. |
+
+### `wanamaker compare-scenarios`
+
+Rank one or more future spend plans with uncertainty.
+
+```bash
+wanamaker compare-scenarios --run-id <run_id> --plans path/to/base.csv --plans path/to/test.csv
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--run-id` | string | required | Existing fitted run ID. |
+| `--plans` | path, repeatable | required | Future spend plan CSV. Repeat once per scenario. |
+| `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
+| `--seed` | integer | run seed | Override posterior-predictive sampling seed. |
+| `--output` | path | `<run_dir>/scenario_comparison.md` | Markdown scenario report path. |
+
+### `wanamaker refresh`
+
+Re-run the model with posterior anchoring against the previous compatible run.
+
+```bash
+wanamaker refresh --config benchmark_data/public_example.yaml --anchor-strength light
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--config`, `-c` | path | required | YAML config file. |
+| `--anchor-strength` | `none`, `light`, `medium`, `heavy`, or float | config value | Override refresh anchoring strength for this run. |
+| `--skip-validation` | flag | false | Hidden expert flag. Bypasses readiness checks and records the skip in artifacts. |
+
+## YAML Config Reference
+
+The YAML config is validated by `wanamaker.config.WanamakerConfig`.
+Unknown fields are rejected.
+
+### Top Level
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `data` | `DataConfig` | required | Input CSV and column mapping. |
+| `channels` | list of `ChannelConfig` | `[]` | Per-channel category and adstock settings. |
+| `refresh` | `RefreshConfig` | `{anchor_strength: medium}` | Refresh accountability settings. |
+| `run` | `RunConfig` | `{seed: 0, runtime_mode: standard, artifact_dir: .wanamaker}` | Reproducibility and artifact settings. |
+
+### `data`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `csv_path` | path | required | Weekly aggregate input CSV. |
+| `date_column` | string | required | Date column in the CSV. |
+| `target_column` | string | required | Target metric column, such as revenue or conversions. |
+| `spend_columns` | list of strings | `[]` | Paid media spend columns. |
+| `control_columns` | list of strings | `[]` | Non-media controls such as price, promotions, holidays, or macro indicators. |
+| `lift_test_csv` | path or null | `null` | Optional lift-test calibration CSV. |
+
+### `channels`
+
+Each entry describes one spend column.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | required | Spend column name. |
+| `category` | string | required | Channel category used to look up default priors. |
+| `adstock_family` | `geometric` or `weibull` | `geometric` | Carryover transform family for the channel. |
+
+### `refresh`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `anchor_strength` | `none`, `light`, `medium`, `heavy`, or float | `medium` | Posterior anchoring preset or numeric weight in `[0, 1]`. |
+
+### `run`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `seed` | integer | `0` | Top-level seed passed down explicitly for reproducibility. |
+| `runtime_mode` | `quick`, `standard`, or `full` | `standard` | Bayesian sampler effort tier. Model structure is unchanged. |
+| `artifact_dir` | path | `.wanamaker` | Local artifact root. |
+
+### Minimal Example
+
+```yaml
+data:
+  csv_path: benchmark_data/public_example.csv
+  date_column: week
+  target_column: revenue
+  spend_columns:
+    - paid_search
+    - paid_social
+  control_columns:
+    - promo_flag
+
+channels:
+  - name: paid_search
+    category: paid_search
+  - name: paid_social
+    category: paid_social
+    adstock_family: weibull
+
+refresh:
+  anchor_strength: medium
+
+run:
+  seed: 20260430
+  runtime_mode: standard
+  artifact_dir: .wanamaker
+```
+
+## Python API Reference
+
+### Package Metadata
+
+::: wanamaker
+
+### CLI Module
+
+::: wanamaker.cli
+
+### Configuration
+
+::: wanamaker.config
+
+### Data
+
+::: wanamaker.data.io
+
+::: wanamaker.data.taxonomy
+
+### Diagnostics
+
+::: wanamaker.diagnose.readiness
+
+::: wanamaker.diagnose.checks
+
+### Transforms
+
+::: wanamaker.transforms.adstock
+
+::: wanamaker.transforms.saturation
+
+### Model
+
+::: wanamaker.model.spec
+
+::: wanamaker.model.priors
+
+::: wanamaker.model.builder
+
+### Engine
+
+::: wanamaker.engine.base
+
+::: wanamaker.engine.summary
+
+::: wanamaker.engine.pymc
+
+### Artifacts
+
+::: wanamaker.artifacts
+
+### Refresh
+
+::: wanamaker.refresh.anchor
+
+::: wanamaker.refresh.classify
+
+::: wanamaker.refresh.diff
+
+### Forecast
+
+::: wanamaker.forecast.posterior_predictive
+
+::: wanamaker.forecast.scenarios
+
+### Trust Card
+
+::: wanamaker.trust_card.card
+
+::: wanamaker.trust_card.compute
+
+### Reports
+
+::: wanamaker.reports.render
+
+### Experiment Advisor
+
+::: wanamaker.advisor.channel_flagging
+
+### Benchmarks
+
+::: wanamaker.benchmarks.loaders
+
+### Reproducibility
+
+::: wanamaker.seeding

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,22 @@ theme:
     - navigation.indexes
     - content.code.copy
 
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            filters:
+              - "!^_"
+            heading_level: 3
+            members_order: source
+            show_if_no_docstring: false
+            show_root_full_path: false
+            show_root_heading: true
+            show_source: false
+
 nav:
   - Home: index.md
   - Installation: installation.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ xgboost = ["xgboost>=2.0"]
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.26",
 ]
 
 [project.scripts]

--- a/src/wanamaker/diagnose/readiness.py
+++ b/src/wanamaker/diagnose/readiness.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 
-class ReadinessLevel(str, Enum):
+class ReadinessLevel(StrEnum):
     """The four discrete readiness verdicts. Deliberately not a numeric score."""
 
     READY = "ready"
@@ -15,7 +15,9 @@ class ReadinessLevel(str, Enum):
     NOT_RECOMMENDED = "not_recommended"
 
 
-class CheckSeverity(str, Enum):
+class CheckSeverity(StrEnum):
+    """Severity levels emitted by individual readiness checks."""
+
     INFO = "info"
     WARNING = "warning"
     BLOCKER = "blocker"

--- a/src/wanamaker/forecast/scenarios.py
+++ b/src/wanamaker/forecast/scenarios.py
@@ -89,7 +89,7 @@ def compare_scenarios(
     Raises:
         ValueError: If ``plans`` is empty.
         TypeError: If a plan element is not a CSV path or DataFrame.
-        Plus any exception raised by ``forecast()`` for a malformed plan.
+        ValueError: If a plan is malformed or cannot be forecast.
     """
     if not plans:
         raise ValueError("compare_scenarios requires at least one plan")

--- a/src/wanamaker/refresh/classify.py
+++ b/src/wanamaker/refresh/classify.py
@@ -18,10 +18,12 @@ the refresh stability dimension of the Trust Card (FR-4.5).
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 
-class MovementClass(str, Enum):
+class MovementClass(StrEnum):
+    """Business-facing explanation class for one historical estimate movement."""
+
     WITHIN_PRIOR_CI = "within_prior_ci"
     IMPROVED_HOLDOUT = "improved_holdout"
     UNEXPLAINED = "unexplained"

--- a/src/wanamaker/trust_card/card.py
+++ b/src/wanamaker/trust_card/card.py
@@ -17,6 +17,8 @@ from enum import StrEnum
 
 
 class TrustStatus(StrEnum):
+    """Discrete credibility status for one Trust Card dimension."""
+
     PASS = "pass"
     MODERATE = "moderate"
     WEAK = "weak"
@@ -24,6 +26,8 @@ class TrustStatus(StrEnum):
 
 @dataclass(frozen=True)
 class TrustDimension:
+    """One named Trust Card dimension and its plain-English explanation."""
+
     name: str
     status: TrustStatus
     explanation: str
@@ -31,6 +35,8 @@ class TrustDimension:
 
 @dataclass(frozen=True)
 class TrustCard:
+    """Collection of Trust Card dimensions for a completed model run."""
+
     dimensions: list[TrustDimension]
 
     def dimension(self, name: str) -> TrustDimension | None:


### PR DESCRIPTION
Addresses #37.

## Summary
- Adds `mkdocstrings[python]` to the docs extra and configures MkDocs to render public Python API docs from Google-style docstrings.
- Replaces the API reference placeholder with CLI usage/examples, YAML config field documentation, and generated Python API sections covering the public modules.
- Adds missing public class docstrings and fixes one malformed Google-style `Raises` entry that caused strict docs warnings.
- Updates touched string enums to `StrEnum` so Ruff remains clean on the edited files.

## Notes
- Scoped staging kept the pre-existing `docs/risk_adjusted_allocation.md` and its local `mkdocs.yml` nav line out of this PR.
- I used `Addresses` rather than `Fixes` because the issue asks for 100% public API coverage; this establishes the generated reference and validates no missing public top-level docstrings, but a final maintainer review should confirm the desired public/private boundary.

## Validation
- `python -m pip install -e ".[docs]"`
- `python -m mkdocs build --strict` (passes; no mkdocstrings/docstring warnings; emits only the upstream Material for MkDocs notice)
- `python -m ruff check src\wanamaker\diagnose\readiness.py src\wanamaker\refresh\classify.py src\wanamaker\trust_card\card.py src\wanamaker\forecast\scenarios.py`
- `python -m pytest tests\unit\test_cli_readiness.py tests\unit\test_refresh_diff.py tests\unit\test_trust_card_compute.py tests\unit\test_compare_scenarios.py -q`
- AST audit: all public top-level functions/classes in `src/wanamaker` have docstrings.