### PR TITLE
Add three scenario-shaped end-to-end examples

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -35,7 +35,7 @@ experiment back as a calibration prior and seeing how the
 recommendations change. Includes a side-by-side ramp comparison between
 the uncalibrated and calibrated runs.
 
-**Commands covered:** `wanamaker fit` (twice), `showcase`,
+**Commands covered:** `wanamaker fit` (twice), `wanamaker showcase`,
 `recommend-ramp`.
 
 ## Suggested order

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,49 @@
+# Worked examples
+
+Three end-to-end walk-throughs covering the workflows Wanamaker is
+designed for. Each runs on the bundled `public_benchmark` dataset, so
+no private data is required to follow along.
+
+The Quickstart shows you what the tool does. These examples show you
+why each piece exists and when you'd use it.
+
+## [DTC reallocates linear TV to CTV](tv_to_ctv.md)
+
+A retailer wants to shift $5K/week from linear TV to CTV. Walks through
+`compare-scenarios` (which plan looks better?) and `recommend-ramp`
+(how much of the move can we defend right now?). Best read after
+finishing the [Quickstart](../quickstart.md).
+
+**Commands covered:** `wanamaker run`, `compare-scenarios`,
+`recommend-ramp`.
+
+## [B2B refresh after a noisy quarter](refresh_after_noisy_quarter.md)
+
+A B2B SaaS company runs MMM quarterly. After a noisy Q4, the historical
+paid-search ROI estimate moved 15% — is this a real shift or sampling
+noise? Walks through the refresh diff and its movement classification
+("expected", "user-induced", "unexplained", etc.) and how to triage
+each class.
+
+**Commands covered:** `wanamaker fit`, `refresh`, `report`.
+
+## [A lift test changes the verdict](lift_test_changes_verdict.md)
+
+A retailer ran a 6-week geo-holdout on paid social and found the lift
+was 12% lower than the MMM was estimating. Walks through feeding the
+experiment back as a calibration prior and seeing how the
+recommendations change. Includes a side-by-side ramp comparison between
+the uncalibrated and calibrated runs.
+
+**Commands covered:** `wanamaker fit` (twice), `showcase`,
+`recommend-ramp`.
+
+## Suggested order
+
+If you're new to MMM workflows: **TV → CTV → Refresh → Lift test**.
+The TV → CTV example is the simplest end-to-end loop; the refresh and
+lift-test examples each add one piece of operational machinery on top.
+
+If you already run MMM elsewhere: jump straight to the
+[refresh example](refresh_after_noisy_quarter.md) — that's the workflow
+that distinguishes Wanamaker from Robyn / PyMC-Marketing.

--- a/docs/examples/lift_test_changes_verdict.md
+++ b/docs/examples/lift_test_changes_verdict.md
@@ -1,0 +1,259 @@
+# Example: a lift test changes the verdict
+
+A retailer ran a 6-week geo-holdout test on paid social and got a clean
+result: incremental lift was about 12% lower than the MMM had been
+estimating. The CFO wants to know whether to keep planning around the
+old MMM estimate or revise the budget.
+
+This example shows how to feed a real-world experiment back into
+Wanamaker as a calibration prior, and how the recommendations change
+when the model has to reconcile its history with an actual experiment.
+
+It uses the bundled `public_benchmark` dataset plus a synthetic
+lift-test result. About 10–15 minutes on a laptop in `quick` mode (two
+fits).
+
+## Setup
+
+```bash
+git clone https://github.com/mbagalman/wanamaker.git
+cd wanamaker
+pip install -e ".[dev]"
+mkdir -p tutorial_data
+cp benchmark_data/public_example.csv tutorial_data/data.csv
+cat > tutorial_data/config_uncalibrated.yaml <<'EOF'
+data:
+  csv_path: tutorial_data/data.csv
+  date_column: week
+  target_column: revenue
+  spend_columns:
+    - paid_search
+    - paid_social
+    - linear_tv
+    - ctv
+    - online_video
+    - display
+    - affiliate
+    - email
+  control_columns:
+    - price_index
+    - promo_flag
+    - holiday_flag
+    - macro_index
+
+channels:
+  - name: paid_search
+    category: paid_search
+  - name: paid_social
+    category: paid_social
+  - name: linear_tv
+    category: linear_tv
+  - name: ctv
+    category: ctv
+  - name: online_video
+    category: video
+  - name: display
+    category: display_programmatic
+  - name: affiliate
+    category: affiliate
+  - name: email
+    category: email_crm
+
+run:
+  seed: 20260430
+  runtime_mode: quick
+  artifact_dir: .wanamaker
+EOF
+```
+
+## Step 1 — Fit without calibration
+
+```bash
+wanamaker fit --config tutorial_data/config_uncalibrated.yaml
+RUN_UNCAL=$(ls -t .wanamaker/runs | head -1)
+wanamaker showcase --run-id "$RUN_UNCAL"
+```
+
+Open `.wanamaker/runs/$RUN_UNCAL/showcase.html`. Note the paid-social
+ROI mean and the 95% credible interval. This is the model's view based
+purely on observational history.
+
+The Trust Card panel will show a `lift_test_consistency` dimension as
+**not present** — there is no calibration data to compare against.
+
+## Step 2 — Add the lift-test result
+
+Suppose your geo-holdout produced a 12% lower point estimate than the
+historical model has been showing — say a measured lift of 0.38 with a
+95% CI of 0.30–0.46 (vs. an MMM-implied lift around 0.43). Encode this
+as a one-row CSV:
+
+```bash
+cat > tutorial_data/lift_tests.csv <<'EOF'
+channel,test_start,test_end,lift_estimate,ci_lower,ci_upper
+paid_social,2024-09-01,2024-10-15,0.38,0.30,0.46
+EOF
+```
+
+The required columns are `channel`, `test_start`, `test_end`,
+`lift_estimate`, `ci_lower`, `ci_upper`. The CI bounds are converted
+into a Gaussian prior on the channel's effect; tighter bounds put more
+weight on the experiment.
+
+## Step 3 — Refit with calibration
+
+Write a calibrated config that points at the lift-test CSV. Use the
+same fields as the uncalibrated config plus a `lift_test_csv` entry
+under `data:`:
+
+```bash
+cat > tutorial_data/config_calibrated.yaml <<'EOF'
+data:
+  csv_path: tutorial_data/data.csv
+  date_column: week
+  target_column: revenue
+  lift_test_csv: tutorial_data/lift_tests.csv
+  spend_columns:
+    - paid_search
+    - paid_social
+    - linear_tv
+    - ctv
+    - online_video
+    - display
+    - affiliate
+    - email
+  control_columns:
+    - price_index
+    - promo_flag
+    - holiday_flag
+    - macro_index
+
+channels:
+  - name: paid_search
+    category: paid_search
+  - name: paid_social
+    category: paid_social
+  - name: linear_tv
+    category: linear_tv
+  - name: ctv
+    category: ctv
+  - name: online_video
+    category: video
+  - name: display
+    category: display_programmatic
+  - name: affiliate
+    category: affiliate
+  - name: email
+    category: email_crm
+
+run:
+  seed: 20260430
+  runtime_mode: quick
+  artifact_dir: .wanamaker
+EOF
+
+wanamaker fit --config tutorial_data/config_calibrated.yaml
+RUN_CAL=$(ls -t .wanamaker/runs | head -1)
+wanamaker showcase --run-id "$RUN_CAL"
+```
+
+> **Tip:** Make sure the CSV path in the calibrated config is correct —
+> the easiest mistake here is leaving a relative path that resolves
+> differently from the run directory. Wanamaker validates the file
+> exists at fit time and fails fast if it doesn't.
+
+## Step 4 — Compare the two showcases
+
+Open the two `showcase.html` files side by side. Three things will have
+moved:
+
+1. **Paid-social ROI mean** in the calibrated run will be pulled toward
+   the lift test (lower than the uncalibrated estimate but not all the
+   way down to it — Bayesian updating compromises between history and
+   experiment in proportion to their relative precisions).
+2. **Paid-social ROI credible interval** will be tighter, because the
+   experiment supplied independent information.
+3. **Trust Card** will now show a `lift_test_consistency` dimension. If
+   the calibrated and uncalibrated estimates were close, it shows
+   **pass**. If they disagree more than the joint uncertainty allows,
+   it shows **weak** and explains what the disagreement implies for
+   downstream decisions.
+
+## Step 5 — See whether the verdict changes
+
+If you have a budget plan that increases paid-social spend, run the
+ramp recommendation against both runs:
+
+```bash
+cat > baseline.csv <<'EOF'
+period,paid_search,paid_social,linear_tv,ctv,online_video,display,affiliate,email
+2025-01-06,9700,8500,20800,12100,9700,4700,3300,2500
+2025-01-13,9700,8500,20800,12100,9700,4700,3300,2500
+2025-01-20,9700,8500,20800,12100,9700,4700,3300,2500
+2025-01-27,9700,8500,20800,12100,9700,4700,3300,2500
+EOF
+
+cat > scale_paid_social.csv <<'EOF'
+period,paid_search,paid_social,linear_tv,ctv,online_video,display,affiliate,email
+2025-01-06,9700,12500,20800,12100,9700,4700,3300,2500
+2025-01-13,9700,12500,20800,12100,9700,4700,3300,2500
+2025-01-20,9700,12500,20800,12100,9700,4700,3300,2500
+2025-01-27,9700,12500,20800,12100,9700,4700,3300,2500
+EOF
+
+wanamaker recommend-ramp --run-id "$RUN_UNCAL" \
+    --baseline baseline.csv --target scale_paid_social.csv \
+    --output uncalibrated_ramp.md
+
+wanamaker recommend-ramp --run-id "$RUN_CAL" \
+    --baseline baseline.csv --target scale_paid_social.csv \
+    --output calibrated_ramp.md
+```
+
+Compare `uncalibrated_ramp.md` and `calibrated_ramp.md`. The expected
+behavior:
+
+- **Uncalibrated:** the ramp may suggest a more aggressive fraction
+  because the model thinks paid-social is more productive than the
+  experiment proved.
+- **Calibrated:** the ramp is more conservative — lower fraction, or a
+  `test_first` verdict. The lift-test prior pulled the expected return
+  down, and the math now flags less headroom for the increase.
+
+This is the calibration mechanism doing exactly what it should: an
+expensive real-world experiment overrides historical correlations.
+
+## What this example demonstrates
+
+- Lift tests are **first-class inputs** to Wanamaker, not a separate
+  reconciliation step you run by hand.
+- The `lift_test_consistency` dimension on the Trust Card surfaces
+  disagreement between MMM and experiments before it becomes a budget
+  argument.
+- A lift test can change the **direction** of a recommendation, not
+  just the magnitude. The calibrated run is the one to act on; the
+  uncalibrated run was the best the model could do without the
+  experiment.
+
+## Cost-benefit framing
+
+Geo-holdouts are expensive — a 6-week test can mean low-six-figures of
+deferred spend. This example exists because that cost is justified
+when:
+
+- The MMM's credible interval is wide enough that bigger budget moves
+  feel risky, and
+- The channel is large enough that a 10–20% recalibration changes
+  meaningful dollars.
+
+For small, well-identified channels, the test isn't worth running. The
+Experiment Advisor in the showcase suggests which channels are the
+best candidates for a calibration test based on width-of-CI and
+spend-share.
+
+## Next reading
+
+- [DTC reallocates linear TV to CTV](tv_to_ctv.md)
+- [Refresh after a noisy quarter](refresh_after_noisy_quarter.md)
+- [What Wanamaker tells your CMO](../cmo_guide.md) — how to communicate
+  a lift-test-driven plan change to non-technical stakeholders

--- a/docs/examples/refresh_after_noisy_quarter.md
+++ b/docs/examples/refresh_after_noisy_quarter.md
@@ -1,0 +1,179 @@
+# Example: B2B refresh after a noisy quarter
+
+A B2B SaaS company runs MMM quarterly. After Q4 — with a heavy holiday
+promotion calendar and a one-off PR spike — the analyst refreshes the
+model and finds that the historical paid-search ROI estimate has dropped
+about 15%. The CMO wants to know whether to revise last quarter's
+budget plan based on the new estimate.
+
+This is the "refresh nightmare" Robyn users complain about: re-running
+on new data quietly rewrites history, and nobody can tell whether the
+change is a real signal or a sampling artifact. Wanamaker's refresh
+workflow is built specifically to answer that question.
+
+This walk-through uses the bundled `public_benchmark` dataset, split
+into an "initial" window and a "refresh" window. About 8–12 minutes on
+a laptop in `quick` mode.
+
+## Setup
+
+```bash
+git clone https://github.com/mbagalman/wanamaker.git
+cd wanamaker
+pip install -e ".[dev]"
+```
+
+Make a working copy of the example so you can swap the CSV under it
+without modifying the bundled file:
+
+```bash
+mkdir -p tutorial_data
+cp benchmark_data/public_example.csv tutorial_data/data.csv
+cat > tutorial_data/config.yaml <<'EOF'
+data:
+  csv_path: tutorial_data/data.csv
+  date_column: week
+  target_column: revenue
+  spend_columns:
+    - paid_search
+    - paid_social
+    - linear_tv
+    - ctv
+    - online_video
+    - display
+    - affiliate
+    - email
+  control_columns:
+    - price_index
+    - promo_flag
+    - holiday_flag
+    - macro_index
+
+channels:
+  - name: paid_search
+    category: paid_search
+  - name: paid_social
+    category: paid_social
+  - name: linear_tv
+    category: linear_tv
+  - name: ctv
+    category: ctv
+  - name: online_video
+    category: video
+  - name: display
+    category: display_programmatic
+  - name: affiliate
+    category: affiliate
+  - name: email
+    category: email_crm
+
+refresh:
+  anchor_strength: medium
+
+run:
+  seed: 20260430
+  runtime_mode: quick
+  artifact_dir: .wanamaker
+EOF
+```
+
+## Step 1 — Fit on the initial window
+
+Pretend you are at the end of Q3 with 130 weeks of history:
+
+```bash
+head -n 131 benchmark_data/public_example.csv > tutorial_data/data.csv
+wc -l tutorial_data/data.csv  # 131 = 1 header + 130 weeks
+wanamaker fit --config tutorial_data/config.yaml
+```
+
+Note the run ID — call it `RUN_INITIAL`. Open
+`.wanamaker/runs/$RUN_INITIAL/showcase.html` and skim the channel ROI
+table. This is the picture the CMO has from the previous refresh.
+
+## Step 2 — Q4 happens; refresh on the full window
+
+Now extend the data with the remaining 26 weeks (Q4 + early Q1):
+
+```bash
+cp benchmark_data/public_example.csv tutorial_data/data.csv
+wc -l tutorial_data/data.csv  # 157 = 1 header + 156 weeks
+wanamaker refresh --config tutorial_data/config.yaml
+```
+
+This is the key command. It does three things at once:
+
+1. **Fits a new model** on the full 156-week window.
+2. **Anchors lightly to the previous posterior** (default
+   `anchor_strength: medium`) so estimates cannot drift unboundedly on
+   one quarter of new data.
+3. **Writes a refresh diff** comparing the old and new posteriors,
+   classifying every parameter movement.
+
+Note the new run ID — call it `RUN_REFRESH`.
+
+## Step 3 — Read the refresh diff
+
+```bash
+ls -la .wanamaker/runs/$RUN_REFRESH/
+```
+
+You should see `refresh_diff.json` alongside the usual artifacts. The
+plain-English summary lives in `report.md`:
+
+```bash
+wanamaker report --run-id $RUN_REFRESH
+less .wanamaker/runs/$RUN_REFRESH/report.md
+```
+
+Look for the **Refresh notes** section. Each parameter movement is
+classified as one of:
+
+| Class | What it means |
+|---|---|
+| `within_prior_ci` | The new estimate is inside the previous credible interval. The "movement" is sampling noise, not a real shift. |
+| `improved_holdout` | The new estimate moved AND the new model predicts recent weeks better than the old one. The shift is real and supported. |
+| `user_induced` | The user changed something (config, anchor strength, prior). The movement is a deliberate decision, not new data. |
+| `weakly_identified` | The parameter has a wide posterior — small differences between runs aren't meaningful. |
+| `unexplained` | The estimate moved, holdout did not improve, and nothing on the user side changed. **This is the only class that warrants real investigation.** |
+
+## Step 4 — Decide what to do
+
+The refresh diff turns "the number changed" into a structured triage
+question:
+
+- **Mostly `within_prior_ci`?** The model is stable; report this to the
+  CMO as "no material change" and continue with the previous plan.
+- **`improved_holdout` for the channel that moved?** This is a real
+  shift. Update plans accordingly and explain the shift in stakeholder
+  communication.
+- **`unexplained` movements above ~10% of all movements?** Pause
+  recommendations and investigate. Possible causes: a structural break
+  in the data (a competitor exit, a media buy that wasn't logged), a
+  config change you didn't realize you made, or a sampling artifact
+  that needs more chains. Open the previous and current `summary.json`
+  and look at convergence statistics for the affected parameters.
+
+The Trust Card has a `refresh_stability` dimension that summarises this
+automatically — green if mostly explained, weak if the unexplained
+fraction is high.
+
+## What this example demonstrates
+
+- Refresh is **not just re-fit** — it's a structured comparison with a
+  defensible classification of every change.
+- The **unexplained fraction** is the only number that should make you
+  nervous, and it is surfaced explicitly rather than buried in a summary
+  statistic.
+- **Light posterior anchoring** prevents the "refresh nightmare" failure
+  mode where one noisy quarter causes a wholesale re-estimate of
+  everything.
+
+## Next reading
+
+- [DTC reallocates linear TV to CTV](tv_to_ctv.md) — using a stable run
+  to score a proposed budget change
+- [Lift-test calibration changes the verdict](lift_test_changes_verdict.md) —
+  when a real-world experiment contradicts the model
+- [Risk-Adjusted Allocation Ramps](../risk_adjusted_allocation.md) —
+  how the Trust Card and refresh diff feed into ramp gating

--- a/docs/examples/refresh_after_noisy_quarter.md
+++ b/docs/examples/refresh_after_noisy_quarter.md
@@ -85,9 +85,11 @@ Pretend you are at the end of Q3 with 130 weeks of history:
 head -n 131 benchmark_data/public_example.csv > tutorial_data/data.csv
 wc -l tutorial_data/data.csv  # 131 = 1 header + 130 weeks
 wanamaker fit --config tutorial_data/config.yaml
+RUN_INITIAL=$(ls -t .wanamaker/runs | head -1)
+wanamaker showcase --run-id "$RUN_INITIAL"
 ```
 
-Note the run ID — call it `RUN_INITIAL`. Open
+Open
 `.wanamaker/runs/$RUN_INITIAL/showcase.html` and skim the channel ROI
 table. This is the picture the CMO has from the previous refresh.
 
@@ -99,6 +101,7 @@ Now extend the data with the remaining 26 weeks (Q4 + early Q1):
 cp benchmark_data/public_example.csv tutorial_data/data.csv
 wc -l tutorial_data/data.csv  # 157 = 1 header + 156 weeks
 wanamaker refresh --config tutorial_data/config.yaml
+RUN_REFRESH=$(ls -t .wanamaker/runs | head -1)
 ```
 
 This is the key command. It does three things at once:
@@ -110,7 +113,7 @@ This is the key command. It does three things at once:
 3. **Writes a refresh diff** comparing the old and new posteriors,
    classifying every parameter movement.
 
-Note the new run ID — call it `RUN_REFRESH`.
+The new run ID is now stored in `RUN_REFRESH`.
 
 ## Step 3 — Read the refresh diff
 

--- a/docs/examples/tv_to_ctv.md
+++ b/docs/examples/tv_to_ctv.md
@@ -1,0 +1,145 @@
+# Example: a DTC brand reallocates linear TV to CTV
+
+A direct-to-consumer apparel brand has been running roughly $30K/week in
+linear TV and $15K/week in CTV. The CMO wants to shift $5K/week from
+linear TV to CTV to chase younger viewers. The CFO wants to see the
+math before approving the move.
+
+This walk-through uses Wanamaker to:
+
+1. Estimate channel ROIs with credible intervals from history.
+2. Score the proposed move against the current plan.
+3. Decide whether to ramp the move all at once, partially, or test first.
+
+It runs end-to-end on the bundled `public_benchmark` dataset — no
+private data needed. About 5–8 minutes on a laptop in `quick` mode.
+
+## What you need
+
+```bash
+git clone https://github.com/mbagalman/wanamaker.git
+cd wanamaker
+pip install -e ".[dev]"
+```
+
+## Step 1 — Fit the baseline model
+
+```bash
+wanamaker run --example public_benchmark
+```
+
+Note the run ID printed at the end (e.g. `1a2b3c4d_20260501T120000Z`).
+Save it:
+
+```bash
+RUN_ID=$(ls -t .wanamaker/runs | head -1)
+echo "$RUN_ID"
+```
+
+The Markdown report is at `.wanamaker/runs/$RUN_ID/report.md` and the
+HTML showcase at `.wanamaker/runs/$RUN_ID/showcase.html`. Open the
+showcase in a browser before continuing — the channel ROI table is the
+context for everything below.
+
+The dataset is engineered so `linear_tv` has a higher absolute
+contribution but `ctv` has a higher per-dollar ROI. That is exactly the
+shape of the question the CMO is asking, which is why this dataset is
+useful for the example.
+
+## Step 2 — Write the two plans
+
+`baseline.csv` keeps the current mix; `tv_to_ctv.csv` shifts $5K/week
+from linear TV to CTV. Both run for the next eight weeks.
+
+```bash
+cat > baseline.csv <<'EOF'
+period,paid_search,paid_social,linear_tv,ctv,online_video,display,affiliate,email
+2025-01-06,9700,8500,20800,12100,9700,4700,3300,2500
+2025-01-13,9700,8500,20800,12100,9700,4700,3300,2500
+2025-01-20,9700,8500,20800,12100,9700,4700,3300,2500
+2025-01-27,9700,8500,20800,12100,9700,4700,3300,2500
+2025-02-03,9700,8500,20800,12100,9700,4700,3300,2500
+2025-02-10,9700,8500,20800,12100,9700,4700,3300,2500
+2025-02-17,9700,8500,20800,12100,9700,4700,3300,2500
+2025-02-24,9700,8500,20800,12100,9700,4700,3300,2500
+EOF
+
+cat > tv_to_ctv.csv <<'EOF'
+period,paid_search,paid_social,linear_tv,ctv,online_video,display,affiliate,email
+2025-01-06,9700,8500,15800,17100,9700,4700,3300,2500
+2025-01-13,9700,8500,15800,17100,9700,4700,3300,2500
+2025-01-20,9700,8500,15800,17100,9700,4700,3300,2500
+2025-01-27,9700,8500,15800,17100,9700,4700,3300,2500
+2025-02-03,9700,8500,15800,17100,9700,4700,3300,2500
+2025-02-10,9700,8500,15800,17100,9700,4700,3300,2500
+2025-02-17,9700,8500,15800,17100,9700,4700,3300,2500
+2025-02-24,9700,8500,15800,17100,9700,4700,3300,2500
+EOF
+```
+
+The amounts roughly match the dataset's historical observed ranges so
+the model has direct evidence for both plans. Wanamaker will warn when a
+plan exceeds the historical range; the warning still applies even on
+synthetic data.
+
+## Step 3 — Compare the two plans
+
+```bash
+wanamaker compare-scenarios --run-id "$RUN_ID" --plans baseline.csv tv_to_ctv.csv
+```
+
+The output ranks the plans by expected outcome with credible intervals.
+Expect `tv_to_ctv.csv` to come out narrowly ahead on the mean — the
+dataset has CTV's ROI engineered higher than linear TV's. Whether the
+credible intervals overlap is the more important number than the point
+ranking.
+
+## Step 4 — Ask how far to move
+
+`compare-scenarios` says which plan looks better. It does not say how
+much of the way to move toward it. That is the job of `recommend-ramp`:
+
+```bash
+wanamaker recommend-ramp --run-id "$RUN_ID" --baseline baseline.csv --target tv_to_ctv.csv
+```
+
+The output is one of four verdicts:
+
+| Verdict | What it means |
+|---|---|
+| `proceed` | Defensible at 100%. Rare on first runs by design (v1 caps the Kelly multiplier at 0.5). |
+| `stage` | Defensible at 25%–50%. The expected outcome at this fraction. |
+| `test_first` | The move is plausible, but evidence is too thin — design an experiment first. |
+| `do_not_recommend` | Either the math is unfavorable or the Trust Card flags a blocker. |
+
+For this dataset, expect a `stage` verdict — the data supports the
+direction of the move but the credible intervals are wide enough that
+reallocating 100% on the first decision would be reckless. The full
+report at `.wanamaker/runs/$RUN_ID/ramp_baseline_to_tv_to_ctv.md` shows
+the per-fraction gate table: which fractions failed and why
+(extrapolation, Trust Card weakness, expected value, downside risk).
+
+## Step 5 — Read the verdict alongside the showcase
+
+The ramp output is a defensible answer to "how much to shift now". The
+showcase from Step 1 is the answer to "why do we believe it". Open both
+side by side before booking the change in your media plan.
+
+## What this example demonstrates
+
+- **`compare-scenarios`** is descriptive: which plan does the model
+  expect to do better?
+- **`recommend-ramp`** is prescriptive: how much of the move can we
+  defend with the evidence we have right now?
+- The two answers can disagree. A plan can rank first on expected
+  outcome but still be `test_first` because the evidence base is too
+  thin to bet much on it.
+
+## Next reading
+
+- [Risk-Adjusted Allocation Ramps](../risk_adjusted_allocation.md) —
+  the design rationale for the four-status verdict
+- [Refresh after a noisy quarter](refresh_after_noisy_quarter.md) —
+  the next workflow you'll need
+- [Lift-test calibration changes the verdict](lift_test_changes_verdict.md) —
+  what happens when an experiment contradicts the model

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -311,6 +311,8 @@ Trust Card flags a risk. Cautious language is a feature, not a failure.
 
 ## Next Reading
 
+- [Worked Examples](examples/index.md) — three end-to-end walk-throughs:
+  TV→CTV reallocation, refresh after a noisy quarter, lift-test calibration
 - [Analyst's Guide](analyst_guide.md)
 - [What Wanamaker Tells Your CMO](cmo_guide.md)
 - [Risk-Adjusted Allocation Ramps](risk_adjusted_allocation.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,11 @@ nav:
   - Home: index.md
   - Installation: installation.md
   - Quickstart: quickstart.md
+  - Worked Examples:
+      - Overview: examples/index.md
+      - DTC reallocates TV to CTV: examples/tv_to_ctv.md
+      - B2B refresh after a noisy quarter: examples/refresh_after_noisy_quarter.md
+      - A lift test changes the verdict: examples/lift_test_changes_verdict.md
   - Analyst's Guide: analyst_guide.md
   - What Wanamaker Tells Your CMO: cmo_guide.md
   - Privacy and Data Handling: privacy.md


### PR DESCRIPTION
## Summary

Closes the last item on the new-user-friction list (the original four-part scoping). Adds [`docs/examples/`](docs/examples/) with three end-to-end walk-throughs that show *why* each piece of Wanamaker exists, by attaching it to a workflow a real team would actually run.

Each example runs end-to-end on the bundled `public_benchmark` dataset — no private data needed.

## What's in each example

**[tv_to_ctv.md](docs/examples/tv_to_ctv.md) — DTC reallocates linear TV to CTV.** A retailer wants to shift $5K/week from linear TV to CTV. Walks through `compare-scenarios` (which plan looks better?) followed by `recommend-ramp` (how much can we defend right now?). Best read right after the Quickstart.

**[refresh_after_noisy_quarter.md](docs/examples/refresh_after_noisy_quarter.md) — B2B SaaS quarterly refresh.** After a noisy Q4, the historical paid-search ROI moved 15% — is it real or sampling noise? Splits the bundled dataset into a "previous quarter" window (130 weeks) and refreshes with the full window, then walks through the movement-classification diff. This is the exact workflow Robyn users complain about as the "refresh nightmare".

**[lift_test_changes_verdict.md](docs/examples/lift_test_changes_verdict.md) — calibration changes the recommendation.** A retailer ran a 6-week geo-holdout and found paid-social lift was 12% lower than the MMM thought. Walks through feeding the experiment back as a `lift_test_csv` prior, then runs `recommend-ramp` against both the uncalibrated and calibrated runs to show how the verdict changes when an experiment overrides history.

## Engineering choices

- **Configs inline, not via sed.** All YAML configs are written in the example via `cat <<'EOF'` heredocs. The earlier draft used `sed -i.bak` to inject keys; that's brittle across Linux/macOS/Windows shells. The inline version is verbose but portable.
- **Single bundled dataset.** All three examples use the existing `public_benchmark` data. No new synthetic datasets to maintain or version.
- **No new code.** Documentation only — every command in every example uses an existing public CLI surface.

## Validation

- `mkdocs build --strict` — passes (cross-references resolve)
- 605 unit tests still passing (no Python changes)
- Manual review for shell portability and YAML correctness

## Test plan

- [ ] Run each example top-to-bottom on a clean checkout (each takes 5–15 min)
- [ ] Open the rendered docs site and check the new "Worked Examples" nav section
- [ ] Verify the cross-links between examples and into the rest of the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)