### PR TITLE
Remove stale scaffold wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ measurement without a PhD program.
 
 ---
 
-**Status:** Pre-build. The combined BRD/PRD is locked at v0.4 and lives in
-[`docs/wanamaker_brd_prd.md`](docs/wanamaker_brd_prd.md). The current phase
-is **Phase -1**: engine decision spike and persona validation. Nothing in
-this repository fits a model yet.
+**Status:** Active pre-1.0 development. The combined BRD/PRD is locked at v0.4
+and lives in [`docs/wanamaker_brd_prd.md`](docs/wanamaker_brd_prd.md). The
+core local workflow is now in place: `diagnose`, `fit`, `report`, `forecast`,
+`compare-scenarios`, `recommend-ramp`, `refresh`, and
+`run --example public_benchmark`.
 
 ## What this is for
 
@@ -45,7 +46,9 @@ Wanamaker sits in the gap.
 ## One-command end-to-end example
 
 ```bash
-pip install wanamaker
+git clone https://github.com/mbagalman/wanamaker.git
+cd wanamaker
+pip install -e ".[dev]"
 wanamaker run --example public_benchmark
 ```
 
@@ -61,8 +64,8 @@ minutes on a modern laptop.
 2. [Privacy and Data Handling](docs/privacy.md) — confidentiality and data isolation guarantees
 3. [`AGENTS.md`](AGENTS.md) — guidance for AI coding assistants and human
    contributors on how to work in this codebase
-4. The `Comparison to Other Tools` page (forthcoming) — Wanamaker vs.
-   Robyn, Meridian, Recast, PyMC-Marketing
+4. [Comparison to Other Tools](docs/comparison.md) — Wanamaker vs. Robyn,
+   Meridian, Recast, PyMC-Marketing
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,11 @@
 
 **Audience:** Developers and AI coding assistants working on the codebase.
 **Companion documents:** [`docs/wanamaker_brd_prd.md`](wanamaker_brd_prd.md) (what and why), [`AGENTS.md`](https://github.com/mbagalman/wanamaker/blob/main/AGENTS.md) (hard rules and coding conventions).
-**Status:** Phase 0 / entering Phase 1. PyMC backend implemented and tested; core transforms, model spec, config, artifacts, diagnose, and refresh diff are all fully implemented. Active work is on forecast, trust card, reports, and remaining CLI commands.
+**Status:** Active pre-1.0 development. PyMC backend, transforms, model spec,
+config, artifacts, diagnose, refresh diff, forecasting, scenario comparison,
+risk-adjusted ramp recommendations, Trust Card, reports, and the public CLI
+workflow are implemented. Active work is on hardening benchmarks, release
+packaging, and deferred supporting-role xgboost paths.
 
 ---
 
@@ -70,8 +74,10 @@ The CLI is intentionally thin. Each command resolves configuration, then delegat
 | `wanamaker diagnose <data.csv> [--config]` | `wanamaker.diagnose` |
 | `wanamaker fit --config <config.yaml>` | `wanamaker.model`, `wanamaker.engine` |
 | `wanamaker report --run-id <id>` | `wanamaker.reports` |
+| `wanamaker run --example public_benchmark` | `wanamaker.diagnose`, `wanamaker.model`, `wanamaker.reports` |
 | `wanamaker forecast --run-id <id> --plan <plan.csv>` | `wanamaker.forecast` |
 | `wanamaker compare-scenarios --run-id <id> --plans ...` | `wanamaker.forecast` |
+| `wanamaker recommend-ramp --run-id <id> --baseline <base.csv> --target <target.csv>` | `wanamaker.forecast` |
 | `wanamaker refresh --config <config.yaml>` | `wanamaker.refresh`, `wanamaker.engine` |
 
 **`diagnose` accepts an optional `--config`:** Without it, only checks that do not require column knowledge run (history length, date regularity, structural breaks), with a warning. With it, all checks run including spend variation and collinearity. This matches the progressive disclosure model: a user exploring a new CSV does not need a config yet.
@@ -495,7 +501,10 @@ The user-facing API has three layers (FR-7), each providing full access:
 | 2 -- Guided config | YAML with full `WanamakerConfig` schema | Channel categories, business constraints, lift test path, runtime mode, anchor strength |
 | 3 -- Expert overrides | Python API | Direct `ModelSpec`, prior overrides, custom transforms, raw `Posterior` objects, sampler tuning |
 
-A new user should be able to go from `pip install wanamaker` to a complete executive summary in under 30 minutes following only the quickstart documentation (FR-7.1 acceptance criterion).
+A new user should be able to go from source checkout today, and eventually
+`pip install wanamaker` after release, to a complete executive summary in under
+30 minutes following only the quickstart documentation (FR-7.1 acceptance
+criterion).
 
 ---
 
@@ -503,7 +512,7 @@ A new user should be able to go from `pip install wanamaker` to a complete execu
 
 All outputs go to `.wanamaker/` in the project directory (FR-Privacy.2). Nothing is written to the user's home directory or any system path by default. The `artifact_dir` can be overridden via `config.run.artifact_dir` or a CLI flag.
 
-**No network calls in any core code path.** Enforced by `tests/test_no_network_in_core.py`, which walks the import graph of all core subpackages at import time and fails the build if any banned module appears. This is an **import-time guardrail** -- it catches modules imported at module load but does not catch optional or lazy imports inside functions until those functions execute. A planned companion test (to be added in Phase 2) will run each of the six core commands in a network-isolated container and compare output.
+**No network calls in any core code path.** Enforced by `tests/test_no_network_in_core.py`, which walks the import graph of all core subpackages at import time and fails the build if any banned module appears. This is an **import-time guardrail** -- it catches modules imported at module load but does not catch optional or lazy imports inside functions until those functions execute. The companion runtime gate, `tests/test_network_isolation.py`, exercises the primary core workflow in a network-isolated environment when engine tests are enabled.
 
 **`manifest.json`** is the run manifest written to every run directory. It records:
 - `run_id` (unique per execution)
@@ -517,21 +526,21 @@ All outputs go to `.wanamaker/` in the project directory (FR-Privacy.2). Nothing
 
 ---
 
-## 7. What Is Built vs. Stubbed
+## 7. What Is Built vs. Deferred
 
 | Module | Status | Phase |
 |---|---|---|
-| `cli.py` | **Implemented** -- `diagnose` and `fit` wired up; `report`, `forecast`, `compare-scenarios`, `refresh` stub | Phase 1-2 |
-| `config.py` | **Implemented** -- full pydantic schema | Done |
+| `cli.py` | **Implemented** -- `diagnose`, `fit`, `report`, `run`, `forecast`, `compare-scenarios`, `recommend-ramp`, and `refresh` | Done |
+| `config.py` | **Implemented** -- strict pydantic schema | Done |
 | `seeding.py` | **Implemented** -- `make_rng` and `derive_seed` | Done |
-| `artifacts.py` | **Implemented** -- directory layout, fingerprint/run_id, versioned envelopes for all JSON artifacts, `list_runs`, `load_manifest` | Done |
-| `data/io.py` | **Partial** -- `load_input_csv` works; `load_lift_test_csv` stubbed | Phase 1 |
+| `artifacts.py` | **Implemented** -- directory layout, fingerprint/run_id, versioned envelopes for summary, Trust Card, refresh diff, and ramp recommendation artifacts, `list_runs`, `load_manifest` | Done |
+| `data/io.py` | **Implemented** -- input CSV and lift-test CSV loading/validation | Done |
 | `data/taxonomy.py` | **Implemented** -- channel category names | Done |
 | `diagnose/readiness.py` | **Implemented** -- all data structures | Done |
 | `diagnose/checks.py` | **Implemented** -- all 9 checks including structural breaks, collinearity, spend variation, target leakage | Done |
 | `engine/base.py` | **Implemented** -- Protocol, `Posterior`, `FitResult` | Done |
-| `engine/summary.py` | **Implemented** -- all typed summary types | Done |
-| `engine/pymc.py` | **Implemented** -- full PyMC backend; HDI, data-adaptive priors, period labels, convergence | Done |
+| `engine/summary.py` | **Implemented** -- typed summary objects, channel summaries, posterior predictive draws | Done |
+| `engine/pymc.py` | **Implemented** -- PyMC backend; HDI, data-adaptive priors, period labels, convergence, posterior predictive | Done |
 | `transforms/adstock.py` | **Implemented** -- `geometric_adstock` (validated), `weibull_adstock`, `half_life_to_decay` | Done |
 | `transforms/saturation.py` | **Implemented** -- `hill_saturation` (validated, log-space stable) | Done |
 | `model/spec.py` | **Implemented** -- full schema: `ChannelSpec`, `LiftPrior`, `HoldoutConfig`, `SeasonalitySpec`, `AnchoredPrior`, `ModelSpec` | Done |
@@ -540,13 +549,15 @@ All outputs go to `.wanamaker/` in the project directory (FR-Privacy.2). Nothing
 | `refresh/anchor.py` | **Implemented** -- presets, `resolve_anchor_weight` | Done |
 | `refresh/classify.py` | **Implemented** -- `MovementClass` enum, `classify_movement`, `unexplained_fraction` | Done |
 | `refresh/diff.py` | **Implemented** -- `ParameterMovement` (with `movement_class`), `RefreshDiff`, `compute_diff` | Done |
-| `forecast/posterior_predictive.py` | Stubbed | Phase 1 |
-| `forecast/scenarios.py` | Stubbed | Phase 1 |
+| `forecast/posterior_predictive.py` | **Implemented** -- forecast plan loading, spend-range warnings, posterior predictive contract | Done |
+| `forecast/scenarios.py` | **Implemented** -- conservative scenario ranking with caveats | Done |
+| `forecast/ramp.py` | **Implemented** -- risk-adjusted ramp recommendation core | Done |
 | `trust_card/card.py` | **Implemented** -- `TrustStatus`, `TrustDimension`, `TrustCard` frozen dataclasses | Done |
-| `advisor/channel_flagging.py` | Scaffolded -- `ChannelFlag` defined; `flag_channels` stubbed | Phase 2 |
-| `reports/render.py` | **Implemented** -- Jinja2 environment wired; template shells | Templates: Phase 2 |
-| `benchmarks/loaders.py` | **Implemented** -- `load_synthetic_ground_truth()` returns `(DataFrame, dict)` | Done |
-| `_xgboost_aux/` | Empty | Phase 1 |
+| `trust_card/compute.py` | **Implemented** -- Trust Card computation from diagnostics and posterior summaries | Done |
+| `advisor/channel_flagging.py` | **Implemented** -- minimal v1 experiment flagging | Done |
+| `reports/render.py` | **Implemented** -- deterministic Jinja2 Markdown rendering for executive summary, Trust Card, and ramp recommendation | Done |
+| `benchmarks/loaders.py` | **Implemented** -- synthetic and public benchmark loaders | Done |
+| `_xgboost_aux/` | Deferred supporting-role module only; no production xgboost paths yet | Post-v1 hardening |
 
 ---
 
@@ -556,7 +567,7 @@ These are not guidelines -- violating them means rebuilding the project's credib
 
 | Invariant | Enforcement |
 |---|---|
-| No HTTP / telemetry in core code paths | CI test `test_no_network_in_core.py` (import-time); planned network-isolated integration tests (Phase 2) |
+| No HTTP / telemetry in core code paths | CI test `test_no_network_in_core.py` (import-time); runtime gate `test_network_isolation.py` when engine tests are enabled |
 | No LLM calls for output generation | Code review + no LLM SDK in dependencies |
 | No xgboost for ROI / saturation / adstock | AGENTS.md Hard Rule 3; `_xgboost_aux` module isolation |
 | Numerically close reproducibility given same seed (RTOL=1e-6) | NFR-2; `tests/test_reproducibility.py` (enabled with `WANAMAKER_RUN_ENGINE_TESTS=1`) |
@@ -605,7 +616,7 @@ These are not guidelines -- violating them means rebuilding the project's credib
 **CI gates:**
 - `test_no_network_in_core.py` -- runs on every PR; walks core import graph at import time (fast guardrail)
 - `tests/test_reproducibility.py` -- enabled with `WANAMAKER_RUN_ENGINE_TESTS=1`; fits same benchmark twice with same seed, compares all summary floats within RTOL=1e-6 (numerically close, not necessarily bit-for-bit identical across platforms)
-- Network-isolated integration test (planned Phase 2) -- runs each of the 6 core commands in a container without network access and compares output
+- Network-isolated integration test -- runs the primary core workflow without network access when engine tests are enabled
 - Cross-platform install test (planned Phase 2) -- clean-environment pip install on Linux, macOS (Intel + ARM), Windows
 
 ---
@@ -621,4 +632,4 @@ These are not guidelines -- violating them means rebuilding the project's credib
 
 ---
 
-*Last updated: 2026-04-29. Update this document when module responsibilities change, interfaces are finalized, or key decisions land.*
+*Last updated: 2026-05-01. Update this document when module responsibilities change, interfaces are finalized, or key decisions land.*

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -139,10 +139,11 @@ tags, or nightly rather than every PR.
 
 ### One-Command Demo
 
-**Status: Tracked, not implemented.**
+**Status: Resolved.**
 
-Issue #42 tracks the `wanamaker run --example public_benchmark` style wrapper.
-This remains blocked by the report command and public example dataset work.
+`wanamaker run --example public_benchmark` now chains the readiness diagnostic,
+quick-mode fit, and report rendering on the bundled public benchmark dataset.
+The remaining work is release verification, not a product-design gap.
 
 ## Documentation Cleanup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,16 +3,17 @@
 Wanamaker is an open-source Bayesian marketing mix model for teams that need credible
 measurement without a deep data science bench.
 
-The project is currently in Phase -1: engine decision and persona validation. The
-documentation site is scaffolded so implementation and user-facing guidance can grow
-together.
+The project is in active pre-1.0 development. The PyMC engine decision is made,
+the local workflow is implemented, and the docs now describe source-checkout
+usage while public package and image release work is still pending.
 
 ## Start Here
 
-- [Installation](installation.md) describes the planned pip and Docker paths.
-- [Quickstart](quickstart.md) outlines the intended end-to-end workflow.
-- [Analyst's Guide](analyst_guide.md) will explain MMM concepts at a working level.
-- [What Wanamaker Tells Your CMO](cmo_guide.md) will explain outputs in business terms.
+- [Installation](installation.md) describes source-checkout and local Docker usage.
+- [Quickstart](quickstart.md) walks through the bundled public benchmark.
+- [Analyst's Guide](analyst_guide.md) explains MMM concepts at a working level.
+- [What Wanamaker Tells Your CMO](cmo_guide.md) explains outputs in business terms.
+- [API Reference](api_reference.md) documents the CLI, YAML config, Python modules, and artifact files.
 
 ## Project References
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,37 +1,53 @@
 # Installation
 
-This page will cover the supported installation paths for Wanamaker.
+Wanamaker is in active pre-1.0 development. The package is not published to
+PyPI yet, so the supported path today is a source checkout.
 
-## Status
+## Requirements
 
-Wanamaker is in Phase -1. The Bayesian engine has not been selected yet, so installation
-instructions are not final.
+- Python 3.11+
+- No R runtime
+- No GPU requirement for v1
+- No network access required for core commands after installation
 
-## Planned Paths
+The selected Bayesian engine is PyMC. Install time can be longer than a small
+pure-Python package because the scientific Python stack is part of the runtime.
 
-### pip
+## Source Checkout
 
-The target path for users comfortable with Python environments:
+Clone the repository and install it in editable mode:
 
 ```bash
-pip install wanamaker
+git clone https://github.com/mbagalman/wanamaker.git
+cd wanamaker
+pip install -e ".[dev]"
 ```
 
-For local development:
+For documentation work:
+
+```bash
+pip install -e ".[docs]"
+```
+
+For both development and docs:
 
 ```bash
 pip install -e ".[dev,docs]"
 ```
 
-### Docker
+Verify the CLI is available:
 
-The target path for users who want all dependencies pre-resolved.
+```bash
+wanamaker --help
+wanamaker run --example public_benchmark
+```
 
-#### Build from source (available today)
+The example writes artifacts under `.wanamaker/runs/<run_id>/`.
 
-A `Dockerfile` ships in the repository root. Until the official
-`wanamaker/wanamaker` image is published to Docker Hub at v1.0, build
-the image locally:
+## Docker
+
+A `Dockerfile` ships in the repository root. Until an official image is
+published, build it locally:
 
 ```bash
 git clone https://github.com/mbagalman/wanamaker.git
@@ -39,40 +55,26 @@ cd wanamaker
 docker build -t wanamaker .
 ```
 
-Run the bundled one-command demo inside the image:
+Run the bundled example:
 
 ```bash
 docker run --rm wanamaker run --example public_benchmark
 ```
 
-Run any subcommand against your own data by mounting the file:
+Run a command against local files by mounting your project directory:
 
 ```bash
-docker run --rm -v "$PWD":/workspace wanamaker diagnose data.csv --config config.yaml
+docker run --rm -v "$PWD":/workspace wanamaker diagnose /workspace/data.csv --config /workspace/config.yaml
 ```
 
-The image leaves run artifacts in the container's `/workspace/.wanamaker/`
-directory; mounting your project root lets `wanamaker fit` write them
-back to the host filesystem so they persist between runs.
+Run artifacts written under `/workspace/.wanamaker/` persist on the host when
+the project directory is mounted.
 
-#### Pulled image (after v1.0)
+## Not Yet Published
 
-Once the image is published, the same flow becomes:
+The future user-facing install paths are still release work:
 
-```bash
-docker run --rm wanamaker/wanamaker run --example public_benchmark
-```
+- `pip install wanamaker` after the PyPI package is published
+- `docker run --rm wanamaker/wanamaker ...` after the official image is published
 
-## Requirements
-
-- Python 3.11+
-- No R runtime
-- No GPU requirement for v1
-- No network access required for core commands after installation (see [Privacy and Data Handling](privacy.md) for details on our local-first guarantees)
-
-## To Be Completed
-
-- Final engine-specific dependency notes
-- Windows, macOS, and Linux installation checks
-- Docker mount examples for local CSV files
-
+Until then, use the source checkout or locally built Docker image.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,9 @@ reading channel estimates, uncertainty, and the Trust Card.
 If you just want to see Wanamaker run end-to-end on the public example:
 
 ```bash
-pip install wanamaker
+git clone https://github.com/mbagalman/wanamaker.git
+cd wanamaker
+pip install -e ".[dev]"
 wanamaker run --example public_benchmark
 ```
 

--- a/docs/references/adstock_and_saturation.md
+++ b/docs/references/adstock_and_saturation.md
@@ -158,7 +158,10 @@ The Hill function alone (without channel-specific data) is hard to specify prior
 
 ## 5. Estimation Approaches
 
-Wanamaker uses **Bayesian estimation** via the engine layer (PyMC, NumPyro, or Stan — to be decided in Phase -1). The adstock and saturation parameters are treated as model parameters with priors and are estimated jointly with the channel coefficients.
+Wanamaker uses **Bayesian estimation** via the engine layer, with PyMC as the
+current production backend. The adstock and saturation parameters are treated
+as model parameters with priors and are estimated jointly with the channel
+coefficients.
 
 For reference, here are the alternatives that are *not* used:
 

--- a/src/wanamaker/__init__.py
+++ b/src/wanamaker/__init__.py
@@ -1,10 +1,10 @@
-"""Wanamaker — open-source Bayesian marketing mix model.
+"""Wanamaker -- open-source Bayesian marketing mix model.
 
 Strategic and product context lives in ``docs/wanamaker_brd_prd.md``.
 Architectural invariants and contributor guidance live in ``AGENTS.md``.
 
-This package is in pre-build scaffolding. Most public surfaces raise
-``NotImplementedError`` until the corresponding phase lands.
+Public workflows are exposed through ``wanamaker.cli``. The package remains
+pre-1.0 while the modeling, reporting, and release contracts stabilize.
 """
 
 __version__ = "0.0.0"

--- a/src/wanamaker/config.py
+++ b/src/wanamaker/config.py
@@ -5,8 +5,9 @@ three-layer progressive disclosure architecture in FR-7). Every field here
 should be motivated by an actual user need — per AGENTS.md, do not add
 config options speculatively.
 
-The schema is intentionally minimal in the scaffold; fields will accrete
-as features land.
+The schema is intentionally compact. New fields should be added only when a
+real workflow needs them because every option becomes part of the user-facing
+contract.
 """
 
 from __future__ import annotations

--- a/src/wanamaker/engine/base.py
+++ b/src/wanamaker/engine/base.py
@@ -43,8 +43,9 @@ class FitResult:
 class Engine(Protocol):
     """The interface every Bayesian engine must satisfy.
 
-    Implementations live alongside this file (e.g., ``engine/pymc.py``) once
-    the Phase -1 decision lands. The protocol is intentionally narrow.
+    Implementations live alongside this file. The production backend is
+    currently ``engine/pymc.py``; the protocol stays intentionally narrow so
+    feature code does not depend on backend-native objects.
     """
 
     name: str

--- a/tests/test_network_isolation.py
+++ b/tests/test_network_isolation.py
@@ -1,4 +1,4 @@
-"""End-to-end network-isolation gate for the six core CLI commands (#33).
+"""End-to-end network-isolation gate for the primary core CLI workflow (#33).
 
 Per FR-Privacy.1 / AGENTS.md Hard Rule 1, none of ``diagnose``, ``fit``,
 ``report``, ``forecast``, ``compare-scenarios``, or ``refresh`` may make
@@ -159,7 +159,7 @@ def _extract_run_id(output: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_six_core_commands_in_network_isolation(tmp_path: Path) -> None:
+def test_primary_core_workflow_in_network_isolation(tmp_path: Path) -> None:
     """Run ``diagnose`` → ``fit`` → ``report`` → ``forecast`` →
     ``compare-scenarios`` → ``refresh`` end-to-end with outbound network
     blocked, asserting each command exits cleanly and writes its

--- a/tests/test_no_network_in_core.py
+++ b/tests/test_no_network_in_core.py
@@ -1,8 +1,7 @@
 """CI gate: core code paths must not import HTTP / network libraries.
 
-Per AGENTS.md Hard Rule 1 and FR-Privacy.1, the core CLI commands
-(``diagnose``, ``fit``, ``report``, ``forecast``, ``compare-scenarios``,
-``refresh``) must not make outbound network calls.
+Per AGENTS.md Hard Rule 1 and FR-Privacy.1, core CLI commands must not make
+outbound network calls.
 
 This test enforces the rule architecturally by walking the import graph
 of every core module and rejecting any transitive import of a known HTTP
@@ -41,7 +40,7 @@ BANNED_MODULES: frozenset[str] = frozenset(
     }
 )
 
-# Subpackages whose code paths back the six core CLI commands.
+# Subpackages whose code paths back the core local workflow.
 CORE_SUBPACKAGES: tuple[str, ...] = (
     "wanamaker.cli",
     "wanamaker.config",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,8 +1,7 @@
-"""Smoke tests for the CLI surface (FR-6.3).
+"""Smoke tests for the public CLI surface (FR-6.3).
 
-We're checking that the six core commands are wired up and discoverable,
-not that they do anything yet — they all raise ``NotImplementedError``
-in the scaffold pass.
+We're checking that the public commands are wired up and discoverable. Command
+behavior is covered by narrower unit and integration tests.
 """
 
 from __future__ import annotations
@@ -14,15 +13,17 @@ from wanamaker.cli import app
 runner = CliRunner()
 
 
-def test_help_lists_all_six_core_commands() -> None:
+def test_help_lists_public_commands() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     for cmd in (
         "diagnose",
         "fit",
         "report",
+        "run",
         "forecast",
         "compare-scenarios",
+        "recommend-ramp",
         "refresh",
     ):
         assert cmd in result.output


### PR DESCRIPTION
## Summary
- Updates README, docs index, installation, quickstart, architecture, and feedback notes to reflect the implemented pre-1.0 workflow instead of Phase -1 scaffolding.
- Updates package/module/test docstrings that still described scaffold or stubbed behavior.
- Leaves release metadata and historical BRD/PRD language alone; PyPI and official Docker image publication remain release work.

## Validation
- `python -m pytest tests/unit/test_cli.py -q`
- `python -m ruff check src/wanamaker/__init__.py src/wanamaker/config.py src/wanamaker/engine/base.py tests/test_network_isolation.py tests/test_no_network_in_core.py tests/unit/test_cli.py`
- `python -m mkdocs build --strict`