### PR TITLE
Wire recommend-ramp CLI

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -89,6 +89,23 @@ wanamaker compare-scenarios --run-id <run_id> --plans path/to/base.csv --plans p
 | `--seed` | integer | run seed | Override posterior-predictive sampling seed. |
 | `--output` | path | `<run_dir>/scenario_comparison.md` | Markdown scenario report path. |
 
+### `wanamaker recommend-ramp`
+
+Recommend a risk-adjusted staged move from a baseline plan toward a target plan.
+
+```bash
+wanamaker recommend-ramp --run-id <run_id> --baseline path/to/base.csv --target path/to/alt.csv
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--run-id` | string | required | Existing fitted run ID. |
+| `--baseline` | path | required | Current or status-quo future spend plan CSV. |
+| `--target` | path | required | Candidate future spend plan CSV. |
+| `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
+| `--seed` | integer | run seed | Override posterior-predictive sampling seed. |
+| `--output` | path | `<run_dir>/ramp_<baseline>_to_<target>.md` | Markdown ramp report path. |
+
 ### `wanamaker refresh`
 
 Re-run the model with posterior anchoring against the previous compatible run.
@@ -244,6 +261,8 @@ run:
 ### Forecast
 
 ::: wanamaker.forecast.posterior_predictive
+
+::: wanamaker.forecast.ramp
 
 ::: wanamaker.forecast.scenarios
 

--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -7,6 +7,7 @@ Six core commands per FR-6.3:
     wanamaker report --run-id <run_id>
     wanamaker forecast --run-id <run_id> --plan <plan.csv>
     wanamaker compare-scenarios --run-id <run_id> --plans <p1.csv> <p2.csv> ...
+    wanamaker recommend-ramp --run-id <run_id> --baseline <base.csv> --target <alt.csv>
     wanamaker refresh --config <config.yaml>
 
 Per AGENTS.md Hard Rule 1, none of these commands may make outbound
@@ -614,6 +615,89 @@ def compare_scenarios(
 
     output_path = output if output is not None else paths.root / "scenario_comparison.md"
     output_path.write_text(_format_scenario_comparison_markdown(results, run_id))
+    typer.echo(typer.style(f"\nReport saved: {output_path}", fg=typer.colors.GREEN))
+
+
+@app.command(name="recommend-ramp")
+def recommend_ramp(
+    run_id: str = typer.Option(..., "--run-id"),
+    baseline: Path = typer.Option(..., "--baseline", exists=True),
+    target: Path = typer.Option(..., "--target", exists=True),
+    artifact_dir: Path = typer.Option(
+        Path(".wanamaker"),
+        "--artifact-dir",
+        help="Root of the runs directory (default: .wanamaker).",
+    ),
+    seed: int | None = typer.Option(
+        None,
+        "--seed",
+        help="Override the run's stored seed for posterior-predictive sampling.",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        help=(
+            "Path to save the Markdown report. "
+            "Default: <run_dir>/ramp_<baseline>_to_<target>.md"
+        ),
+    ),
+) -> None:
+    """Recommend a risk-adjusted ramp from a baseline plan to a target plan."""
+    from wanamaker.artifacts import deserialize_refresh_diff
+    from wanamaker.config import load_config
+    from wanamaker.forecast.ramp import recommend_ramp as run_recommend_ramp
+    from wanamaker.reports import (
+        build_ramp_recommendation_context,
+        render_ramp_recommendation,
+    )
+    from wanamaker.trust_card.compute import build_trust_card
+
+    plan_engine, _, summary, paths, run_seed = _load_run_for_forecast(
+        artifact_dir, run_id
+    )
+    seed_used = seed if seed is not None else run_seed
+
+    refresh_diff = None
+    if paths.refresh_diff.exists():
+        refresh_diff = deserialize_refresh_diff(paths.refresh_diff.read_text())
+
+    cfg = load_config(paths.config)
+    trust_card = build_trust_card(
+        summary,
+        refresh_diff=refresh_diff,
+        lift_test_priors=_load_lift_priors_if_any(cfg),
+    )
+    spend_by_channel = _spend_by_channel_from_training_data(cfg)
+
+    typer.echo(
+        f"Recommending ramp from {baseline} to {target} "
+        f"with run {run_id} (seed={seed_used})..."
+    )
+    recommendation = run_recommend_ramp(
+        summary,
+        baseline,
+        target,
+        seed_used,
+        plan_engine,
+        trust_card=trust_card,
+    )
+
+    _print_ramp_recommendation(recommendation)
+    advisor_handoff = _ramp_advisor_handoff(
+        recommendation, summary, spend_by_channel=spend_by_channel,
+    )
+
+    output_path = output if output is not None else (
+        paths.root / f"ramp_{baseline.stem}_to_{target.stem}.md"
+    )
+    context = build_ramp_recommendation_context(
+        recommendation,
+        run_id=run_id,
+        baseline_path=baseline,
+        target_path=target,
+        advisor_handoff=advisor_handoff,
+    )
+    output_path.write_text(render_ramp_recommendation(context), encoding="utf-8")
     typer.echo(typer.style(f"\nReport saved: {output_path}", fg=typer.colors.GREEN))
 
 
@@ -1455,6 +1539,64 @@ def _format_scenario_comparison_markdown(results: list[Any], run_id: str) -> str
                     )
         lines.append("")
     return "\n".join(lines) + "\n"
+
+
+def _print_ramp_recommendation(recommendation: Any) -> None:
+    """Print the ramp recommendation as a compact human-readable table."""
+    typer.echo("\nRisk-adjusted ramp recommendation")
+    typer.echo(f"  Verdict: {recommendation.status}")
+    typer.echo(f"  Recommended ramp: {recommendation.recommended_fraction:.0%}")
+    typer.echo(f"  {recommendation.explanation}")
+    if recommendation.blocking_reason:
+        typer.echo(f"  Blocking reason: {recommendation.blocking_reason}")
+
+    if not recommendation.candidates:
+        return
+
+    typer.echo("")
+    typer.echo(
+        f"  {'Ramp':<8} {'Pass':<6} {'Expected inc.':>14} "
+        f"{'P(improve)':>12} {'P(loss)':>10} {'Failed gates':<28}"
+    )
+    for candidate in recommendation.candidates:
+        failed = ", ".join(candidate.failed_gates) if candidate.failed_gates else "none"
+        typer.echo(
+            f"  {candidate.fraction:<8.0%} {str(candidate.passes):<6} "
+            f"{candidate.expected_increment:>14,.0f} "
+            f"{candidate.probability_positive:>12.0%} "
+            f"{candidate.probability_material_loss:>10.0%} "
+            f"{failed:<28}"
+        )
+
+
+def _ramp_advisor_handoff(
+    recommendation: Any,
+    summary: Any,
+    *,
+    spend_by_channel: dict[str, float] | None = None,
+) -> str | None:
+    """Return an Experiment Advisor handoff for evidence-bound ramp outcomes."""
+    if recommendation.status != "test_first" or recommendation.blocking_reason:
+        return None
+
+    from wanamaker.advisor import flag_channels
+
+    try:
+        flags = flag_channels(summary, spend_by_channel=spend_by_channel)
+    except NotImplementedError:
+        flags = []
+
+    if flags:
+        channel = flags[0].channel
+    else:
+        contributions = list(getattr(summary, "channel_contributions", []) or [])
+        if not contributions:
+            return (
+                "A controlled test would most reduce the binding gate for this "
+                "recommendation."
+            )
+        channel = max(contributions, key=lambda c: c.mean_contribution).channel
+    return f"A test on `{channel}` would most reduce the binding gate."
 
 
 def _load_lift_priors_if_any(cfg: Any) -> Any:

--- a/src/wanamaker/reports/__init__.py
+++ b/src/wanamaker/reports/__init__.py
@@ -13,14 +13,18 @@ Templates ship inside this subpackage so the package is self-contained.
 
 from wanamaker.reports.render import (
     build_executive_summary_context,
+    build_ramp_recommendation_context,
     build_trust_card_context,
     render_executive_summary,
+    render_ramp_recommendation,
     render_trust_card,
 )
 
 __all__ = [
     "build_executive_summary_context",
+    "build_ramp_recommendation_context",
     "build_trust_card_context",
     "render_executive_summary",
+    "render_ramp_recommendation",
     "render_trust_card",
 ]

--- a/src/wanamaker/reports/render.py
+++ b/src/wanamaker/reports/render.py
@@ -71,6 +71,11 @@ def render_trust_card(context: dict[str, Any]) -> str:
     return _render("trust_card.md.j2", context)
 
 
+def render_ramp_recommendation(context: dict[str, Any]) -> str:
+    """Render a risk-adjusted allocation ramp recommendation (FR-5.6)."""
+    return _render("ramp_recommendation.md.j2", context)
+
+
 # ---------------------------------------------------------------------------
 # Context shaping
 # ---------------------------------------------------------------------------
@@ -185,6 +190,71 @@ def build_trust_card_context(
         ],
         "saturation_channels": saturation_channels,
         "has_invariant_channels": has_invariant,
+    }
+
+
+def build_ramp_recommendation_context(
+    recommendation: Any,
+    *,
+    run_id: str,
+    baseline_path: Any,
+    target_path: Any,
+    advisor_handoff: str | None = None,
+) -> dict[str, Any]:
+    """Shape the inputs the ramp-recommendation template expects.
+
+    Args:
+        recommendation: ``RampRecommendation`` returned by
+            ``wanamaker.forecast.ramp.recommend_ramp``.
+        run_id: Run ID used to reconstruct the posterior.
+        baseline_path: User-supplied baseline plan path.
+        target_path: User-supplied target plan path.
+        advisor_handoff: Optional Experiment Advisor sentence for
+            evidence-bound recommendations.
+
+    Returns:
+        Plain dict ready to feed into ``render_ramp_recommendation``.
+    """
+    status_labels = {
+        "proceed": "Proceed",
+        "stage": "Stage",
+        "test_first": "Test first",
+        "do_not_recommend": "Do not recommend",
+    }
+    candidates = []
+    for candidate in recommendation.candidates:
+        candidates.append({
+            "fraction": float(candidate.fraction),
+            "fraction_label": f"{candidate.fraction:.0%}",
+            "expected_increment": float(candidate.expected_increment),
+            "probability_positive": float(candidate.probability_positive),
+            "probability_material_loss": float(candidate.probability_material_loss),
+            "q05_increment": float(candidate.q05_increment),
+            "cvar_5": float(candidate.cvar_5),
+            "largest_move_share": float(candidate.largest_move_share),
+            "fractional_kelly": float(candidate.fractional_kelly),
+            "passes": bool(candidate.passes),
+            "failed_gates": list(candidate.failed_gates),
+            "failed_gates_label": (
+                ", ".join(candidate.failed_gates) if candidate.failed_gates else "none"
+            ),
+            "extrapolation_count": len(candidate.extrapolation_flags),
+        })
+
+    return {
+        "run_id": run_id,
+        "baseline_path": str(baseline_path),
+        "target_path": str(target_path),
+        "baseline_plan_name": recommendation.baseline_plan_name,
+        "target_plan_name": recommendation.target_plan_name,
+        "recommended_fraction": float(recommendation.recommended_fraction),
+        "recommended_fraction_label": f"{recommendation.recommended_fraction:.0%}",
+        "status": recommendation.status,
+        "status_label": status_labels.get(recommendation.status, recommendation.status),
+        "explanation": recommendation.explanation,
+        "blocking_reason": recommendation.blocking_reason,
+        "candidates": candidates,
+        "advisor_handoff": advisor_handoff,
     }
 
 

--- a/src/wanamaker/reports/templates/ramp_recommendation.md.j2
+++ b/src/wanamaker/reports/templates/ramp_recommendation.md.j2
@@ -1,0 +1,45 @@
+{# Risk-adjusted allocation ramp template (FR-5.6).
+
+   Voice: dry, direct, deterministic. This report explains how far the
+   model supports moving from a baseline plan toward a target plan.
+#}
+# Risk-adjusted ramp recommendation
+
+- Run ID: `{{ run_id }}`
+- Baseline plan: `{{ baseline_path }}`
+- Target plan: `{{ target_path }}`
+- Verdict: **{{ status_label }}** (`{{ status }}`)
+- Recommended ramp: **{{ recommended_fraction_label }}**
+
+## Recommendation
+
+{{ explanation }}
+{% if advisor_handoff %}
+
+{{ advisor_handoff }}
+{% endif %}
+{% if blocking_reason %}
+
+Blocking reason: `{{ blocking_reason }}`
+{% endif %}
+
+## Candidate Gates
+
+{% if candidates %}
+| Ramp | Gate status | Expected increment | P(improvement) | P(material loss) | q05 increment | CVaR 5 | Largest move share | Kelly cap | Failed gates | Extrapolation flags |
+|---:|---|---:|---:|---:|---:|---:|---:|---:|---|---:|
+{% for c in candidates %}
+| {{ c.fraction_label }} | {% if c.passes %}pass{% else %}fail{% endif %} | {{ "{:,.0f}".format(c.expected_increment) }} | {{ "{:.0%}".format(c.probability_positive) }} | {{ "{:.0%}".format(c.probability_material_loss) }} | {{ "{:,.0f}".format(c.q05_increment) }} | {{ "{:,.0f}".format(c.cvar_5) }} | {{ "{:.0%}".format(c.largest_move_share) }} | {{ "{:.0%}".format(c.fractional_kelly) }} | {{ c.failed_gates_label }} | {{ c.extrapolation_count }} |
+{% endfor %}
+{% else %}
+No positive ramp candidates were evaluated. The recommendation was blocked before
+candidate scoring.
+{% endif %}
+
+## How To Use This
+
+This is not an automatic budget optimizer. It evaluates how much of the
+user-supplied target plan is analytically supported right now. If the verdict is
+`stage`, adopt the recommended fraction and refresh after new data arrives. If
+the verdict is `test_first`, the next useful action is better evidence, not a
+larger immediate move.

--- a/tests/unit/test_cli_recommend_ramp.py
+++ b/tests/unit/test_cli_recommend_ramp.py
@@ -1,0 +1,340 @@
+"""Tests for the ``wanamaker recommend-ramp`` CLI command (issue #66).
+
+The CLI orchestration mirrors ``forecast`` and ``compare-scenarios``:
+it reconstructs the run, binds a saved posterior to the engine adapter,
+calls the engine-neutral ramp core, and writes a deterministic Markdown
+report. Tests stub ``PyMCEngine.load_posterior`` and
+``PyMCEngine.posterior_predictive`` so no PyMC sampling is invoked.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from wanamaker.artifacts import serialize_summary
+from wanamaker.engine.base import Posterior
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    ConvergenceSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+
+runner = CliRunner()
+
+CSV_BODY = textwrap.dedent(
+    """\
+    week,revenue,search,tv
+    2024-01-01,100,10,50
+    2024-01-08,110,12,55
+    2024-01-15,120,15,60
+    2024-01-22,118,10,58
+    """
+)
+
+
+def _write_data_csv(tmp_path: Path) -> Path:
+    path = tmp_path / "data.csv"
+    path.write_text(CSV_BODY)
+    return path
+
+
+def _write_plan_csv(
+    tmp_path: Path,
+    name: str,
+    *,
+    search: float,
+    tv: float = 100.0,
+) -> Path:
+    path = tmp_path / name
+    path.write_text(f"period,search,tv\n2024-02-05,{search},{tv}\n")
+    return path
+
+
+def _summary(*, spend_invariant_tv: bool = False) -> PosteriorSummary:
+    return PosteriorSummary(
+        parameters=[],
+        channel_contributions=[
+            ChannelContributionSummary(
+                channel="search",
+                mean_contribution=500.0,
+                hdi_low=100.0,
+                hdi_high=900.0,
+                roi_mean=1.0,
+                roi_hdi_low=-1.0,
+                roi_hdi_high=3.0,
+                observed_spend_min=10.0,
+                observed_spend_max=50.0,
+            ),
+            ChannelContributionSummary(
+                channel="tv",
+                mean_contribution=200.0,
+                hdi_low=150.0,
+                hdi_high=250.0,
+                roi_mean=0.5,
+                roi_hdi_low=0.4,
+                roi_hdi_high=0.6,
+                observed_spend_min=80.0,
+                observed_spend_max=120.0,
+                spend_invariant=spend_invariant_tv,
+            ),
+        ],
+        convergence=ConvergenceSummary(
+            max_r_hat=1.001,
+            min_ess_bulk=800.0,
+            n_divergences=0,
+            n_chains=4,
+            n_draws=500,
+        ),
+    )
+
+
+def _write_run(
+    tmp_path: Path,
+    *,
+    csv_path: Path,
+    artifact_dir: Path,
+    summary: PosteriorSummary | None = None,
+    run_id: str = "00000000_20260101T000000Z",
+) -> Path:
+    run_dir = artifact_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "config.yaml").write_text(
+        textwrap.dedent(
+            f"""\
+            data:
+              csv_path: {csv_path.as_posix()}
+              date_column: week
+              target_column: revenue
+              spend_columns: [search, tv]
+            channels:
+              - {{name: search, category: paid_search}}
+              - {{name: tv, category: linear_tv}}
+            run:
+              seed: 7
+              runtime_mode: quick
+            """
+        )
+    )
+    (run_dir / "summary.json").write_text(serialize_summary(summary or _summary()))
+    (run_dir / "posterior.nc").write_bytes(b"fake")
+    return run_dir
+
+
+def _install_stub_engine(monkeypatch: pytest.MonkeyPatch, mode: str) -> dict[str, Any]:
+    captured: dict[str, Any] = {"seeds": []}
+
+    def _load_posterior(self: Any, run_dir: Any, model_spec: Any, data: Any) -> Any:
+        captured["run_dir"] = run_dir
+        captured["model_spec"] = model_spec
+        captured["data_rows"] = len(data)
+        return Posterior(raw=object())
+
+    def _posterior_predictive(
+        self: Any, posterior: Any, new_data: Any, seed: int  # noqa: ARG001
+    ) -> PredictiveSummary:
+        captured["seeds"].append(seed)
+        df = pd.DataFrame(new_data)
+        search = df["search"].astype(float).to_numpy()
+        draws = _draws_for_mode(mode, search, n_periods=len(df))
+        return PredictiveSummary(
+            periods=df["period"].astype(str).tolist(),
+            mean=draws.mean(axis=0).tolist(),
+            hdi_low=np.quantile(draws, 0.025, axis=0).tolist(),
+            hdi_high=np.quantile(draws, 0.975, axis=0).tolist(),
+            draws=draws.tolist(),
+        )
+
+    monkeypatch.setattr(
+        "wanamaker.engine.pymc.PyMCEngine.load_posterior",
+        _load_posterior,
+    )
+    monkeypatch.setattr(
+        "wanamaker.engine.pymc.PyMCEngine.posterior_predictive",
+        _posterior_predictive,
+    )
+    return captured
+
+
+def _draws_for_mode(mode: str, search: np.ndarray, *, n_periods: int) -> np.ndarray:
+    draws = np.full((100, n_periods), 1_000.0)
+    first_search = float(search[0])
+
+    if mode == "proceed":
+        fraction = max(0.0, min(1.0, (first_search - 10.0) / 10.0))
+        if fraction > 0.50:
+            delta = np.concatenate([
+                np.full(70, 100.0 * fraction),
+                np.full(30, -10.0 * fraction),
+            ])
+        else:
+            delta = np.full(100, 100.0 * fraction)
+    elif mode == "stage":
+        fraction = max(0.0, min(1.0, (first_search - 20.0) / 60.0))
+        delta = np.full(100, 100.0 * fraction)
+    elif mode == "test_first":
+        fraction = max(0.0, min(1.0, (first_search - 50.0) / 250.0))
+        delta = np.full(100, 100.0 * fraction)
+    elif mode == "negative":
+        fraction = max(0.0, min(1.0, (first_search - 10.0) / 10.0))
+        delta = np.full(100, -100.0 * fraction)
+    else:
+        delta = np.zeros(100)
+
+    return draws + delta[:, None]
+
+
+def _invoke_recommend_ramp(
+    tmp_path: Path,
+    *,
+    mode: str,
+    baseline_search: float,
+    target_search: float,
+    baseline_tv: float = 100.0,
+    target_tv: float = 100.0,
+    summary: PosteriorSummary | None = None,
+    output: Path | None = None,
+    seed: int | None = None,
+) -> tuple[Any, Path, Path]:
+    artifact_dir = tmp_path / ".wanamaker"
+    csv = _write_data_csv(tmp_path)
+    run_dir = _write_run(
+        tmp_path,
+        csv_path=csv,
+        artifact_dir=artifact_dir,
+        summary=summary,
+    )
+    baseline = _write_plan_csv(
+        tmp_path, "base.csv", search=baseline_search, tv=baseline_tv,
+    )
+    target = _write_plan_csv(
+        tmp_path, "alt.csv", search=target_search, tv=target_tv,
+    )
+
+    from wanamaker.cli import app
+
+    args = [
+        "recommend-ramp",
+        "--run-id",
+        "00000000_20260101T000000Z",
+        "--baseline",
+        str(baseline),
+        "--target",
+        str(target),
+        "--artifact-dir",
+        str(artifact_dir),
+    ]
+    if seed is not None:
+        args.extend(["--seed", str(seed)])
+    if output is not None:
+        args.extend(["--output", str(output)])
+
+    result = runner.invoke(app, args)
+    return result, run_dir, target
+
+
+@pytest.mark.parametrize(
+    ("mode", "baseline_search", "target_search", "expected_status"),
+    [
+        ("proceed", 10.0, 20.0, "proceed"),
+        ("stage", 20.0, 80.0, "stage"),
+        ("test_first", 50.0, 300.0, "test_first"),
+        ("negative", 10.0, 20.0, "do_not_recommend"),
+    ],
+)
+def test_each_ramp_status_is_reachable_through_cli(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    baseline_search: float,
+    target_search: float,
+    expected_status: str,
+) -> None:
+    _install_stub_engine(monkeypatch, mode)
+    result, run_dir, _ = _invoke_recommend_ramp(
+        tmp_path,
+        mode=mode,
+        baseline_search=baseline_search,
+        target_search=target_search,
+    )
+    assert result.exit_code == 0, result.output
+    assert f"Verdict: {expected_status}" in result.output
+
+    report = run_dir / "ramp_base_to_alt.md"
+    assert report.exists()
+    body = report.read_text()
+    assert f"(`{expected_status}`)" in body
+    assert "## Candidate Gates" in body
+    if expected_status != "do_not_recommend":
+        assert "Failed gates" in body
+
+
+def test_report_contains_risk_table_failed_gates_and_advisor_handoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_stub_engine(monkeypatch, "test_first")
+    result, run_dir, _ = _invoke_recommend_ramp(
+        tmp_path,
+        mode="test_first",
+        baseline_search=50.0,
+        target_search=300.0,
+    )
+    assert result.exit_code == 0, result.output
+
+    body = (run_dir / "ramp_base_to_alt.md").read_text()
+    assert "| Ramp | Gate status | Expected increment | P(improvement) |" in body
+    assert "extrapolation" in body
+    assert "A test on `search` would most reduce the binding gate." in body
+
+
+def test_spend_invariant_target_reallocation_blocks_recommendation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_stub_engine(monkeypatch, "stage")
+    result, run_dir, _ = _invoke_recommend_ramp(
+        tmp_path,
+        mode="stage",
+        baseline_search=20.0,
+        target_search=20.0,
+        baseline_tv=100.0,
+        target_tv=120.0,
+        summary=_summary(spend_invariant_tv=True),
+    )
+    assert result.exit_code == 0, result.output
+    assert "do_not_recommend" in result.output
+    assert "spend_invariant_reallocation" in result.output
+
+    body = (run_dir / "ramp_base_to_alt.md").read_text()
+    assert "Do not recommend" in body
+    assert "spend-invariant channel(s)" in body
+    assert "Blocking reason: `spend_invariant_reallocation`" in body
+
+
+def test_seed_and_output_overrides_are_supported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _install_stub_engine(monkeypatch, "stage")
+    custom_output = tmp_path / "custom_ramp.md"
+    result, _, _ = _invoke_recommend_ramp(
+        tmp_path,
+        mode="stage",
+        baseline_search=20.0,
+        target_search=80.0,
+        output=custom_output,
+        seed=1234,
+    )
+    assert result.exit_code == 0, result.output
+    assert custom_output.exists()
+    assert "# Risk-adjusted ramp recommendation" in custom_output.read_text()
+    assert captured["seeds"]
+    assert set(captured["seeds"]) == {1234}


### PR DESCRIPTION
Fixes #66.

## Summary
- Adds `wanamaker recommend-ramp --run-id <id> --baseline <plan.csv> --target <plan.csv>`.
- Reuses the forecast engine adapter path to reconstruct the saved posterior and call `recommend_ramp()`.
- Computes the Trust Card on demand, includes optional refresh diff context, and adds an Experiment Advisor handoff sentence for evidence-bound `test_first` recommendations.
- Adds a deterministic Jinja2 Markdown ramp report saved by default to `<run_dir>/ramp_<baseline>_to_<target>.md`.
- Documents the new CLI command and ramp Python API in `docs/api_reference.md`.

## Validation
- `python -m pytest tests\unit\test_cli_recommend_ramp.py -q` — 7 passed
- `python -m pytest tests\unit\test_cli_recommend_ramp.py tests\unit\test_cli_forecast.py tests\unit\test_ramp.py tests\unit\test_reports_render.py -q` — 53 passed
- `python -m pytest tests\test_no_network_in_core.py tests\unit\test_cli_recommend_ramp.py -q` — 8 passed
- `python -m pytest tests\unit -q` — 565 passed
- `python -m mkdocs build --strict` — passes; emits only the upstream Material for MkDocs notice
- `python -m ruff check src\wanamaker\reports\render.py src\wanamaker\reports\__init__.py tests\unit\test_cli_recommend_ramp.py` — passes
- `python -m ruff check src\wanamaker\cli.py --ignore B008,F401,UP017,N806,I001` — passes; full-file Ruff still has pre-existing Typer/default and cleanup backlog outside this change