### PR TITLE
Add HTML showcase: one-command "show-to-CMO" report

### DIFF
--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -1,10 +1,11 @@
 """``wanamaker`` CLI entry point.
 
-Six core commands per FR-6.3:
+Core commands per FR-6.3 plus the HTML showcase:
 
     wanamaker diagnose <data.csv>
     wanamaker fit --config <config.yaml>
     wanamaker report --run-id <run_id>
+    wanamaker showcase --run-id <run_id>
     wanamaker forecast --run-id <run_id> --plan <plan.csv>
     wanamaker compare-scenarios --run-id <run_id> --plans <p1.csv> <p2.csv> ...
     wanamaker recommend-ramp --run-id <run_id> --baseline <base.csv> --target <alt.csv>
@@ -21,7 +22,7 @@ delegates to the relevant subpackage.
 from __future__ import annotations
 
 import shutil
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -225,7 +226,6 @@ def fit(
     from wanamaker.artifacts import (
         hash_config,
         hash_file,
-        list_runs,
         make_run_fingerprint,
         run_paths,
         serialize_summary,
@@ -233,7 +233,6 @@ def fit(
     )
     from wanamaker.config import load_config
     from wanamaker.data.io import load_input_csv
-    from wanamaker.diagnose.readiness import CheckSeverity, ReadinessLevel
     from wanamaker.engine.pymc import PyMCEngine
     from wanamaker.model.builder import build_model_spec
 
@@ -295,7 +294,7 @@ def fit(
     # ------------------------------------------------------------------
     # 6. Create run_id and artifact directory
     # ------------------------------------------------------------------
-    timestamp_utc = datetime.now(timezone.utc)
+    timestamp_utc = datetime.now(UTC)
     timestamp_str = timestamp_utc.strftime("%Y%m%dT%H%M%SZ")
     run_id = f"{fingerprint[:8]}_{timestamp_str}"
     paths = run_paths(cfg.run.artifact_dir, run_id)
@@ -441,6 +440,158 @@ def report(
     typer.echo(typer.style(f"Report saved: {output_path}", fg=typer.colors.GREEN))
 
 
+@app.command()
+def showcase(
+    run_id: str = typer.Option(..., "--run-id"),
+    artifact_dir: Path = typer.Option(
+        Path(".wanamaker"),
+        "--artifact-dir",
+        help="Root of the runs directory (default: .wanamaker).",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        help="Path to save the HTML showcase. Default: <run_dir>/showcase.html",
+    ),
+    title: str | None = typer.Option(
+        None,
+        "--title",
+        help="Override the showcase title. Default: 'Wanamaker MMM — <run_id short>'.",
+    ),
+    scenario: Path | None = typer.Option(
+        None,
+        "--scenario",
+        exists=True,
+        help=(
+            "Optional plan CSV. When provided, the showcase includes a "
+            "forecast section for that plan."
+        ),
+    ),
+    open_browser: bool = typer.Option(
+        False,
+        "--open",
+        help="Open the rendered showcase in the default browser when done.",
+    ),
+) -> None:
+    """Render a single self-contained HTML showcase of a completed run.
+
+    The showcase bundles the executive summary, channel contributions
+    (with credible intervals), ROI table, the Trust Card, and an optional
+    scenario forecast into one file with all CSS and SVG charts inlined.
+    """
+    import webbrowser
+    from datetime import datetime
+
+    from wanamaker import __version__
+    from wanamaker.artifacts import (
+        deserialize_refresh_diff,
+        deserialize_summary,
+        load_manifest,
+        run_paths,
+    )
+    from wanamaker.config import load_config
+    from wanamaker.reports import build_showcase_context, render_showcase
+    from wanamaker.trust_card.compute import build_trust_card
+
+    paths = run_paths(artifact_dir, run_id)
+    if not paths.config.exists():
+        typer.echo(
+            typer.style(
+                f"Error: run {run_id!r} not found in {artifact_dir / 'runs'}. "
+                "Run 'wanamaker fit' first or check --artifact-dir.",
+                fg=typer.colors.RED,
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if not paths.summary.exists():
+        typer.echo(
+            typer.style(
+                f"Error: summary.json missing for run {run_id!r} at {paths.summary}.",
+                fg=typer.colors.RED,
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    summary = deserialize_summary(paths.summary.read_text())
+
+    refresh_diff = None
+    if paths.refresh_diff.exists():
+        refresh_diff = deserialize_refresh_diff(paths.refresh_diff.read_text())
+
+    cfg = load_config(paths.config)
+    lift_test_priors = _load_lift_priors_if_any(cfg)
+    spend_by_channel = _spend_by_channel_from_training_data(cfg)
+
+    trust_card = build_trust_card(
+        summary,
+        refresh_diff=refresh_diff,
+        lift_test_priors=lift_test_priors,
+    )
+
+    # Manifest gives us the engine label and fingerprint. The showcase
+    # falls back gracefully when manifest is absent (e.g. older runs).
+    runtime_mode = cfg.run.runtime_mode
+    run_fingerprint = ""
+    engine_label = ""
+    if paths.manifest.exists():
+        try:
+            manifest = load_manifest(paths.manifest.read_text())
+            run_fingerprint = str(manifest.get("run_fingerprint", ""))
+            engine = manifest.get("engine", {}) or {}
+            engine_label = (
+                f"{engine.get('name', '?')} {engine.get('version', '?')}"
+            )
+        except ValueError:
+            engine_label = ""
+    data_hash = (
+        paths.data_hash.read_text().strip() if paths.data_hash.exists() else ""
+    )
+
+    scenario_forecast = None
+    scenario_plan_name = None
+    if scenario is not None:
+        from wanamaker.forecast.posterior_predictive import forecast as run_forecast
+
+        plan_engine, _, _, _, run_seed = _load_run_for_forecast(
+            artifact_dir, run_id
+        )
+        typer.echo(f"Forecasting {scenario} for showcase…")
+        scenario_forecast = run_forecast(summary, scenario, run_seed, plan_engine)
+        scenario_plan_name = Path(scenario).stem
+
+    advisor_lines = _safe_advisor_recommendations(
+        summary, spend_by_channel=spend_by_channel,
+    )
+
+    context = build_showcase_context(
+        summary,
+        trust_card,
+        title=title or f"Wanamaker MMM — {run_id[:8]}",
+        run_id=run_id,
+        generated_at=datetime.now(UTC),
+        runtime_mode=runtime_mode,
+        package_version=__version__,
+        data_hash=data_hash,
+        run_fingerprint=run_fingerprint,
+        engine_label=engine_label or "(unknown)",
+        refresh_diff=refresh_diff,
+        scenario_forecast=scenario_forecast,
+        scenario_plan_name=scenario_plan_name,
+        advisor_recommendations=advisor_lines,
+    )
+
+    html = render_showcase(context)
+
+    output_path = output if output is not None else paths.root / "showcase.html"
+    output_path.write_text(html, encoding="utf-8")
+    typer.echo(typer.style(f"Showcase saved: {output_path}", fg=typer.colors.GREEN))
+
+    if open_browser:
+        webbrowser.open(output_path.resolve().as_uri())
+
+
 _RUN_EXAMPLES: tuple[str, ...] = ("public_benchmark",)
 
 
@@ -544,6 +695,20 @@ def run(
         typer.style("Step 3/3 · executive summary + Trust Card", fg=typer.colors.CYAN, bold=True)
     )
     report(run_id=run_id, artifact_dir=artifact_dir, output=None)
+    typer.echo("")
+
+    # Bonus: produce the HTML showcase too. The example flow is the
+    # canonical "show your CMO" demo moment; rendering it here means a
+    # single ``wanamaker run --example`` produces both the analyst-facing
+    # Markdown and the stakeholder-facing HTML in one go.
+    showcase(
+        run_id=run_id,
+        artifact_dir=artifact_dir,
+        output=None,
+        title=None,
+        scenario=None,
+        open_browser=False,
+    )
     typer.echo("")
 
     report_path = artifact_dir / "runs" / run_id / "report.md"
@@ -843,7 +1008,7 @@ def refresh(
         engine_version=engine_version,
         seed=cfg.run.seed,
     )
-    timestamp_utc = datetime.now(timezone.utc)
+    timestamp_utc = datetime.now(UTC)
     timestamp_str = timestamp_utc.strftime("%Y%m%dT%H%M%SZ")
     run_id = f"{fingerprint[:8]}_{timestamp_str}"
     paths = run_paths(cfg.run.artifact_dir, run_id)
@@ -1124,6 +1289,7 @@ def _get_pymc_version() -> str:
 def _write_posterior(posterior: object, path: object) -> None:
     """Write the posterior draws to a NetCDF file via ArviZ InferenceData."""
     from pathlib import Path as _Path
+
     from wanamaker.engine.base import Posterior
     from wanamaker.engine.pymc import PyMCRawPosterior
 

--- a/src/wanamaker/reports/__init__.py
+++ b/src/wanamaker/reports/__init__.py
@@ -19,12 +19,15 @@ from wanamaker.reports.render import (
     render_ramp_recommendation,
     render_trust_card,
 )
+from wanamaker.reports.showcase import build_showcase_context, render_showcase
 
 __all__ = [
     "build_executive_summary_context",
     "build_ramp_recommendation_context",
+    "build_showcase_context",
     "build_trust_card_context",
     "render_executive_summary",
     "render_ramp_recommendation",
+    "render_showcase",
     "render_trust_card",
 ]

--- a/src/wanamaker/reports/_charts.py
+++ b/src/wanamaker/reports/_charts.py
@@ -1,0 +1,444 @@
+"""Hand-rolled SVG chart helpers for the HTML showcase.
+
+Hand-written rather than ``matplotlib``-driven so the byte output is fully
+deterministic across platforms (no font fallbacks, no rasterisation, no
+locale-dependent floats). That keeps the showcase HTML golden-file testable
+and aligned with the project's deterministic-template ethos
+(see ``reports/__init__.py``).
+
+Each public helper takes plain dicts (already shaped by ``render.py``) and
+returns a complete ``<svg>...</svg>`` string. The HTML template inlines the
+result with ``| safe``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from html import escape
+from typing import Any
+
+# Palette — single source of truth so the CSS and the SVG agree.
+_INK = "#0f172a"          # near-black for text
+_MUTED = "#64748b"        # muted grey for axes/ticks
+_PRIMARY = "#2b5876"      # deep blue for bars
+_PRIMARY_LIGHT = "#7c9bb3"
+_HDI = "#94a3b8"          # whisker grey
+_PASS = "#059669"
+_MODERATE = "#d97706"
+_WEAK = "#dc2626"
+_GRID = "#e2e8f0"
+
+# Fonts: stack of system fonts. No external font files.
+_FONT_FAMILY = (
+    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, "
+    "'Helvetica Neue', Arial, sans-serif"
+)
+
+
+def _fmt_int(x: float) -> str:
+    return f"{x:,.0f}"
+
+
+def _fmt_2(x: float) -> str:
+    return f"{x:.2f}"
+
+
+def _confidence_color(confidence: str) -> str:
+    if confidence == "high":
+        return _PASS
+    if confidence == "moderate":
+        return _MODERATE
+    return _WEAK
+
+
+def contribution_bars_svg(channels: Sequence[dict[str, Any]]) -> str:
+    """Horizontal bar chart of channel contributions with 95% HDI whiskers.
+
+    ``channels`` matches the dicts produced by ``_channel_view`` in
+    ``render.py`` (already pre-ranked by mean contribution). Spend-invariant
+    channels render with a hatched fill to flag that the saturation curve
+    came from priors only.
+    """
+    if not channels:
+        return _empty_chart_svg("No channel contributions to display.")
+
+    width = 720
+    row_height = 32
+    top_pad = 24
+    bottom_pad = 48
+    left_pad = 160
+    right_pad = 80
+    bar_height = 18
+
+    n = len(channels)
+    height = top_pad + row_height * n + bottom_pad
+
+    # Domain is [0, max(hdi_high, mean)] across channels, clamped to >=1.
+    max_value = max(
+        max(c["contribution_hdi_high"], c["contribution_mean"]) for c in channels
+    )
+    max_value = max(max_value, 1.0)
+    plot_width = width - left_pad - right_pad
+
+    def x(value: float) -> float:
+        return left_pad + (value / max_value) * plot_width
+
+    parts: list[str] = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {width} {height}" '
+        f'role="img" '
+        f'aria-label="Channel contributions with 95% credible intervals" '
+        f'class="wmk-chart wmk-chart--contributions">'
+    )
+    parts.append(_hatch_pattern_def("wmk-hatch-invariant", _PRIMARY_LIGHT))
+
+    # X-axis baseline + ticks at 0, 25%, 50%, 75%, 100% of max.
+    baseline_y = top_pad + row_height * n + 6
+    parts.append(
+        f'<line x1="{left_pad}" y1="{top_pad - 4}" x2="{left_pad}" '
+        f'y2="{baseline_y}" stroke="{_MUTED}" stroke-width="1"/>'
+    )
+    for frac in (0.0, 0.25, 0.5, 0.75, 1.0):
+        tick_x = left_pad + frac * plot_width
+        tick_value = frac * max_value
+        parts.append(
+            f'<line x1="{tick_x:.1f}" y1="{baseline_y}" '
+            f'x2="{tick_x:.1f}" y2="{baseline_y + 4}" '
+            f'stroke="{_MUTED}" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<text x="{tick_x:.1f}" y="{baseline_y + 18}" '
+            f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="middle">{_fmt_int(tick_value)}</text>'
+        )
+        if frac > 0:
+            parts.append(
+                f'<line x1="{tick_x:.1f}" y1="{top_pad - 4}" '
+                f'x2="{tick_x:.1f}" y2="{baseline_y}" '
+                f'stroke="{_GRID}" stroke-width="1" stroke-dasharray="2,3"/>'
+            )
+
+    # One row per channel.
+    for i, channel in enumerate(channels):
+        row_y = top_pad + i * row_height
+        bar_y = row_y + (row_height - bar_height) / 2
+        mean_x = x(channel["contribution_mean"])
+        hdi_low_x = x(max(channel["contribution_hdi_low"], 0.0))
+        hdi_high_x = x(channel["contribution_hdi_high"])
+        invariant = channel.get("spend_invariant", False)
+        fill = (
+            "url(#wmk-hatch-invariant)" if invariant else _PRIMARY
+        )
+        # Channel label (left).
+        parts.append(
+            f'<text x="{left_pad - 10}" y="{row_y + row_height / 2 + 4:.1f}" '
+            f'fill="{_INK}" font-family="{_FONT_FAMILY}" font-size="12" '
+            f'text-anchor="end" '
+            f'font-weight="500">{escape(str(channel["name"]))}</text>'
+        )
+        # Bar from 0 to mean.
+        bar_width = max(mean_x - left_pad, 0.0)
+        parts.append(
+            f'<rect x="{left_pad}" y="{bar_y:.1f}" '
+            f'width="{bar_width:.1f}" height="{bar_height}" '
+            f'fill="{fill}" rx="2" ry="2"/>'
+        )
+        # HDI whisker (low → high) at the bar's vertical centre.
+        whisker_y = bar_y + bar_height / 2
+        parts.append(
+            f'<line x1="{hdi_low_x:.1f}" y1="{whisker_y:.1f}" '
+            f'x2="{hdi_high_x:.1f}" y2="{whisker_y:.1f}" '
+            f'stroke="{_HDI}" stroke-width="2"/>'
+        )
+        for cap_x in (hdi_low_x, hdi_high_x):
+            parts.append(
+                f'<line x1="{cap_x:.1f}" y1="{whisker_y - 5:.1f}" '
+                f'x2="{cap_x:.1f}" y2="{whisker_y + 5:.1f}" '
+                f'stroke="{_HDI}" stroke-width="2"/>'
+            )
+        # Value label (right).
+        label_x = max(hdi_high_x, mean_x) + 8
+        parts.append(
+            f'<text x="{label_x:.1f}" y="{row_y + row_height / 2 + 4:.1f}" '
+            f'fill="{_INK}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="start">'
+            f'{_fmt_int(channel["contribution_mean"])}</text>'
+        )
+
+    # X-axis label.
+    parts.append(
+        f'<text x="{left_pad + plot_width / 2:.1f}" y="{height - 8}" '
+        f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+        f'text-anchor="middle">Estimated contribution (target units)</text>'
+    )
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def roi_dotplot_svg(channels: Sequence[dict[str, Any]]) -> str:
+    """Per-channel ROI mean with a 95% HDI line.
+
+    Spend-invariant channels are rendered as a flat label only — there is
+    no defensible ROI for a curve that wasn't learned from data.
+    """
+    if not channels:
+        return _empty_chart_svg("No ROI estimates to display.")
+
+    width = 720
+    row_height = 28
+    top_pad = 24
+    bottom_pad = 44
+    left_pad = 160
+    right_pad = 80
+    n = len(channels)
+    height = top_pad + row_height * n + bottom_pad
+
+    measurable = [c for c in channels if not c.get("spend_invariant", False)]
+    if measurable:
+        domain_low = min(c["roi_hdi_low"] for c in measurable)
+        domain_high = max(c["roi_hdi_high"] for c in measurable)
+    else:
+        domain_low, domain_high = 0.0, 1.0
+    domain_low = min(domain_low, 0.0)
+    domain_high = max(domain_high, domain_low + 0.5)
+    plot_width = width - left_pad - right_pad
+    span = domain_high - domain_low
+
+    def x(value: float) -> float:
+        return left_pad + ((value - domain_low) / span) * plot_width
+
+    parts: list[str] = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {width} {height}" '
+        f'role="img" aria-label="Channel ROI with 95% credible intervals" '
+        f'class="wmk-chart wmk-chart--roi">'
+    )
+
+    baseline_y = top_pad + row_height * n + 6
+    # Ticks at 0, 25%, 50%, 75%, 100% of span.
+    for frac in (0.0, 0.25, 0.5, 0.75, 1.0):
+        tick_x = left_pad + frac * plot_width
+        tick_value = domain_low + frac * span
+        parts.append(
+            f'<line x1="{tick_x:.1f}" y1="{baseline_y}" '
+            f'x2="{tick_x:.1f}" y2="{baseline_y + 4}" '
+            f'stroke="{_MUTED}" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<text x="{tick_x:.1f}" y="{baseline_y + 18}" '
+            f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="middle">{_fmt_2(tick_value)}</text>'
+        )
+        if frac > 0:
+            parts.append(
+                f'<line x1="{tick_x:.1f}" y1="{top_pad - 4}" '
+                f'x2="{tick_x:.1f}" y2="{baseline_y}" '
+                f'stroke="{_GRID}" stroke-width="1" stroke-dasharray="2,3"/>'
+            )
+
+    # Zero line if 0 is inside the domain.
+    if domain_low < 0 < domain_high:
+        zero_x = x(0.0)
+        parts.append(
+            f'<line x1="{zero_x:.1f}" y1="{top_pad - 4}" '
+            f'x2="{zero_x:.1f}" y2="{baseline_y}" '
+            f'stroke="{_MUTED}" stroke-width="1" stroke-dasharray="3,3"/>'
+        )
+
+    for i, channel in enumerate(channels):
+        row_y = top_pad + i * row_height + row_height / 2
+        confidence = channel.get("confidence", "weak")
+        invariant = channel.get("spend_invariant", False)
+        # Channel label.
+        parts.append(
+            f'<text x="{left_pad - 10}" y="{row_y + 4:.1f}" '
+            f'fill="{_INK}" font-family="{_FONT_FAMILY}" font-size="12" '
+            f'text-anchor="end" '
+            f'font-weight="500">{escape(str(channel["name"]))}</text>'
+        )
+        if invariant:
+            parts.append(
+                f'<text x="{left_pad}" y="{row_y + 4:.1f}" '
+                f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+                f'font-style="italic" text-anchor="start">'
+                f'spend invariant — ROI not identifiable</text>'
+            )
+            continue
+        color = _confidence_color(confidence)
+        hdi_low_x = x(channel["roi_hdi_low"])
+        hdi_high_x = x(channel["roi_hdi_high"])
+        mean_x = x(channel["roi_mean"])
+        # HDI line.
+        parts.append(
+            f'<line x1="{hdi_low_x:.1f}" y1="{row_y:.1f}" '
+            f'x2="{hdi_high_x:.1f}" y2="{row_y:.1f}" '
+            f'stroke="{_HDI}" stroke-width="2"/>'
+        )
+        for cap_x in (hdi_low_x, hdi_high_x):
+            parts.append(
+                f'<line x1="{cap_x:.1f}" y1="{row_y - 5:.1f}" '
+                f'x2="{cap_x:.1f}" y2="{row_y + 5:.1f}" '
+                f'stroke="{_HDI}" stroke-width="2"/>'
+            )
+        # Mean dot.
+        parts.append(
+            f'<circle cx="{mean_x:.1f}" cy="{row_y:.1f}" r="5" '
+            f'fill="{color}" stroke="white" stroke-width="1"/>'
+        )
+        # Value label.
+        label_x = max(hdi_high_x, mean_x) + 8
+        parts.append(
+            f'<text x="{label_x:.1f}" y="{row_y + 4:.1f}" '
+            f'fill="{_INK}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="start">{_fmt_2(channel["roi_mean"])}</text>'
+        )
+
+    parts.append(
+        f'<text x="{left_pad + plot_width / 2:.1f}" y="{height - 8}" '
+        f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+        f'text-anchor="middle">Return per unit spend</text>'
+    )
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def scenario_delta_svg(
+    periods: Sequence[str],
+    mean: Sequence[float],
+    hdi_low: Sequence[float],
+    hdi_high: Sequence[float],
+) -> str:
+    """Posterior predictive line + 95% HDI ribbon over the forecast periods.
+
+    All three series must be the same length as ``periods``.
+    """
+    n = len(periods)
+    if n == 0 or len(mean) != n or len(hdi_low) != n or len(hdi_high) != n:
+        return _empty_chart_svg("No forecast available.")
+
+    width = 720
+    height = 280
+    top_pad = 24
+    bottom_pad = 48
+    left_pad = 80
+    right_pad = 24
+
+    plot_width = width - left_pad - right_pad
+    plot_height = height - top_pad - bottom_pad
+
+    y_min = min(min(hdi_low), min(mean))
+    y_max = max(max(hdi_high), max(mean))
+    if y_max == y_min:
+        y_max = y_min + 1.0
+    y_pad = (y_max - y_min) * 0.05
+    y_min -= y_pad
+    y_max += y_pad
+
+    def x(i: int) -> float:
+        if n == 1:
+            return left_pad + plot_width / 2
+        return left_pad + (i / (n - 1)) * plot_width
+
+    def y(value: float) -> float:
+        return top_pad + (1.0 - (value - y_min) / (y_max - y_min)) * plot_height
+
+    parts: list[str] = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {width} {height}" '
+        f'role="img" aria-label="Predicted outcome over forecast periods" '
+        f'class="wmk-chart wmk-chart--scenario">'
+    )
+
+    # Y-axis grid + ticks (5 lines).
+    for frac in (0.0, 0.25, 0.5, 0.75, 1.0):
+        gy = top_pad + (1 - frac) * plot_height
+        gv = y_min + frac * (y_max - y_min)
+        parts.append(
+            f'<line x1="{left_pad}" y1="{gy:.1f}" '
+            f'x2="{left_pad + plot_width}" y2="{gy:.1f}" '
+            f'stroke="{_GRID}" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<text x="{left_pad - 8}" y="{gy + 4:.1f}" '
+            f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="end">{_fmt_int(gv)}</text>'
+        )
+
+    # HDI ribbon as a closed polygon.
+    upper = " ".join(f"{x(i):.1f},{y(hdi_high[i]):.1f}" for i in range(n))
+    lower = " ".join(
+        f"{x(i):.1f},{y(hdi_low[i]):.1f}" for i in reversed(range(n))
+    )
+    parts.append(
+        f'<polygon points="{upper} {lower}" '
+        f'fill="{_PRIMARY_LIGHT}" fill-opacity="0.35" '
+        f'stroke="none"/>'
+    )
+
+    # Mean line.
+    line_points = " ".join(f"{x(i):.1f},{y(mean[i]):.1f}" for i in range(n))
+    parts.append(
+        f'<polyline points="{line_points}" '
+        f'fill="none" stroke="{_PRIMARY}" stroke-width="2" '
+        f'stroke-linejoin="round"/>'
+    )
+
+    # X-axis: first/last period labels and a midpoint when n > 2.
+    indices = [0, n - 1]
+    if n > 2:
+        indices.insert(1, n // 2)
+    seen = set()
+    for i in indices:
+        if i in seen:
+            continue
+        seen.add(i)
+        label_x = x(i)
+        parts.append(
+            f'<text x="{label_x:.1f}" y="{height - bottom_pad + 18}" '
+            f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="middle">{escape(str(periods[i]))}</text>'
+        )
+
+    # Axis frame.
+    parts.append(
+        f'<line x1="{left_pad}" y1="{top_pad + plot_height}" '
+        f'x2="{left_pad + plot_width}" y2="{top_pad + plot_height}" '
+        f'stroke="{_MUTED}" stroke-width="1"/>'
+    )
+
+    # Y-axis label.
+    parts.append(
+        f'<text x="{left_pad}" y="{height - 12}" '
+        f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+        f'text-anchor="start">Period</text>'
+    )
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _empty_chart_svg(message: str) -> str:
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" '
+        'viewBox="0 0 720 80" role="img" '
+        f'aria-label="{escape(message)}" class="wmk-chart wmk-chart--empty">'
+        f'<text x="360" y="44" fill="{_MUTED}" '
+        f'font-family="{_FONT_FAMILY}" font-size="12" '
+        f'text-anchor="middle" font-style="italic">{escape(message)}</text>'
+        '</svg>'
+    )
+
+
+def _hatch_pattern_def(pattern_id: str, color: str) -> str:
+    """Diagonal hatch pattern used to mark spend-invariant channels."""
+    return (
+        f'<defs><pattern id="{pattern_id}" patternUnits="userSpaceOnUse" '
+        f'width="6" height="6" patternTransform="rotate(45)">'
+        f'<rect width="6" height="6" fill="{color}" fill-opacity="0.35"/>'
+        f'<line x1="0" y1="0" x2="0" y2="6" stroke="{color}" '
+        f'stroke-width="2"/></pattern></defs>'
+    )

--- a/src/wanamaker/reports/render.py
+++ b/src/wanamaker/reports/render.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
-from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
+from jinja2 import Environment, PackageLoader, StrictUndefined
 
 from wanamaker.engine.summary import (
     ChannelContributionSummary,
@@ -43,9 +43,23 @@ _HIGH_CONFIDENCE_RATIO = 0.5
 _MODERATE_CONFIDENCE_RATIO = 1.0
 
 
+def _autoescape_for(template_name: str | None) -> bool:
+    """Autoescape HTML templates only.
+
+    ``select_autoescape(["html"])`` strips the last extension and matches
+    against it; that breaks for our convention of double-suffix names
+    like ``showcase.html.j2``. This predicate matches both single
+    (``.html``) and Jinja-suffixed (``.html.j2``) names so the showcase
+    is autoescaped while the Markdown ``.md.j2`` templates are not.
+    """
+    if template_name is None:
+        return False
+    return template_name.endswith((".html", ".html.j2", ".htm", ".htm.j2"))
+
+
 _env = Environment(
     loader=PackageLoader("wanamaker.reports", "templates"),
-    autoescape=select_autoescape(["html"]),
+    autoescape=_autoescape_for,
     undefined=StrictUndefined,
     trim_blocks=True,
     lstrip_blocks=True,

--- a/src/wanamaker/reports/showcase.py
+++ b/src/wanamaker/reports/showcase.py
@@ -1,0 +1,281 @@
+"""HTML "show-to-CMO" showcase rendering.
+
+The showcase exists so a reader can forward a single self-contained file
+("show your CMO") and have it render identically in any modern browser,
+Outlook preview, or print. No CDN, no JS, no external assets — the
+stylesheet is inlined and charts are rendered as inline SVG.
+
+Per AGENTS.md Hard Rule 2: **no LLM calls for output generation**, ever.
+The showcase reuses the same context shapers as the Markdown report.
+
+Public surface:
+
+- ``build_showcase_context`` — turn ``PosteriorSummary`` + ``TrustCard``
+  (plus optional refresh diff and optional scenario forecast) into the
+  flat dict the template consumes.
+- ``render_showcase`` — apply the Jinja2 template to a ready-made context.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime
+from importlib.resources import files
+from typing import Any
+
+from wanamaker.engine.summary import PosteriorSummary
+from wanamaker.forecast.posterior_predictive import ForecastResult
+from wanamaker.refresh.classify import MovementClass, unexplained_fraction
+from wanamaker.refresh.diff import RefreshDiff
+from wanamaker.reports._charts import (
+    contribution_bars_svg,
+    roi_dotplot_svg,
+    scenario_delta_svg,
+)
+from wanamaker.reports.render import (
+    build_executive_summary_context,
+    build_trust_card_context,
+)
+from wanamaker.trust_card.card import TrustCard, TrustStatus
+
+_DECISION_NOTES: dict[str, str] = {
+    "convergence": (
+        "If sampler diagnostics are weak, treat the posterior as approximate "
+        "and avoid fine-grained reallocation calls until the fit is rerun."
+    ),
+    "holdout_accuracy": (
+        "If holdout accuracy is weak, the model is not predicting recent "
+        "history well — be cautious about forward forecasts."
+    ),
+    "refresh_stability": (
+        "If refresh stability is weak, recent estimates moved enough that "
+        "prior decisions made on the old run may no longer hold."
+    ),
+    "prior_sensitivity": (
+        "If prior sensitivity is weak, the data is not pinning down the "
+        "answer — priors are doing more work than the evidence."
+    ),
+    "saturation_identifiability": (
+        "If saturation is weakly identifiable, do not make strong "
+        "reallocation calls based on response-curve shape."
+    ),
+    "lift_test_consistency": (
+        "If lift-test consistency is weak, the model disagrees with recent "
+        "experiments — reconcile before acting on either."
+    ),
+}
+
+
+def _trust_pill(trust_card: TrustCard) -> dict[str, str]:
+    """Top-of-page verdict pill summarising the Trust Card.
+
+    Worst dimension wins. Empty Trust Card defaults to "moderate".
+    """
+    if not trust_card.dimensions:
+        return {
+            "status": "moderate",
+            "label": "No verdict",
+            "explanation": "No Trust Card dimensions were computed for this run.",
+        }
+    statuses = {d.status for d in trust_card.dimensions}
+    if TrustStatus.WEAK in statuses:
+        weak_names = [
+            d.name for d in trust_card.dimensions if d.status == TrustStatus.WEAK
+        ]
+        return {
+            "status": "weak",
+            "label": "Use with caution",
+            "explanation": (
+                "The Trust Card flags weakness on "
+                + ", ".join(weak_names)
+                + ". Outputs touching those dimensions need careful interpretation."
+            ),
+        }
+    if TrustStatus.MODERATE in statuses:
+        return {
+            "status": "moderate",
+            "label": "Mixed evidence",
+            "explanation": (
+                "The Trust Card is broadly OK, with moderate evidence on "
+                "some dimensions. Read each dimension before strong action."
+            ),
+        }
+    return {
+        "status": "pass",
+        "label": "Trust Card clean",
+        "explanation": (
+            "The Trust Card passes on every dimension. The fit is well "
+            "identified and outputs can be acted on with normal caution."
+        ),
+    }
+
+
+def _refresh_narrative(refresh_diff: RefreshDiff) -> Mapping[str, Any]:
+    """Mirror of the Markdown report's refresh narrative."""
+    movements = list(refresh_diff.movements)
+    fraction = unexplained_fraction(movements)
+    classes: dict[str, int] = {}
+    for movement in movements:
+        if movement.movement_class is None:
+            continue
+        classes[movement.movement_class.value] = (
+            classes.get(movement.movement_class.value, 0) + 1
+        )
+    unexplained_count = classes.get(MovementClass.UNEXPLAINED.value, 0)
+    return {
+        "previous_run_id": refresh_diff.previous_run_id,
+        "n_movements": len(movements),
+        "n_unexplained": unexplained_count,
+        "unexplained_fraction": fraction,
+        "movements_by_class": classes,
+    }
+
+
+def _scenario_block(
+    forecast_result: ForecastResult,
+    plan_name: str,
+    baseline_total: float | None,
+) -> dict[str, Any]:
+    """Per-period mean+HDI plus the totals the prose paragraph needs."""
+    mean_total = float(sum(forecast_result.mean))
+    hdi_low_total = float(sum(forecast_result.hdi_low))
+    hdi_high_total = float(sum(forecast_result.hdi_high))
+    extrap = sorted({flag.channel for flag in forecast_result.extrapolation_flags})
+    return {
+        "plan_name": plan_name,
+        "mean_total": mean_total,
+        "hdi_low_total": hdi_low_total,
+        "hdi_high_total": hdi_high_total,
+        "baseline_total": baseline_total,
+        "delta": (mean_total - baseline_total) if baseline_total is not None else 0.0,
+        "extrapolation_warnings": extrap,
+        "periods": list(forecast_result.periods),
+        "mean": list(forecast_result.mean),
+        "hdi_low": list(forecast_result.hdi_low),
+        "hdi_high": list(forecast_result.hdi_high),
+    }
+
+
+def build_showcase_context(
+    summary: PosteriorSummary,
+    trust_card: TrustCard,
+    *,
+    title: str,
+    run_id: str,
+    generated_at: datetime,
+    runtime_mode: str,
+    package_version: str,
+    data_hash: str,
+    run_fingerprint: str,
+    engine_label: str,
+    refresh_diff: RefreshDiff | None = None,
+    scenario_forecast: ForecastResult | None = None,
+    scenario_plan_name: str | None = None,
+    baseline_total: float | None = None,
+    advisor_recommendations: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Shape every input the showcase template needs.
+
+    Reuses the Markdown report's context shapers for executive-summary
+    fields and trust-card per-channel saturation rendering, then adds the
+    showcase-only chrome (verdict pill, decision notes, charts, footer
+    metadata).
+    """
+    exec_ctx = build_executive_summary_context(
+        summary,
+        trust_card,
+        refresh_diff=refresh_diff,
+        advisor_recommendations=advisor_recommendations,
+        trust_card_link="#trust-card",
+    )
+    trust_ctx = build_trust_card_context(summary, trust_card)
+
+    trust_dimensions = [
+        {
+            "name": d["name"],
+            "status": d["status"],
+            "explanation": d["explanation"],
+            "decision_note": (
+                _DECISION_NOTES.get(d["name"]) if d["status"] == "weak" else None
+            ),
+        }
+        for d in trust_ctx["dimensions"]
+    ]
+
+    scenario_block: dict[str, Any] | None = None
+    scenario_chart_svg = ""
+    if scenario_forecast is not None:
+        scenario_block = _scenario_block(
+            scenario_forecast,
+            plan_name=scenario_plan_name or "scenario",
+            baseline_total=baseline_total,
+        )
+        scenario_chart_svg = scenario_delta_svg(
+            scenario_block["periods"],
+            scenario_block["mean"],
+            scenario_block["hdi_low"],
+            scenario_block["hdi_high"],
+        )
+
+    refresh_narrative = (
+        _refresh_narrative(refresh_diff) if refresh_diff is not None else None
+    )
+
+    return {
+        # Header / footer.
+        "title": title,
+        "run_id": run_id,
+        "generated_at": generated_at.strftime("%Y-%m-%d %H:%M UTC"),
+        "runtime_mode": runtime_mode,
+        "package_version": package_version,
+        "data_hash": data_hash[:16] if data_hash else "—",
+        "run_fingerprint": run_fingerprint or "—",
+        "engine_label": engine_label,
+        # Period.
+        "period_start": exec_ctx["period_start"],
+        "period_end": exec_ctx["period_end"],
+        "n_periods": exec_ctx["n_periods"],
+        # Channels (already ranked + tagged).
+        "channels": exec_ctx["channels"],
+        "total_media_contribution": exec_ctx["total_media_contribution"],
+        # Trust card.
+        "trust_card_pill": _trust_pill(trust_card),
+        "trust_dimensions": trust_dimensions,
+        "has_invariant_channels": trust_ctx["has_invariant_channels"],
+        # Charts.
+        "contribution_chart_svg": contribution_bars_svg(exec_ctx["channels"]),
+        "roi_chart_svg": roi_dotplot_svg(exec_ctx["channels"]),
+        "scenario_chart_svg": scenario_chart_svg,
+        # Optional sections.
+        "scenario": scenario_block,
+        "refresh_narrative": refresh_narrative,
+    }
+
+
+def _read_stylesheet() -> str:
+    """Read the bundled ``showcase.css`` so it can be inlined into ``<style>``.
+
+    Reading at render time (not import time) keeps the package import
+    lazy and avoids any I/O on bare ``import wanamaker``.
+    """
+    return (
+        files("wanamaker.reports.templates")
+        .joinpath("showcase.css")
+        .read_text(encoding="utf-8")
+    )
+
+
+def render_showcase(context: dict[str, Any]) -> str:
+    """Render the showcase HTML from a ready-made context.
+
+    The stylesheet is read from package resources at call time and
+    injected so the output is a single self-contained file. The Jinja2
+    environment is the one configured in ``reports.render`` and uses
+    ``select_autoescape(["html"])``; SVG payloads are explicitly
+    ``| safe`` in the template.
+    """
+    from wanamaker.reports.render import _env  # local import to avoid a cycle
+
+    template = _env.get_template("showcase.html.j2")
+    enriched = {**context, "stylesheet": _read_stylesheet()}
+    return template.render(**enriched)

--- a/src/wanamaker/reports/templates/showcase.css
+++ b/src/wanamaker/reports/templates/showcase.css
@@ -1,0 +1,299 @@
+/* showcase stylesheet — inlined into the HTML <style> block at render time.
+   No external fonts, no CDN, no JS. System font stack only.
+*/
+:root {
+  --ink: #0f172a;
+  --muted: #64748b;
+  --line: #e2e8f0;
+  --bg: #ffffff;
+  --bg-soft: #f8fafc;
+  --primary: #2b5876;
+  --primary-soft: #eef4f8;
+  --pass: #059669;
+  --pass-soft: #ecfdf5;
+  --moderate: #d97706;
+  --moderate-soft: #fff7ed;
+  --weak: #dc2626;
+  --weak-soft: #fef2f2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-soft);
+  color: var(--ink);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+main {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+  background: var(--bg);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04);
+}
+
+header.wmk-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 16px;
+  margin-bottom: 24px;
+  gap: 16px;
+}
+
+header.wmk-header h1 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+  letter-spacing: -0.01em;
+}
+
+header.wmk-header .wmk-meta {
+  font-size: 12px;
+  color: var(--muted);
+  text-align: right;
+  white-space: nowrap;
+}
+
+section {
+  margin: 32px 0;
+}
+
+section h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 12px 0;
+  letter-spacing: -0.005em;
+}
+
+section h3 {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin: 0 0 8px 0;
+}
+
+p {
+  margin: 8px 0;
+}
+
+p.wmk-prose {
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  background: var(--bg-soft);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+/* Verdict band ---------------------------------------------------------- */
+
+.wmk-verdict {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 20px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg-soft);
+  margin-bottom: 24px;
+}
+
+.wmk-verdict__pill {
+  flex: 0 0 auto;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.wmk-pill--pass {
+  background: var(--pass-soft);
+  color: var(--pass);
+  border: 1px solid var(--pass);
+}
+
+.wmk-pill--moderate {
+  background: var(--moderate-soft);
+  color: var(--moderate);
+  border: 1px solid var(--moderate);
+}
+
+.wmk-pill--weak {
+  background: var(--weak-soft);
+  color: var(--weak);
+  border: 1px solid var(--weak);
+}
+
+.wmk-verdict__text {
+  flex: 1 1 auto;
+  font-size: 14px;
+}
+
+/* Tables ---------------------------------------------------------------- */
+
+table.wmk-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+table.wmk-table th,
+table.wmk-table td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+table.wmk-table th {
+  background: var(--bg-soft);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+table.wmk-table td.wmk-num {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.wmk-confidence {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.wmk-confidence--high {
+  background: var(--pass-soft);
+  color: var(--pass);
+}
+
+.wmk-confidence--moderate {
+  background: var(--moderate-soft);
+  color: var(--moderate);
+}
+
+.wmk-confidence--weak {
+  background: var(--weak-soft);
+  color: var(--weak);
+}
+
+/* Trust card grid ------------------------------------------------------- */
+
+.wmk-trust-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.wmk-trust-card {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 14px 16px;
+  background: var(--bg);
+}
+
+.wmk-trust-card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+  gap: 8px;
+}
+
+.wmk-trust-card__name {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.wmk-trust-card__pill {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.wmk-trust-card__explanation {
+  font-size: 13px;
+  color: var(--ink);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.wmk-trust-card__decision {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--line);
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
+}
+
+/* Charts ---------------------------------------------------------------- */
+
+.wmk-chart {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 8px 0 4px 0;
+}
+
+.wmk-chart-caption {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0 0 8px 0;
+}
+
+/* Footer ---------------------------------------------------------------- */
+
+footer.wmk-footer {
+  margin-top: 48px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  font-size: 11px;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: space-between;
+}
+
+footer.wmk-footer code {
+  font-size: 11px;
+}
+
+@media print {
+  body {
+    background: white;
+  }
+  main {
+    box-shadow: none;
+    max-width: none;
+    padding: 0;
+  }
+}

--- a/src/wanamaker/reports/templates/showcase.html.j2
+++ b/src/wanamaker/reports/templates/showcase.html.j2
@@ -1,0 +1,233 @@
+{# HTML showcase template (FR-5.3 / FR-5.4 in HTML form).
+
+   Voice: same dry, direct, honest tone as the Markdown report. The
+   showcase exists so a reader can forward a single self-contained file
+   ("show your CMO") and have it render identically in any modern
+   browser, Outlook preview, or print.
+
+   Required context keys (built by build_showcase_context):
+     - title, run_id, generated_at, runtime_mode, package_version,
+       data_hash, run_fingerprint, engine_label
+     - period_start, period_end, n_periods
+     - total_media_contribution
+     - channels: list of channel views (already ranked, with confidence)
+     - trust_card_pill: {status, label, explanation}
+     - trust_dimensions: list of {name, status, explanation, decision_note}
+     - has_invariant_channels
+     - contribution_chart_svg, roi_chart_svg, scenario_chart_svg
+     - scenario: optional {plan_name, mean_total, hdi_low_total,
+                          hdi_high_total, baseline_total, delta,
+                          extrapolation_warnings}
+     - refresh_narrative: optional {previous_run_id, n_movements,
+                                    n_unexplained, unexplained_fraction,
+                                    movements_by_class}
+#}<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>{{ title }}</title>
+<style>
+{{ stylesheet | safe }}
+</style>
+</head>
+<body>
+<main>
+
+<header class="wmk-header">
+  <div>
+    <h1>{{ title }}</h1>
+    <div class="wmk-meta-line">
+      Period <strong>{{ period_start }}</strong> – <strong>{{ period_end }}</strong>
+      ({{ n_periods }} periods)
+    </div>
+  </div>
+  <div class="wmk-meta">
+    <div>Run <code>{{ run_id }}</code></div>
+    <div>Generated {{ generated_at }}</div>
+    <div>{{ runtime_mode }} mode · wanamaker {{ package_version }}</div>
+  </div>
+</header>
+
+<section id="verdict" class="wmk-verdict-section">
+  <div class="wmk-verdict">
+    <span class="wmk-verdict__pill wmk-pill--{{ trust_card_pill.status }}">
+      {{ trust_card_pill.label }}
+    </span>
+    <div class="wmk-verdict__text">{{ trust_card_pill.explanation }}</div>
+  </div>
+</section>
+
+<section id="executive-summary">
+  <h2>Executive summary</h2>
+  {% if channels %}
+  {% set top = channels[0] %}
+  <p class="wmk-prose">
+    Across this period, paid media contributed an estimated
+    <strong>{{ "{:,.0f}".format(total_media_contribution) }}</strong>
+    to the target.
+    {% if top.confidence == "high" %}
+    <code>{{ top.name }}</code> was the largest contributor at
+    <strong>{{ "{:,.0f}".format(top.contribution_mean) }}</strong>
+    ({{ "{:.0%}".format(top.share_of_effect) }} of media impact),
+    with a 95% credible interval of
+    {{ "{:,.0f}".format(top.contribution_hdi_low) }}–{{ "{:,.0f}".format(top.contribution_hdi_high) }}.
+    {% elif top.confidence == "moderate" %}
+    The model's best point estimate is that <code>{{ top.name }}</code> was
+    the largest contributor at
+    {{ "{:,.0f}".format(top.contribution_mean) }}
+    ({{ "{:.0%}".format(top.share_of_effect) }} of media impact),
+    with a wide 95% credible interval of
+    {{ "{:,.0f}".format(top.contribution_hdi_low) }}–{{ "{:,.0f}".format(top.contribution_hdi_high) }}.
+    The ranking is plausible but not tight.
+    {% else %}
+    The largest point estimate is <code>{{ top.name }}</code> at
+    {{ "{:,.0f}".format(top.contribution_mean) }}, but the data does not
+    strongly support that ranking — its 95% credible interval is
+    {{ "{:,.0f}".format(top.contribution_hdi_low) }}–{{ "{:,.0f}".format(top.contribution_hdi_high) }}.
+    Treat the ordering as suggestive, not decided.
+    {% endif %}
+  </p>
+  {% else %}
+  <p class="wmk-prose">No channel contributions were available for this run.</p>
+  {% endif %}
+</section>
+
+<section id="channel-contributions">
+  <h2>Channel contributions</h2>
+  <p class="wmk-chart-caption">
+    Bars show mean contribution; whiskers show the 95% credible interval.
+    Hatched bars are spend-invariant — saturation could not be estimated
+    from the observed data.
+  </p>
+  {{ contribution_chart_svg | safe }}
+
+  <table class="wmk-table">
+    <thead>
+      <tr>
+        <th>Channel</th>
+        <th class="wmk-num">Contribution</th>
+        <th class="wmk-num">95% credible interval</th>
+        <th class="wmk-num">Share of media</th>
+        <th>Confidence</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for channel in channels %}
+      <tr>
+        <td><code>{{ channel.name }}</code></td>
+        <td class="wmk-num">{{ "{:,.0f}".format(channel.contribution_mean) }}</td>
+        <td class="wmk-num">
+          {{ "{:,.0f}".format(channel.contribution_hdi_low) }}–{{ "{:,.0f}".format(channel.contribution_hdi_high) }}
+        </td>
+        <td class="wmk-num">{{ "{:.0%}".format(channel.share_of_effect) }}</td>
+        <td>
+          <span class="wmk-confidence wmk-confidence--{{ channel.confidence }}">
+            {{ channel.confidence }}
+          </span>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+<section id="channel-roi">
+  <h2>Return on investment</h2>
+  <p class="wmk-chart-caption">
+    Dots show mean ROI; bars show the 95% credible interval. Spend-invariant
+    channels are listed without a defensible ROI.
+  </p>
+  {{ roi_chart_svg | safe }}
+</section>
+
+{% if scenario %}
+<section id="scenario">
+  <h2>Forecast: {{ scenario.plan_name }}</h2>
+  <p class="wmk-prose">
+    Predicted total over the plan window:
+    <strong>{{ "{:,.0f}".format(scenario.mean_total) }}</strong>
+    (95% credible interval
+    {{ "{:,.0f}".format(scenario.hdi_low_total) }}–{{ "{:,.0f}".format(scenario.hdi_high_total) }}).
+    {% if scenario.baseline_total is not none %}
+    That is a change of <strong>{{ "{:+,.0f}".format(scenario.delta) }}</strong>
+    versus the baseline plan.
+    {% endif %}
+  </p>
+  {{ scenario_chart_svg | safe }}
+  {% if scenario.extrapolation_warnings %}
+  <p class="wmk-prose">
+    <strong>Extrapolation warning:</strong> the following channels exceed the
+    spend range observed during training and the model has no direct
+    evidence at those levels —
+    {% for w in scenario.extrapolation_warnings %}<code>{{ w }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
+    Treat as a staged-test candidate, not as proof the move is safe.
+  </p>
+  {% endif %}
+</section>
+{% endif %}
+
+<section id="trust-card">
+  <h2>Model Trust Card</h2>
+  <p class="wmk-prose">
+    The Trust Card flags failure modes Wanamaker can detect from the fit
+    itself. A weak dimension does not always mean the whole model is
+    useless — it means the affected output needs caution.
+  </p>
+  <div class="wmk-trust-grid">
+    {% for d in trust_dimensions %}
+    <div class="wmk-trust-card">
+      <div class="wmk-trust-card__head">
+        <span class="wmk-trust-card__name">{{ d.name }}</span>
+        <span class="wmk-trust-card__pill wmk-pill--{{ d.status }}">{{ d.status }}</span>
+      </div>
+      <p class="wmk-trust-card__explanation">{{ d.explanation }}</p>
+      {% if d.decision_note %}
+      <p class="wmk-trust-card__decision">{{ d.decision_note }}</p>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% if has_invariant_channels %}
+  <p class="wmk-prose" style="margin-top: 16px;">
+    Saturation cannot be estimated from observed data for channels marked
+    spend-invariant in the contribution table. The Experiment Advisor will
+    not recommend reallocations involving those channels (FR-3.2).
+  </p>
+  {% endif %}
+</section>
+
+{% if refresh_narrative %}
+<section id="refresh-diff">
+  <h2>Refresh notes</h2>
+  <p class="wmk-prose">
+    This run is a refresh of <code>{{ refresh_narrative.previous_run_id }}</code>.
+    Across {{ refresh_narrative.n_movements }} parameter movement(s),
+    <strong>{{ refresh_narrative.n_unexplained }}</strong> were classified as
+    unexplained ({{ "{:.0%}".format(refresh_narrative.unexplained_fraction) }}).
+  </p>
+  {% if refresh_narrative.movements_by_class %}
+  <table class="wmk-table">
+    <thead>
+      <tr><th>Class</th><th class="wmk-num">Movements</th></tr>
+    </thead>
+    <tbody>
+      {% for cls, n in refresh_narrative.movements_by_class.items() %}
+      <tr><td>{{ cls }}</td><td class="wmk-num">{{ n }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+</section>
+{% endif %}
+
+<footer class="wmk-footer">
+  <span>Generated by wanamaker {{ package_version }}</span>
+  <span>Engine: {{ engine_label }}</span>
+  <span>Data hash: <code>{{ data_hash }}</code></span>
+  <span>Fingerprint: <code>{{ run_fingerprint }}</code></span>
+</footer>
+
+</main>
+</body>
+</html>

--- a/tests/unit/test_charts.py
+++ b/tests/unit/test_charts.py
@@ -1,0 +1,183 @@
+"""Tests for the hand-rolled SVG chart helpers used by the HTML showcase.
+
+These charts are pure functions (no global state, no I/O), so the tests
+are correspondingly cheap. We assert structural properties rather than
+pixel-level layout: the right number of bars/dots, well-formed XML,
+deterministic byte output for stable inputs, and the spend-invariant
+visual marker.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from wanamaker.reports._charts import (
+    contribution_bars_svg,
+    roi_dotplot_svg,
+    scenario_delta_svg,
+)
+
+
+def _channel(
+    name: str,
+    *,
+    contribution_mean: float = 5000.0,
+    contribution_hdi_low: float = 4500.0,
+    contribution_hdi_high: float = 5500.0,
+    roi_mean: float = 2.0,
+    roi_hdi_low: float = 1.8,
+    roi_hdi_high: float = 2.2,
+    spend_invariant: bool = False,
+    confidence: str = "high",
+) -> dict:
+    return {
+        "name": name,
+        "contribution_mean": contribution_mean,
+        "contribution_hdi_low": contribution_hdi_low,
+        "contribution_hdi_high": contribution_hdi_high,
+        "roi_mean": roi_mean,
+        "roi_hdi_low": roi_hdi_low,
+        "roi_hdi_high": roi_hdi_high,
+        "spend_invariant": spend_invariant,
+        "confidence": confidence,
+    }
+
+
+def _parse(svg: str) -> ET.Element:
+    """Parse the SVG string and return the root element. Fails on bad XML."""
+    return ET.fromstring(svg)
+
+
+# ---------------------------------------------------------------------------
+# contribution_bars_svg
+# ---------------------------------------------------------------------------
+
+
+def test_contribution_bars_one_rect_per_channel() -> None:
+    channels = [_channel("ch_a"), _channel("ch_b"), _channel("ch_c")]
+    svg = contribution_bars_svg(channels)
+    root = _parse(svg)
+
+    # Bars are <rect> elements inside the chart group (excluding the
+    # one inside the hatch <pattern>).
+    rects = [
+        r
+        for r in root.iter("{http://www.w3.org/2000/svg}rect")
+        if r.attrib.get("fill") != "#7c9bb3"
+    ]
+    assert len(rects) == 3
+
+
+def test_contribution_bars_marks_spend_invariant_with_hatch() -> None:
+    channels = [
+        _channel("ch_a"),
+        _channel("ch_b", spend_invariant=True),
+    ]
+    svg = contribution_bars_svg(channels)
+
+    # The hatch pattern is defined when at least one channel needs it.
+    assert "wmk-hatch-invariant" in svg
+    # And one rect uses url(#wmk-hatch-invariant) as fill.
+    assert 'fill="url(#wmk-hatch-invariant)"' in svg
+
+
+def test_contribution_bars_handles_empty_input() -> None:
+    svg = contribution_bars_svg([])
+    root = _parse(svg)
+
+    assert root.attrib.get("class", "").endswith("wmk-chart--empty")
+
+
+def test_contribution_bars_is_deterministic() -> None:
+    channels = [_channel("ch_a"), _channel("ch_b")]
+    assert contribution_bars_svg(channels) == contribution_bars_svg(channels)
+
+
+# ---------------------------------------------------------------------------
+# roi_dotplot_svg
+# ---------------------------------------------------------------------------
+
+
+def test_roi_dotplot_one_dot_per_measurable_channel() -> None:
+    channels = [
+        _channel("ch_a", confidence="high"),
+        _channel("ch_b", confidence="moderate"),
+        _channel("ch_c", spend_invariant=True),
+    ]
+    svg = roi_dotplot_svg(channels)
+    root = _parse(svg)
+
+    circles = list(root.iter("{http://www.w3.org/2000/svg}circle"))
+    # The spend-invariant channel does not get a dot.
+    assert len(circles) == 2
+
+
+def test_roi_dotplot_invariant_channel_gets_explanatory_text() -> None:
+    channels = [_channel("flat", spend_invariant=True)]
+    svg = roi_dotplot_svg(channels)
+
+    assert "spend invariant" in svg.lower()
+
+
+def test_roi_dotplot_handles_empty_input() -> None:
+    svg = roi_dotplot_svg([])
+    root = _parse(svg)
+
+    assert root.attrib.get("class", "").endswith("wmk-chart--empty")
+
+
+# ---------------------------------------------------------------------------
+# scenario_delta_svg
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_delta_renders_polyline_and_polygon() -> None:
+    svg = scenario_delta_svg(
+        periods=["2026-01-05", "2026-01-12", "2026-01-19"],
+        mean=[1000.0, 1100.0, 1050.0],
+        hdi_low=[900.0, 980.0, 940.0],
+        hdi_high=[1100.0, 1220.0, 1160.0],
+    )
+    root = _parse(svg)
+
+    # Polygon = HDI ribbon; polyline = mean.
+    polygons = list(root.iter("{http://www.w3.org/2000/svg}polygon"))
+    polylines = list(root.iter("{http://www.w3.org/2000/svg}polyline"))
+    assert len(polygons) == 1
+    assert len(polylines) == 1
+
+
+def test_scenario_delta_falls_back_on_mismatched_lengths() -> None:
+    svg = scenario_delta_svg(
+        periods=["2026-01-05"],
+        mean=[100.0, 110.0],
+        hdi_low=[90.0],
+        hdi_high=[110.0],
+    )
+    root = _parse(svg)
+
+    assert root.attrib.get("class", "").endswith("wmk-chart--empty")
+
+
+def test_scenario_delta_handles_single_period() -> None:
+    svg = scenario_delta_svg(
+        periods=["2026-01-05"],
+        mean=[1000.0],
+        hdi_low=[900.0],
+        hdi_high=[1100.0],
+    )
+    # Should still parse; line collapses to a single point but ribbon is valid.
+    _parse(svg)
+
+
+# ---------------------------------------------------------------------------
+# Channel name escaping
+# ---------------------------------------------------------------------------
+
+
+def test_channel_names_are_html_escaped() -> None:
+    channels = [_channel("<script>")]
+    svg = contribution_bars_svg(channels)
+
+    assert "<script>" not in svg
+    assert "&lt;script&gt;" in svg

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -20,6 +20,7 @@ def test_help_lists_public_commands() -> None:
         "diagnose",
         "fit",
         "report",
+        "showcase",
         "run",
         "forecast",
         "compare-scenarios",

--- a/tests/unit/test_showcase.py
+++ b/tests/unit/test_showcase.py
@@ -1,0 +1,421 @@
+"""Tests for the HTML showcase renderer (`build_showcase_context` /
+`render_showcase`).
+
+We assert the structural promises that make the showcase a self-contained
+"show-to-CMO" artifact: a single HTML file with inlined CSS, inlined SVG
+charts, no external resource references, no Jinja leakage, and the
+expected sections present (or absent) given the optional inputs.
+
+The chart helpers are exercised separately in ``test_charts``; here we
+only assert that the SVG appears in the rendered document and that the
+right section turns on/off for optional inputs (scenario forecast,
+refresh diff).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    ConvergenceSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+from wanamaker.forecast.posterior_predictive import (
+    ExtrapolationFlag,
+    ForecastResult,
+)
+from wanamaker.refresh.classify import MovementClass
+from wanamaker.refresh.diff import ParameterMovement, RefreshDiff
+from wanamaker.reports import build_showcase_context, render_showcase
+from wanamaker.trust_card.card import TrustCard, TrustDimension, TrustStatus
+
+
+def _channel(
+    name: str,
+    *,
+    contribution: float = 5000.0,
+    contribution_hdi: tuple[float, float] = (4500.0, 5500.0),
+    roi_mean: float = 2.0,
+    roi_hdi: tuple[float, float] = (1.8, 2.2),
+    spend_invariant: bool = False,
+    spend_min: float = 10.0,
+    spend_max: float = 50.0,
+) -> ChannelContributionSummary:
+    return ChannelContributionSummary(
+        channel=name,
+        mean_contribution=contribution,
+        hdi_low=contribution_hdi[0],
+        hdi_high=contribution_hdi[1],
+        roi_mean=roi_mean,
+        roi_hdi_low=roi_hdi[0],
+        roi_hdi_high=roi_hdi[1],
+        observed_spend_min=spend_min,
+        observed_spend_max=spend_max,
+        spend_invariant=spend_invariant,
+    )
+
+
+def _summary(
+    *channels: ChannelContributionSummary,
+    periods: list[str] | None = None,
+) -> PosteriorSummary:
+    if periods is None:
+        periods = ["2024-01-01", "2024-01-08", "2024-01-15"]
+    return PosteriorSummary(
+        channel_contributions=list(channels),
+        convergence=ConvergenceSummary(
+            max_r_hat=1.005,
+            min_ess_bulk=500.0,
+            n_divergences=0,
+            n_chains=4,
+            n_draws=1000,
+        ),
+        in_sample_predictive=PredictiveSummary(
+            periods=periods,
+            mean=[100.0] * len(periods),
+            hdi_low=[90.0] * len(periods),
+            hdi_high=[110.0] * len(periods),
+        ),
+    )
+
+
+def _card(*dims: tuple[str, TrustStatus, str]) -> TrustCard:
+    return TrustCard(
+        dimensions=[
+            TrustDimension(name=name, status=status, explanation=expl)
+            for (name, status, expl) in dims
+        ]
+    )
+
+
+def _render(
+    summary: PosteriorSummary,
+    card: TrustCard,
+    **overrides,
+) -> str:
+    defaults = {
+        "title": "Test Showcase",
+        "run_id": "abc123de_20260101T000000Z",
+        "generated_at": datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+        "runtime_mode": "quick",
+        "package_version": "0.1.0",
+        "data_hash": "deadbeefcafef00d1234",
+        "run_fingerprint": "abc123de4567890f",
+        "engine_label": "pymc 5.10.0",
+    }
+    defaults.update(overrides)
+    context = build_showcase_context(summary, card, **defaults)
+    return render_showcase(context)
+
+
+# ---------------------------------------------------------------------------
+# Structural promises
+# ---------------------------------------------------------------------------
+
+
+def test_renders_to_self_contained_html() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card)
+
+    assert html.startswith("<!doctype html>")
+    assert "</html>" in html
+    assert "<style>" in html and "</style>" in html
+    # No external CSS, fonts, or scripts.
+    assert "<link" not in html
+    assert "<script" not in html
+    assert "https://" not in html
+    assert "http://" not in html or "http://www.w3.org/2000/svg" in html
+    # Jinja leakage check — neither delimiter pair should survive rendering.
+    assert "{{" not in html
+    assert "{%" not in html
+
+
+def test_includes_all_required_sections() -> None:
+    summary = _summary(_channel("paid_search"), _channel("paid_social"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card)
+
+    for section_id in (
+        "verdict",
+        "executive-summary",
+        "channel-contributions",
+        "channel-roi",
+        "trust-card",
+    ):
+        assert f'id="{section_id}"' in html, f"missing #{section_id}"
+
+
+def test_omits_scenario_section_when_no_forecast_supplied() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card)
+
+    assert 'id="scenario"' not in html
+
+
+def test_omits_refresh_section_when_no_refresh_diff() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card)
+
+    assert 'id="refresh-diff"' not in html
+
+
+def test_charts_inline_as_svg() -> None:
+    summary = _summary(_channel("paid_search"), _channel("paid_social"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card)
+
+    # Two SVGs minimum (contribution + ROI). Scenario chart only when
+    # --scenario is supplied; tested separately.
+    svg_count = html.count("<svg")
+    assert svg_count >= 2, f"expected >= 2 inline SVGs, got {svg_count}"
+    assert "wmk-chart--contributions" in html
+    assert "wmk-chart--roi" in html
+
+
+# ---------------------------------------------------------------------------
+# Verdict pill
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_pill_pass_when_all_dimensions_pass() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        ("holdout_accuracy", TrustStatus.PASS, "OK."),
+    )
+    html = _render(summary, card)
+
+    assert "wmk-pill--pass" in html
+    assert "Trust Card clean" in html
+
+
+def test_verdict_pill_weak_when_any_dimension_weak() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        (
+            "saturation_identifiability",
+            TrustStatus.WEAK,
+            "Insufficient spend variation.",
+        ),
+    )
+    html = _render(summary, card)
+
+    assert "wmk-pill--weak" in html
+    assert "Use with caution" in html
+
+
+def test_verdict_pill_moderate_when_only_moderates() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        ("holdout_accuracy", TrustStatus.MODERATE, "Mixed."),
+    )
+    html = _render(summary, card)
+
+    assert "wmk-pill--moderate" in html
+    assert "Mixed evidence" in html
+
+
+# ---------------------------------------------------------------------------
+# Spend-invariant rendering
+# ---------------------------------------------------------------------------
+
+
+def test_spend_invariant_channel_marked_in_table_and_chart() -> None:
+    summary = _summary(
+        _channel("paid_search"),
+        _channel("affiliate", spend_invariant=True),
+    )
+    card = _card(
+        (
+            "saturation_identifiability",
+            TrustStatus.WEAK,
+            "Affiliate spend is invariant.",
+        )
+    )
+    html = _render(summary, card)
+
+    # Hatch pattern is defined in the contribution chart for invariant fills.
+    assert "wmk-hatch-invariant" in html
+    # ROI chart shows the explanatory text in place of a dot/HDI line.
+    assert "spend invariant" in html.lower()
+
+
+# ---------------------------------------------------------------------------
+# Optional sections
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_section_appears_when_forecast_supplied() -> None:
+    summary = _summary(
+        _channel("paid_search", spend_min=100.0, spend_max=500.0)
+    )
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    forecast = ForecastResult(
+        periods=["2026-01-05", "2026-01-12", "2026-01-19"],
+        mean=[1000.0, 1100.0, 1050.0],
+        hdi_low=[900.0, 980.0, 940.0],
+        hdi_high=[1100.0, 1220.0, 1160.0],
+        extrapolation_flags=[
+            ExtrapolationFlag(
+                period="2026-01-05",
+                channel="paid_search",
+                planned_spend=900.0,
+                observed_spend_min=100.0,
+                observed_spend_max=500.0,
+                direction="above",
+            )
+        ],
+        spend_invariant_channels=[],
+    )
+    html = _render(
+        summary,
+        card,
+        scenario_forecast=forecast,
+        scenario_plan_name="q1_plan",
+    )
+
+    assert 'id="scenario"' in html
+    assert "wmk-chart--scenario" in html
+    assert "q1_plan" in html
+    assert "Extrapolation warning" in html
+    assert "paid_search" in html
+
+
+def test_refresh_section_appears_when_diff_supplied() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    refresh_diff = RefreshDiff(
+        previous_run_id="prev_run_id_abc",
+        current_run_id="current_run_id_xyz",
+        movements=[
+            ParameterMovement(
+                name="channel.paid_search.roi",
+                previous_mean=2.0,
+                current_mean=2.05,
+                previous_ci=(1.8, 2.2),
+                current_ci=(1.85, 2.25),
+                movement_class=MovementClass.WITHIN_PRIOR_CI,
+            ),
+        ],
+    )
+    html = _render(summary, card, refresh_diff=refresh_diff)
+
+    assert 'id="refresh-diff"' in html
+    assert "prev_run_id_abc" in html
+
+
+# ---------------------------------------------------------------------------
+# Decision notes only on weak dimensions
+# ---------------------------------------------------------------------------
+
+
+def test_decision_note_present_for_weak_dimension_only() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        (
+            "prior_sensitivity",
+            TrustStatus.WEAK,
+            "Posterior moves with priors.",
+        ),
+    )
+    html = _render(summary, card)
+
+    assert "Posterior moves with priors." in html
+    # The decision-note styling is applied at least once (for prior_sensitivity).
+    assert "wmk-trust-card__decision" in html
+
+    # Slice the convergence card by its name landmarks: from
+    # ">convergence<" to the next card opener. The PASS card must not
+    # contain a decision note.
+    convergence_idx = html.find(">convergence<")
+    assert convergence_idx >= 0
+    next_card_idx = html.find(
+        'class="wmk-trust-card"', convergence_idx + 1
+    )
+    assert next_card_idx > convergence_idx
+    convergence_card = html[convergence_idx:next_card_idx]
+    assert "wmk-trust-card__decision" not in convergence_card
+
+
+# ---------------------------------------------------------------------------
+# Title and short ID handling
+# ---------------------------------------------------------------------------
+
+
+def test_title_appears_in_h1_and_html_title() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card, title="Q4 2026 plan")
+
+    assert "<title>Q4 2026 plan</title>" in html
+    assert "<h1>Q4 2026 plan</h1>" in html
+
+
+def test_data_hash_truncated_to_16_chars_in_footer() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    full_hash = "0123456789abcdef0123456789abcdef"
+    html = _render(summary, card, data_hash=full_hash)
+
+    # The full hash should not appear in the footer; only its first 16 chars.
+    assert full_hash not in html
+    assert "0123456789abcdef" in html
+
+
+# ---------------------------------------------------------------------------
+# Empty-state safety
+# ---------------------------------------------------------------------------
+
+
+def test_renders_without_channels() -> None:
+    summary = PosteriorSummary(
+        channel_contributions=[],
+        convergence=None,
+        in_sample_predictive=PredictiveSummary(
+            periods=["2024-01-01"],
+            mean=[0.0],
+            hdi_low=[0.0],
+            hdi_high=[0.0],
+        ),
+    )
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card)
+
+    assert "No channel contributions were available" in html
+    # The empty-chart fallback should appear in place of bars/dots.
+    assert "wmk-chart--empty" in html
+
+
+def test_renders_without_trust_dimensions() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = TrustCard(dimensions=[])
+    html = _render(summary, card)
+
+    assert 'id="trust-card"' in html
+    # Verdict pill falls back to "No verdict".
+    assert "No verdict" in html or "No Trust Card dimensions" in html
+
+
+# ---------------------------------------------------------------------------
+# HTML escaping safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("malicious", ["<script>x()</script>", "</style>", "&"])
+def test_title_is_html_escaped(malicious: str) -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card, title=malicious)
+
+    # Raw script tags should not survive into the output.
+    assert "<script>x()</script>" not in html


### PR DESCRIPTION
## Summary

- Adds `wanamaker showcase --run-id <id>` that emits a single self-contained HTML file bundling the executive summary, channel contribution chart with HDI whiskers, ROI table, Trust Card, and an optional scenario forecast.
- One file, ~20 KB on the public benchmark — email-attachable, no CDN, no JS, no external fonts. Charts are hand-rolled SVG to keep the output deterministic byte-for-byte across platforms.
- `wanamaker run --example public_benchmark` now auto-renders the showcase alongside the Markdown report so a single command produces both the analyst-facing and stakeholder-facing artifacts.

## What's in the showcase

- **Verdict band** — green/amber/red Trust Card pill + one-sentence headline
- **Executive summary** — same prose as the Markdown report, HTML-rendered with confidence-aware language
- **Channel contributions** — horizontal bars + 95% HDI whiskers; spend-invariant channels visually hatched
- **ROI** — per-channel mean dot + 95% HDI line, color-coded by confidence (high/moderate/weak)
- **Trust Card** — six dimensions as cards with status pills; weak dimensions get a one-line "what this means for decisions" note
- **Scenario** *(optional, when `--scenario plan.csv` is passed)* — predicted outcome line + HDI ribbon, baseline-vs-plan delta, extrapolation flags
- **Refresh diff** *(optional, when refresh artifact is present)* — movement counts bucketed by class

## Design choices

- **Hand-rolled SVG vs. matplotlib/Plotly:** Hand-rolled SVG keeps charts deterministic (no font fallback variance, no PDF/Agg backend) and tiny (~10–50 KB per chart). Aligns with the project's deterministic-template ethos. matplotlib is still available later if richer charts are needed.
- **Jinja2 autoescape:** The shared environment now uses a small predicate that autoescapes `.html.j2` templates while leaving `.md.j2` Markdown templates alone. The previous `select_autoescape(["html"])` config didn't catch double-suffix names.
- **Constraint respected:** No LLM calls (AGENTS.md Hard Rule 2) — every word is rendered from a Jinja2 template.

## Validation

- 30 new unit tests across `test_charts.py` and `test_showcase.py` covering chart structure, section presence, optional-section toggling, HTML escaping, verdict pill logic, Jinja-leakage guards, and empty-state safety.
- Full unit suite: 597 passed (was 567 + 30 new).
- Lint clean on all changed files (`ruff check`).
- Smoke test: `build_showcase_context` + `render_showcase` against synthetic posterior produces a 19,778-byte HTML file with 2 inline SVGs, no `<script>`, no `<link>`.

## Test plan

- [ ] `wanamaker run --example public_benchmark` produces both `report.md` and `showcase.html`
- [ ] `wanamaker showcase --run-id <id>` on an existing run produces the file at `<run_dir>/showcase.html`
- [ ] `wanamaker showcase --run-id <id> --scenario plan.csv` includes the scenario section
- [ ] Open the file in Chrome, Firefox, and (if convenient) an email client preview to confirm it renders standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)