### PR TITLE
Add one-page comparison matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,42 @@ minutes on a modern laptop.
 The same flow runs end-to-end in [a hosted Colab notebook](notebooks/quickstart.ipynb)
 — useful for evaluators who don't want to install PyMC locally first.
 
+## How Wanamaker compares to other MMM tools
+
+Wanamaker is built around the *workflow* gaps the other open-source MMM
+tools leave to the user — readiness checks, credibility audit, refresh
+accountability, decision-grade reports. The math layer is intentionally
+the same proven Bayesian foundation everyone else uses.
+
+|                                              | [Robyn](https://github.com/facebookexperimental/Robyn) | [Meridian](https://github.com/google/meridian) | [PyMC-Marketing](https://github.com/pymc-labs/pymc-marketing) | **Wanamaker** |
+| -------------------------------------------- | :----------------------------------------------------: | :--------------------------------------------: | :-----------------------------------------------------------: | :-----------: |
+| Full posterior distributions                 |                           –                            |                       ✓                        |                               ✓                               |     **✓**     |
+| Pre-fit data readiness diagnostic            |                           –                            |                       –                        |                               –                               |     **✓**     |
+| Post-fit Trust Card (credibility audit)      |                           –                            |                       –                        |                               –                               |     **✓**     |
+| Refresh diff with movement classification    |                           –                            |                       –                        |                               –                               |     **✓**     |
+| Risk-adjusted allocation ramp                |                           –                            |                       –                        |                               –                               |     **✓**     |
+| Plain-English executive summary              |                        partial                         |                       –                        |                               –                               |     **✓**     |
+| Self-contained HTML stakeholder report       |                           –                            |                       –                        |                               –                               |     **✓**     |
+| Lift-test calibration                        |                           ✓                            |                       ✓                        |                               ✓                               |       ✓       |
+| Geo-level hierarchical modeling              |                        partial                         |                       ✓                        |                            possible                           |    – (v1)     |
+| Built-in budget optimizer                    |                       ✓ (mature)                       |                    partial                     |                               –                               |    – (v1)     |
+| CPU-only at typical mid-market scale         |                           ✓                            |                  GPU advised                   |                               ✓                               |       ✓       |
+
+**Where Wanamaker pulls ahead** is the operational layer above the math —
+the work it takes to turn a fitted Bayesian model into a recurring decision
+cadence. **Where Wanamaker lags** is intentional v1 scope: no geo-hierarchy,
+no built-in budget optimizer.
+
+If you have geo-level data, a JAX-comfortable team, or 50+ channels, Meridian
+will fit better. If your team lives in R and budget allocation is the primary
+output, Robyn will fit better. If you want maximum modeling flexibility and
+have senior Bayesian practitioners on staff, PyMC-Marketing will fit better.
+If you can budget $80–120K/year for a managed service,
+[Recast](https://getrecast.com) is the obvious commercial comparison.
+
+Full long-form comparison with honest tradeoffs:
+[`docs/comparison.md`](docs/comparison.md).
+
 ## Reading order
 
 1. [BRD/PRD](docs/wanamaker_brd_prd.md) — strategic and product context

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -262,6 +262,8 @@ purpose-built tool like Wanamaker does not support.
 | **Refresh diff + accountability** | No | No | Partial | No | Yes |
 | **Trust Card / credibility audit** | No | No | Partial | No | Yes |
 | **Executive summary output** | Partial | No | Yes | No | Yes |
+| **Self-contained HTML stakeholder report** | No | No | Yes (web UI) | No | Yes |
+| **Risk-adjusted allocation ramp** | No | No | Partial | No | Yes |
 | **Lift-test calibration** | Yes | Yes | Yes | Yes | Yes |
 | **Budget optimizer** | Yes (mature) | Partial | Yes | No | No (v1) |
 | **Installation complexity** | Low (R) / Medium (Python) | High (JAX/GPU) | None (SaaS) | Low | Low |


### PR DESCRIPTION
## Summary

Adds a compact, scan-friendly feature matrix to the README showing Wanamaker vs. Robyn, Meridian, and PyMC-Marketing on the workflow-layer capabilities that differentiate v1 — and the gaps Wanamaker intentionally lacks at v1.

The goal is a screenshot-able artifact that establishes positioning at a glance, without forcing evaluators to re-read the long-form `docs/comparison.md`.

## What's in the matrix

11 rows, grouped by story:

**Where Wanamaker pulls ahead (workflow layer above the math):**
- Pre-fit data readiness diagnostic
- Post-fit Trust Card (credibility audit)
- Refresh diff with movement classification
- Risk-adjusted allocation ramp
- Plain-English executive summary
- Self-contained HTML stakeholder report

**Table stakes (math layer):**
- Full posterior distributions
- Lift-test calibration

**Where Wanamaker lags (intentional v1 scope):**
- Geo-level hierarchical modeling
- Built-in budget optimizer
- (CPU-only at typical mid-market scale — comparison row, not a gap)

Followed by a paragraph naming when each alternative is the better fit, and a link to `docs/comparison.md` for the long-form.

## Long-form consistency

Also adds two rows to the existing summary table in `docs/comparison.md` (HTML stakeholder report, risk-adjusted allocation ramp) so the README and the long-form stay aligned. Those features shipped recently (PRs #69, #72) but hadn't been added to the comparison page yet.

## Validation

- `mkdocs build --strict` — passes
- Full unit suite — 605 passed (no Python changes)
- Manual visual review of the rendered Markdown table

## Test plan

- [ ] Eyeball the README on GitHub — Wanamaker column should read as a visible green stripe of checkmarks, with honest gaps below
- [ ] Verify the long-form `docs/comparison.md` summary table now includes both HTML report and ramp rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)