### PR TITLE
feat: expose raw posterior predictive draws from engine

### DIFF
--- a/src/wanamaker/engine/pymc.py
+++ b/src/wanamaker/engine/pymc.py
@@ -200,7 +200,19 @@ class PyMCEngine:
         self, raw: PyMCRawPosterior, seed: int
     ) -> PredictiveSummary:
         pm, az, _, _ = _require_pymc_stack()
+        # Restore training data coordinates and data in case the model was
+        # mutated by a previous forecast call.
+        n_periods = raw.idata.posterior.sizes.get(_TIME_COORD_NAME, 0)
+        coord_updates = {_TIME_COORD_NAME: np.arange(n_periods, dtype=np.int64)}
+        data_updates = {}
+        for var_name in raw.idata.constant_data:
+            data_updates[var_name] = raw.idata.constant_data[var_name].values
+        # Add target data explicitly (size must match coordinates)
+        data_updates[_TARGET_DATA_NAME] = np.zeros(n_periods, dtype=np.float64)
+
         with raw.model:
+            if data_updates:
+                pm.set_data(data_updates, coords=coord_updates)
             ppc = pm.sample_posterior_predictive(
                 raw.idata,
                 var_names=["target"],
@@ -220,6 +232,7 @@ class PyMCEngine:
             hdi_low=hdi[:, 0].tolist(),
             hdi_high=hdi[:, 1].tolist(),
             interval_mass=INTERVAL_MASS,
+            draws=target.tolist(),
         )
 
     def _posterior_predictive_forecast(
@@ -269,6 +282,7 @@ class PyMCEngine:
             hdi_low=hdi[:, 0].tolist(),
             hdi_high=hdi[:, 1].tolist(),
             interval_mass=INTERVAL_MASS,
+            draws=target.tolist(),
         )
 
     def load_posterior(
@@ -854,6 +868,7 @@ def _in_sample_predictive_summary(
         hdi_low=hdi[:, 0].tolist(),
         hdi_high=hdi[:, 1].tolist(),
         interval_mass=INTERVAL_MASS,
+        draws=target.tolist(),
     )
 
 

--- a/src/wanamaker/engine/summary.py
+++ b/src/wanamaker/engine/summary.py
@@ -100,6 +100,12 @@ class PredictiveSummary:
     hdi_high: list[float]
     interval_mass: float = 0.95
     """Probability mass of the HDI. Must be 0.95 for all v1 outputs (FR-3.1)."""
+    draws: list[list[float]] | None = None
+    """Raw posterior predictive draws, shape ``(n_draws, n_periods)``.
+
+    Included so downstream consumers (like risk-adjusted allocation) can compute
+    tail risks (e.g. CVaR, P_loss) without dropping back to engine-native code.
+    """
 
 
 @dataclass(frozen=True)

--- a/src/wanamaker/forecast/posterior_predictive.py
+++ b/src/wanamaker/forecast/posterior_predictive.py
@@ -35,7 +35,11 @@ class PosteriorPredictiveEngine(Protocol):
         new_data: pd.DataFrame,
         seed: int,
     ) -> PredictiveSummary:
-        """Draw target samples for ``new_data`` using ``posterior_summary`` context."""
+        """Draw target samples for ``new_data`` using ``posterior_summary`` context.
+
+        The returned ``PredictiveSummary`` must include the per-draw outcome matrix
+        in its ``draws`` field with shape ``(n_draws, n_periods)``.
+        """
         ...
 
 

--- a/tests/test_pymc_posterior_predictive.py
+++ b/tests/test_pymc_posterior_predictive.py
@@ -123,6 +123,17 @@ def test_new_data_returns_predictive_summary_over_plan_periods(fitted_posterior)
     assert result.periods[0].startswith("2024-09")
     assert result.interval_mass == pytest.approx(0.95)
 
+    # Check draws matrix (#64)
+    assert result.draws is not None
+    n_draws = len(result.draws)
+    assert n_draws > 0
+    assert all(len(d) == 4 for d in result.draws)
+
+    # Mean derived from draws must match the summary
+    draws_array = np.array(result.draws)
+    derived_mean = draws_array.mean(axis=0)
+    np.testing.assert_allclose(derived_mean, result.mean, rtol=1e-6)
+
 
 def test_new_data_predictive_is_reproducible_for_same_seed(fitted_posterior) -> None:
     engine, posterior = fitted_posterior
@@ -164,3 +175,5 @@ def test_in_sample_path_still_works(fitted_posterior) -> None:
     result = engine.posterior_predictive(posterior, new_data=None, seed=_FORECAST_SEED)
     assert isinstance(result, PredictiveSummary)
     assert len(result.periods) == 32  # toy dataset length
+    assert result.draws is not None
+    assert all(len(d) == 32 for d in result.draws)


### PR DESCRIPTION
Closes #64.

This PR extends `PredictiveSummary` to optionally include the raw posterior predictive draws `(n_draws, n_periods)`. This enables callers to compute probability metrics like CVaR_5 without reaching into engine-native posterior structures. 

It updates `PyMCEngine` to attach these draws to the `PredictiveSummary` returned from both `posterior_predictive` (in-sample) and `posterior_predictive` (new-data forecast). It also fixes an underlying issue where forecasting on new data would mutate the PyMC model's coordinates and `constant_data`, causing subsequent in-sample prediction attempts to fail due to shape mismatches.

---
*PR created automatically by Jules for task [17637069800878212057](https://jules.google.com/task/17637069800878212057) started by @mbagalman*