### PR TITLE
Add Colab quickstart notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,16 @@ wanamaker run --example public_benchmark
 That's the whole thing. The command runs the readiness diagnostic, fits a
 quick-mode Bayesian model on the bundled `public_benchmark` dataset, and
 prints the executive summary plus the Model Trust Card. The full report
-is also written to `.wanamaker/runs/<run_id>/report.md`. Expect a few
+is also written to `.wanamaker/runs/<run_id>/report.md`, and an HTML
+showcase suitable for emailing is rendered alongside it. Expect a few
 minutes on a modern laptop.
+
+## Try it without installing
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mbagalman/wanamaker/blob/master/notebooks/quickstart.ipynb)
+
+The same flow runs end-to-end in [a hosted Colab notebook](notebooks/quickstart.ipynb)
+— useful for evaluators who don't want to install PyMC locally first.
 
 ## Reading order
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,6 +7,14 @@ The goal is to go from installation to a first Markdown report. The report is
 not a final business recommendation by itself. It is the starting point for
 reading channel estimates, uncertainty, and the Trust Card.
 
+## Browser version (no install)
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mbagalman/wanamaker/blob/master/notebooks/quickstart.ipynb)
+
+The [Colab notebook](https://github.com/mbagalman/wanamaker/blob/master/notebooks/quickstart.ipynb)
+runs the same flow end-to-end in a hosted Python kernel. It is the fastest way
+to evaluate Wanamaker without a local PyMC install.
+
 ## The 30-second version
 
 If you just want to see Wanamaker run end-to-end on the public example:

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Wanamaker Quickstart\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mbagalman/wanamaker/blob/master/notebooks/quickstart.ipynb)\n",
+    "\n",
+    "This notebook runs Wanamaker end-to-end on the bundled `public_benchmark`\n",
+    "dataset \u2014 diagnose, fit, executive summary, Trust Card, and the HTML showcase\n",
+    "report \u2014 without leaving the browser.\n",
+    "\n",
+    "**Time:** about 10 minutes including the ~3-minute model fit.\n",
+    "\n",
+    "**Requirements:** Python 3.11+. Colab's standard runtime works.\n",
+    "\n",
+    "Wanamaker makes no network calls during analysis. Installation is the only\n",
+    "step that hits the network."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 \u2014 Install Wanamaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q git+https://github.com/mbagalman/wanamaker.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On Colab you may need to restart the runtime after installation so PyMC's\n",
+    "compiled extensions are picked up (`Runtime \u2192 Restart runtime`). The next\n",
+    "cell verifies the install."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import wanamaker\n",
+    "\n",
+    "print(f\"wanamaker {wanamaker.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 \u2014 Look at the example data\n",
+    "\n",
+    "Wanamaker ships with `public_benchmark`, a synthetic weekly dataset with eight\n",
+    "media channels and four controls. It is safe to inspect publicly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib.resources as resources\n",
+    "import pandas as pd\n",
+    "\n",
+    "example_root = resources.files(\"wanamaker._examples.public_benchmark\")\n",
+    "csv_path = example_root.joinpath(\"public_example.csv\")\n",
+    "df = pd.read_csv(csv_path)\n",
+    "print(f\"{len(df)} rows \u00d7 {len(df.columns)} columns\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 \u2014 Run the end-to-end demo\n",
+    "\n",
+    "This chains the readiness diagnostic, a quick-mode fit, the Markdown report,\n",
+    "and the HTML showcase. On Colab's CPU runtime expect 3\u20135 minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wanamaker run --example public_benchmark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 \u2014 View the showcase\n",
+    "\n",
+    "The `run` command auto-renders an HTML showcase \u2014 a single self-contained file\n",
+    "you can email or print. It includes the executive summary, channel contributions\n",
+    "with 95% credible intervals, ROI, and the Trust Card."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from IPython.display import HTML, display\n",
+    "\n",
+    "_runs_dir = Path(\".wanamaker/runs\")\n",
+    "_latest_run = max(_runs_dir.iterdir(), key=lambda p: p.stat().st_mtime)\n",
+    "_showcase_path = _latest_run / \"showcase.html\"\n",
+    "print(f\"Showcase: {_showcase_path}\")\n",
+    "display(HTML(_showcase_path.read_text(encoding=\"utf-8\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5 \u2014 Read the Markdown report\n",
+    "\n",
+    "The same content also lives at `.wanamaker/runs/<run_id>/report.md` \u2014 better\n",
+    "suited for git, code review, or pasting into Slack."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown\n",
+    "\n",
+    "_report_path = _latest_run / \"report.md\"\n",
+    "display(Markdown(_report_path.read_text(encoding=\"utf-8\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6 \u2014 Bring your own data\n",
+    "\n",
+    "To run Wanamaker against your own dataset:\n",
+    "\n",
+    "1. Upload a weekly CSV via Colab's **Files \u2192 Upload to session storage**.\n",
+    "2. Write a YAML config naming your date column, target column, media spend\n",
+    "   columns, and any controls. See\n",
+    "   [`benchmark_data/public_example.yaml`](https://github.com/mbagalman/wanamaker/blob/master/benchmark_data/public_example.yaml)\n",
+    "   for the schema.\n",
+    "3. Run:\n",
+    "\n",
+    "   ```python\n",
+    "   !wanamaker diagnose your_data.csv --config your_config.yaml\n",
+    "   !wanamaker fit --config your_config.yaml\n",
+    "   !wanamaker showcase --run-id <run_id_printed_by_fit>\n",
+    "   ```\n",
+    "\n",
+    "Treat sensitive spend data carefully on Colab. Wanamaker itself makes no\n",
+    "outbound network calls during analysis, but Colab is hosted infrastructure.\n",
+    "Run on your own machine when in doubt \u2014 the same commands work locally."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to read next\n",
+    "\n",
+    "- [Quickstart](https://github.com/mbagalman/wanamaker/blob/master/docs/quickstart.md) \u2014 the same flow on the command line\n",
+    "- [Analyst's Guide](https://github.com/mbagalman/wanamaker/blob/master/docs/analyst_guide.md)\n",
+    "- [Risk-Adjusted Allocation Ramps](https://github.com/mbagalman/wanamaker/blob/master/docs/risk_adjusted_allocation.md) \u2014 design of the `recommend-ramp` command\n",
+    "- [Comparison to Robyn / Meridian / PyMC-Marketing](https://github.com/mbagalman/wanamaker/blob/master/docs/comparison.md)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  },
+  "colab": {
+   "provenance": [],
+   "toc_visible": true,
+   "name": "Wanamaker Quickstart"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/test_quickstart_notebook.py
+++ b/tests/unit/test_quickstart_notebook.py
@@ -1,0 +1,101 @@
+"""Sanity checks for the Colab quickstart notebook.
+
+We don't *execute* the notebook in CI (PyMC fits take minutes; that belongs
+in a smoke job, not unit tests). Instead we validate that the file is
+well-formed JSON in nbformat 4 shape and that the load-bearing cells
+(install, end-to-end command, showcase render) are present and point at
+the right things. Catches accidental corruption from manual edits or
+incompatible regenerations of the notebook source.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+NOTEBOOK_PATH = Path(__file__).resolve().parents[2] / "notebooks" / "quickstart.ipynb"
+
+
+@pytest.fixture(scope="module")
+def notebook() -> dict:
+    assert NOTEBOOK_PATH.exists(), f"notebook missing at {NOTEBOOK_PATH}"
+    return json.loads(NOTEBOOK_PATH.read_text(encoding="utf-8"))
+
+
+def _cell_source(cell: dict) -> str:
+    src = cell["source"]
+    return "".join(src) if isinstance(src, list) else src
+
+
+def test_notebook_is_valid_nbformat_4(notebook: dict) -> None:
+    assert notebook["nbformat"] == 4
+    assert notebook.get("nbformat_minor", 0) >= 0
+    assert isinstance(notebook["cells"], list)
+    assert notebook["cells"], "notebook has no cells"
+
+
+def test_every_cell_has_known_type(notebook: dict) -> None:
+    for cell in notebook["cells"]:
+        assert cell["cell_type"] in {"markdown", "code", "raw"}
+        assert "source" in cell
+        if cell["cell_type"] == "code":
+            assert cell.get("execution_count", None) is None, (
+                "committed code cells must have execution_count=null so the "
+                "notebook is not bloated with stale outputs"
+            )
+            assert cell.get("outputs", []) == [], (
+                "committed code cells must have outputs cleared"
+            )
+
+
+def test_install_cell_uses_canonical_pip_target(notebook: dict) -> None:
+    """The install cell must use ``%pip install`` (works in Colab and Jupyter)
+    and point at the canonical git source — not a fork."""
+    sources = [_cell_source(c) for c in notebook["cells"] if c["cell_type"] == "code"]
+    install_cells = [s for s in sources if "pip install" in s]
+    assert install_cells, "no pip install cell found"
+    install = install_cells[0]
+    assert install.startswith("%pip install"), (
+        "use the %pip magic so the install lands in the current kernel"
+    )
+    assert "git+https://github.com/mbagalman/wanamaker.git" in install
+
+
+def test_end_to_end_command_is_invoked(notebook: dict) -> None:
+    sources = [_cell_source(c) for c in notebook["cells"]]
+    assert any(
+        "wanamaker run --example public_benchmark" in s for s in sources
+    ), "the notebook must run the canonical end-to-end demo"
+
+
+def test_renders_showcase_inline(notebook: dict) -> None:
+    sources = [_cell_source(c) for c in notebook["cells"] if c["cell_type"] == "code"]
+    text = "\n".join(sources)
+    assert "showcase.html" in text
+    assert "IPython.display" in text and "HTML" in text
+
+
+def test_renders_report_markdown_inline(notebook: dict) -> None:
+    sources = [_cell_source(c) for c in notebook["cells"] if c["cell_type"] == "code"]
+    text = "\n".join(sources)
+    assert "report.md" in text
+    assert "Markdown" in text
+
+
+def test_opens_with_colab_badge(notebook: dict) -> None:
+    """Colab uses the first markdown cell as the title page; we also rely on
+    it for the badge link."""
+    first_cell = notebook["cells"][0]
+    assert first_cell["cell_type"] == "markdown"
+    src = _cell_source(first_cell)
+    assert "Open In Colab" in src
+    assert "colab.research.google.com/github/mbagalman/wanamaker" in src
+
+
+def test_no_secrets_or_credentials_committed(notebook: dict) -> None:
+    """Quick paranoia check — the notebook should never reference auth tokens."""
+    text = json.dumps(notebook)
+    for forbidden in ("api_key", "API_KEY", "Bearer ", "secret_key"):
+        assert forbidden not in text, f"unexpected token-shaped string: {forbidden!r}"


### PR DESCRIPTION
## Summary

Adds [`notebooks/quickstart.ipynb`](notebooks/quickstart.ipynb) — a hosted-runtime version of the quickstart that runs the canonical `diagnose → fit → report → showcase` flow on the bundled `public_benchmark` dataset. Removes the local-PyMC install barrier for evaluators: the entire end-to-end demo runs in the browser, with the showcase HTML rendered inline via `IPython.display.HTML`.

Added "Open In Colab" badges in the README and the Markdown quickstart so the no-install path is discoverable.

## Notebook structure (15 cells)

1. Header with the Colab badge
2. `%pip install -q git+https://github.com/mbagalman/wanamaker.git`
3. Verify install + version
4. Inspect bundled CSV with pandas
5. `!wanamaker run --example public_benchmark` — chains the whole pipeline
6. Render `showcase.html` inline
7. Render `report.md` inline
8. Bring-your-own-data instructions (with a privacy note about Colab being hosted)
9. Links to docs

## Validation

- Added [`tests/unit/test_quickstart_notebook.py`](tests/unit/test_quickstart_notebook.py) — 8 tests that validate nbformat structure, that the install cell uses `%pip` and points at the canonical git source, that the showcase + report cells exist, and that the Colab badge is present. We don't *execute* the notebook in CI (PyMC fits take minutes; that belongs in a smoke job, not unit tests).
- Full unit suite: 575 passed (was 567 + 8 new).
- Lint clean.

## Notes

- Depends on PR #72 (HTML showcase) for the `showcase.html` cell to do anything useful. The notebook will still run if #72 is not yet merged — it just won't find a showcase file. Worth merging #72 first.
- Install pulls from `master`. Once we tag a release we can pin: `git+https://github.com/mbagalman/wanamaker.git@v0.1.0`.

## Test plan

- [ ] Open the notebook on Colab via the README badge link
- [ ] Run all cells start-to-finish on a fresh Colab runtime
- [ ] Confirm the showcase renders inline (will require PR #72 to be merged or to bump the install URL to that branch)
- [ ] Confirm the Markdown report renders inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)