### PR TITLE
Add Trust Card one-pager: executive-facing forwarding artifact

### DIFF
--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -6,6 +6,7 @@ Core commands per FR-6.3 plus the HTML showcase:
     wanamaker fit --config <config.yaml>
     wanamaker report --run-id <run_id>
     wanamaker showcase --run-id <run_id>
+    wanamaker trust-card --run-id <run_id>
     wanamaker forecast --run-id <run_id> --plan <plan.csv>
     wanamaker compare-scenarios --run-id <run_id> --plans <p1.csv> <p2.csv> ...
     wanamaker recommend-ramp --run-id <run_id> --baseline <base.csv> --target <alt.csv>
@@ -592,6 +593,123 @@ def showcase(
         webbrowser.open(output_path.resolve().as_uri())
 
 
+@app.command(name="trust-card")
+def trust_card(
+    run_id: str = typer.Option(..., "--run-id"),
+    artifact_dir: Path = typer.Option(
+        Path(".wanamaker"),
+        "--artifact-dir",
+        help="Root of the runs directory (default: .wanamaker).",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        help="Path to save the one-pager HTML. Default: <run_dir>/trust_card.html",
+    ),
+    title: str | None = typer.Option(
+        None,
+        "--title",
+        help=(
+            "Override the one-pager title. "
+            "Default: 'Wanamaker MMM — <run_id short>'."
+        ),
+    ),
+    open_browser: bool = typer.Option(
+        False,
+        "--open",
+        help="Open the rendered one-pager in the default browser when done.",
+    ),
+) -> None:
+    """Render the executive-facing Trust Card one-pager for a completed run.
+
+    The one-pager is a single self-contained HTML file designed for
+    forwarding to non-technical executives. It prints to a single page
+    on US Letter or A4 and uses plain-English translations of each
+    Trust Card dimension instead of the analyst-facing technical text.
+    """
+    import webbrowser
+    from datetime import datetime, timezone
+
+    from wanamaker import __version__
+    from wanamaker.artifacts import (
+        deserialize_refresh_diff,
+        deserialize_summary,
+        load_manifest,
+        run_paths,
+    )
+    from wanamaker.config import load_config
+    from wanamaker.reports import (
+        build_trust_card_one_pager_context,
+        render_trust_card_one_pager,
+    )
+    from wanamaker.trust_card.compute import build_trust_card
+
+    paths = run_paths(artifact_dir, run_id)
+    if not paths.config.exists():
+        typer.echo(
+            typer.style(
+                f"Error: run {run_id!r} not found in {artifact_dir / 'runs'}. "
+                "Run 'wanamaker fit' first or check --artifact-dir.",
+                fg=typer.colors.RED,
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if not paths.summary.exists():
+        typer.echo(
+            typer.style(
+                f"Error: summary.json missing for run {run_id!r} at {paths.summary}.",
+                fg=typer.colors.RED,
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    summary = deserialize_summary(paths.summary.read_text())
+
+    refresh_diff = None
+    if paths.refresh_diff.exists():
+        refresh_diff = deserialize_refresh_diff(paths.refresh_diff.read_text())
+
+    cfg = load_config(paths.config)
+    lift_test_priors = _load_lift_priors_if_any(cfg)
+
+    card = build_trust_card(
+        summary,
+        refresh_diff=refresh_diff,
+        lift_test_priors=lift_test_priors,
+    )
+
+    run_fingerprint = ""
+    if paths.manifest.exists():
+        try:
+            manifest = load_manifest(paths.manifest.read_text())
+            run_fingerprint = str(manifest.get("run_fingerprint", ""))
+        except ValueError:
+            run_fingerprint = ""
+
+    context = build_trust_card_one_pager_context(
+        summary,
+        card,
+        title=title or f"Wanamaker MMM — {run_id[:8]}",
+        run_id=run_id,
+        generated_at=datetime.now(timezone.utc),
+        package_version=__version__,
+        run_fingerprint=run_fingerprint,
+    )
+
+    html = render_trust_card_one_pager(context)
+
+    output_path = output if output is not None else paths.root / "trust_card.html"
+    output_path.write_text(html, encoding="utf-8")
+    typer.echo(
+        typer.style(f"Trust Card one-pager saved: {output_path}", fg=typer.colors.GREEN)
+    )
+
+    if open_browser:
+        webbrowser.open(output_path.resolve().as_uri())
+
+
 _RUN_EXAMPLES: tuple[str, ...] = ("public_benchmark",)
 
 
@@ -707,6 +825,13 @@ def run(
         output=None,
         title=None,
         scenario=None,
+        open_browser=False,
+    )
+    trust_card(
+        run_id=run_id,
+        artifact_dir=artifact_dir,
+        output=None,
+        title=None,
         open_browser=False,
     )
     typer.echo("")

--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -628,7 +628,6 @@ def trust_card(
     Trust Card dimension instead of the analyst-facing technical text.
     """
     import webbrowser
-    from datetime import datetime, timezone
 
     from wanamaker import __version__
     from wanamaker.artifacts import (
@@ -693,7 +692,7 @@ def trust_card(
         card,
         title=title or f"Wanamaker MMM — {run_id[:8]}",
         run_id=run_id,
-        generated_at=datetime.now(timezone.utc),
+        generated_at=datetime.now(UTC),
         package_version=__version__,
         run_fingerprint=run_fingerprint,
     )

--- a/src/wanamaker/reports/__init__.py
+++ b/src/wanamaker/reports/__init__.py
@@ -20,14 +20,20 @@ from wanamaker.reports.render import (
     render_trust_card,
 )
 from wanamaker.reports.showcase import build_showcase_context, render_showcase
+from wanamaker.reports.trust_card_one_pager import (
+    build_trust_card_one_pager_context,
+    render_trust_card_one_pager,
+)
 
 __all__ = [
     "build_executive_summary_context",
     "build_ramp_recommendation_context",
     "build_showcase_context",
     "build_trust_card_context",
+    "build_trust_card_one_pager_context",
     "render_executive_summary",
     "render_ramp_recommendation",
     "render_showcase",
     "render_trust_card",
+    "render_trust_card_one_pager",
 ]

--- a/src/wanamaker/reports/_trust_card_translations.py
+++ b/src/wanamaker/reports/_trust_card_translations.py
@@ -1,0 +1,188 @@
+"""Plain-English translations of Trust Card dimensions for non-technical readers.
+
+The full executive summary and the showcase use the *technical* explanation
+that ``trust_card.compute`` produces — analyst-facing strings that reference
+credible intervals, R-hat, MAPE, etc. The Trust Card one-pager is for
+forwarding to non-technical executives, so it uses these translated strings
+instead.
+
+Each dimension maps to (status -> consequence sentence) plus an "if weak,
+what should the reader do" decision sentence. The consequence sentence
+answers "what does this mean about the analysis?"; the decision sentence
+answers "and so what should I change?".
+
+Voice: dry, direct, no jargon. None of the following words should appear in
+the translations: credible interval, HDI, R-hat, MCMC, Bayesian, posterior,
+ESS, Gelman-Rubin. The unit test ``test_trust_card_one_pager`` enforces this
+on the rendered HTML.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from wanamaker.trust_card.card import TrustStatus
+
+# The friendly label users see on the one-pager. The internal key remains
+# ``saturation_identifiability`` etc. so the report and showcase keep their
+# precise vocabulary; only the executive-facing artifact is translated.
+DIMENSION_LABELS: Final[dict[str, str]] = {
+    "convergence": "Math stability",
+    "holdout_accuracy": "Recent-week accuracy",
+    "refresh_stability": "Refresh stability",
+    "prior_sensitivity": "Data-driven vs. assumption-driven",
+    "saturation_identifiability": "Diminishing-returns curves",
+    "lift_test_consistency": "Agreement with experiments",
+}
+
+
+# (dimension, status) -> plain-English consequence sentence.
+# Missing entries fall back to the status label only.
+_CONSEQUENCES: Final[dict[tuple[str, TrustStatus], str]] = {
+    ("convergence", TrustStatus.PASS): (
+        "The math behind the model settled cleanly. Estimates are stable "
+        "across re-runs."
+    ),
+    ("convergence", TrustStatus.MODERATE): (
+        "The math behind the model settled, with minor irregularities. "
+        "Re-running may shift estimates slightly."
+    ),
+    ("convergence", TrustStatus.WEAK): (
+        "The math did not settle cleanly. Some estimates may shift meaningfully "
+        "if you re-run; treat them as approximate."
+    ),
+    ("holdout_accuracy", TrustStatus.PASS): (
+        "The model's recent forecasts have been tracking actuals well."
+    ),
+    ("holdout_accuracy", TrustStatus.MODERATE): (
+        "The model's recent forecasts are roughly tracking actuals, with some "
+        "misses worth noting."
+    ),
+    ("holdout_accuracy", TrustStatus.WEAK): (
+        "The model is not predicting recent weeks well. Be cautious about "
+        "forward forecasts."
+    ),
+    ("refresh_stability", TrustStatus.PASS): (
+        "When new data arrives, historical estimates stay stable. Decisions "
+        "made on the prior run still hold."
+    ),
+    ("refresh_stability", TrustStatus.MODERATE): (
+        "Some historical estimates moved with the latest data, but most are "
+        "explained by routine change. Watch the diff for surprises."
+    ),
+    ("refresh_stability", TrustStatus.WEAK): (
+        "Recent estimates moved enough that prior-run decisions may no longer "
+        "hold. Read the refresh diff before acting."
+    ),
+    ("prior_sensitivity", TrustStatus.PASS): (
+        "The data drove the answer. Built-in modeling assumptions had little "
+        "influence on the result."
+    ),
+    ("prior_sensitivity", TrustStatus.MODERATE): (
+        "The data is doing most of the work, but built-in assumptions matter "
+        "on a few estimates."
+    ),
+    ("prior_sensitivity", TrustStatus.WEAK): (
+        "The data is not pinning down the answer. Built-in assumptions are "
+        "doing more work than the evidence — treat conclusions as soft."
+    ),
+    ("saturation_identifiability", TrustStatus.PASS): (
+        "There was enough variation in spend over time to learn each channel's "
+        "diminishing-returns curve."
+    ),
+    ("saturation_identifiability", TrustStatus.MODERATE): (
+        "Most channels' diminishing-returns curves are reasonably learned; a "
+        "few are uncertain. See the per-channel notes in the full report."
+    ),
+    ("saturation_identifiability", TrustStatus.WEAK): (
+        "One or more channels had near-constant spend, so their "
+        "diminishing-returns curves are not learned from data. They should be "
+        "left out of reallocation decisions."
+    ),
+    ("lift_test_consistency", TrustStatus.PASS): (
+        "The model agrees with the field experiments you provided."
+    ),
+    ("lift_test_consistency", TrustStatus.MODERATE): (
+        "The model and field experiments are mostly aligned, with minor "
+        "disagreements worth noting."
+    ),
+    ("lift_test_consistency", TrustStatus.WEAK): (
+        "The model disagrees with one or more field experiments. Reconcile "
+        "the two before acting on either."
+    ),
+}
+
+
+# Decision sentence shown in the "what this means for decisions" block when a
+# dimension is weak. Missing entry falls back to a generic caveat.
+_DECISIONS: Final[dict[str, str]] = {
+    "convergence": (
+        "Treat channel estimates as approximate; small reallocation calls are "
+        "OK, big bets are not."
+    ),
+    "holdout_accuracy": (
+        "Use the model's directional read, not its point predictions, for "
+        "forward-looking budget calls."
+    ),
+    "refresh_stability": (
+        "Do not act on conclusions that contradict the previous run without "
+        "first reviewing the refresh diff."
+    ),
+    "prior_sensitivity": (
+        "Treat the analysis as suggestive. Aim for plans that work across a "
+        "range of reasonable assumptions."
+    ),
+    "saturation_identifiability": (
+        "Avoid large reallocation calls based on response-curve shape. "
+        "Channels with constant historical spend are off-limits for "
+        "reallocation."
+    ),
+    "lift_test_consistency": (
+        "Reconcile the model and the experiment before acting on either. "
+        "Default to trusting the experiment when in doubt."
+    ),
+}
+
+
+# Words that must NEVER appear in the rendered one-pager. The plain-English
+# guard test asserts this on the rendered HTML.
+JARGON_BLACKLIST: Final[tuple[str, ...]] = (
+    "credible interval",
+    "HDI",
+    "R-hat",
+    "MCMC",
+    "Bayesian",
+    "posterior",
+    "ESS",
+    "Gelman-Rubin",
+)
+
+
+def consequence_for(dimension: str, status: TrustStatus) -> str:
+    """Return the plain-English consequence sentence for a dimension/status.
+
+    Falls back to a status-only sentence when an unknown dimension is
+    encountered, so future dimensions added to the Trust Card don't break
+    the one-pager render.
+    """
+    explicit = _CONSEQUENCES.get((dimension, status))
+    if explicit is not None:
+        return explicit
+    if status == TrustStatus.PASS:
+        return "This dimension passes."
+    if status == TrustStatus.MODERATE:
+        return "This dimension is moderate — read the full report for details."
+    return "This dimension is weak — read the full report before acting."
+
+
+def decision_for(dimension: str) -> str:
+    """Return the executive-facing decision sentence for a weak dimension."""
+    return _DECISIONS.get(
+        dimension,
+        "Read the full report before acting on conclusions that touch this dimension.",
+    )
+
+
+def label_for(dimension: str) -> str:
+    """Return the friendly display label for a dimension name."""
+    return DIMENSION_LABELS.get(dimension, dimension.replace("_", " ").capitalize())

--- a/src/wanamaker/reports/templates/trust_card_one_pager.css
+++ b/src/wanamaker/reports/templates/trust_card_one_pager.css
@@ -1,0 +1,264 @@
+/* trust_card_one_pager stylesheet — inlined into the HTML <style> block.
+   No external fonts, no CDN, no JS. Designed to print to a single page on
+   either US Letter or A4 via @page size: auto.
+*/
+:root {
+  --ink: #0f172a;
+  --muted: #64748b;
+  --line: #e2e8f0;
+  --bg: #ffffff;
+  --bg-soft: #f8fafc;
+  --primary: #2b5876;
+  --pass: #059669;
+  --pass-soft: #ecfdf5;
+  --moderate: #d97706;
+  --moderate-soft: #fff7ed;
+  --weak: #dc2626;
+  --weak-soft: #fef2f2;
+}
+
+@page {
+  size: auto;
+  margin: 0.5in;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-soft);
+  color: var(--ink);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+main {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 48px 32px 40px;
+  background: var(--bg);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04);
+}
+
+/* Header ---------------------------------------------------------------- */
+
+header.wmk-card-header {
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 16px;
+  margin-bottom: 28px;
+}
+
+header.wmk-card-header .wmk-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-weight: 600;
+  margin: 0 0 6px 0;
+}
+
+header.wmk-card-header h1 {
+  font-size: 26px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+  letter-spacing: -0.015em;
+  line-height: 1.25;
+}
+
+header.wmk-card-header .wmk-meta {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+/* Verdict band — the headline call ------------------------------------- */
+
+section.wmk-verdict {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 24px 28px;
+  border-radius: 8px;
+  margin: 0 0 32px 0;
+}
+
+.wmk-verdict--pass {
+  background: var(--pass-soft);
+  border: 1px solid var(--pass);
+}
+
+.wmk-verdict--moderate {
+  background: var(--moderate-soft);
+  border: 1px solid var(--moderate);
+}
+
+.wmk-verdict--weak {
+  background: var(--weak-soft);
+  border: 1px solid var(--weak);
+}
+
+.wmk-verdict__pill {
+  display: inline-block;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.wmk-pill--pass {
+  background: white;
+  color: var(--pass);
+  border: 2px solid var(--pass);
+}
+
+.wmk-pill--moderate {
+  background: white;
+  color: var(--moderate);
+  border: 2px solid var(--moderate);
+}
+
+.wmk-pill--weak {
+  background: white;
+  color: var(--weak);
+  border: 2px solid var(--weak);
+}
+
+.wmk-verdict__sentence {
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0;
+  color: var(--ink);
+}
+
+/* Section structure ---------------------------------------------------- */
+
+section.wmk-card-section {
+  margin: 0 0 32px 0;
+}
+
+section.wmk-card-section h2 {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin: 0 0 14px 0;
+}
+
+/* Six-dimension status strip ------------------------------------------- */
+
+.wmk-dim-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.wmk-dim {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 14px 16px;
+  background: var(--bg);
+}
+
+.wmk-dim__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.wmk-dim__name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--ink);
+}
+
+.wmk-dim__pill {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.wmk-dim__text {
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0;
+  color: var(--ink);
+}
+
+/* Decisions block ------------------------------------------------------ */
+
+ul.wmk-decisions {
+  margin: 0;
+  padding: 0 0 0 20px;
+}
+
+ul.wmk-decisions li {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+ul.wmk-decisions li strong {
+  font-weight: 600;
+}
+
+/* Caveat paragraph + footer ------------------------------------------- */
+
+p.wmk-caveat {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+footer.wmk-card-footer {
+  margin-top: 36px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  font-size: 11px;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+footer.wmk-card-footer code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+}
+
+@media print {
+  body {
+    background: white;
+  }
+  main {
+    box-shadow: none;
+    max-width: none;
+    padding: 0;
+  }
+  /* Tighter spacing in print so the page doesn't break awkwardly. */
+  section.wmk-verdict {
+    padding: 16px 20px;
+    margin-bottom: 20px;
+  }
+  section.wmk-card-section {
+    margin-bottom: 20px;
+  }
+}

--- a/src/wanamaker/reports/templates/trust_card_one_pager.html.j2
+++ b/src/wanamaker/reports/templates/trust_card_one_pager.html.j2
@@ -1,0 +1,96 @@
+{# Trust Card one-pager template (executive-facing).
+
+   Required context keys (built by build_trust_card_one_pager_context):
+     - title, run_id, generated_at, package_version, run_fingerprint
+     - period_start, period_end, n_periods
+     - verdict: {status, label, sentence}
+     - dimensions: list of {name_label, status, sentence}
+     - decisions: list of {dimension_label, sentence}  (only weak ones)
+
+   Voice: dry, direct, no jargon. The plain-English guard test asserts
+   that none of the strings in JARGON_BLACKLIST appear in the rendered
+   output.
+#}<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>{{ title }}</title>
+<style>
+{{ stylesheet | safe }}
+</style>
+</head>
+<body>
+<main>
+
+<header class="wmk-card-header">
+  <p class="wmk-eyebrow">Model Trust Card</p>
+  <h1>{{ title }}</h1>
+  <p class="wmk-meta">
+    Period <strong>{{ period_start }}</strong> – <strong>{{ period_end }}</strong>
+    ({{ n_periods }} periods) · Generated {{ generated_at }}
+  </p>
+</header>
+
+<section class="wmk-verdict wmk-verdict--{{ verdict.status }}">
+  <span class="wmk-verdict__pill wmk-pill--{{ verdict.status }}">
+    {{ verdict.label }}
+  </span>
+  <p class="wmk-verdict__sentence">{{ verdict.sentence }}</p>
+</section>
+
+<section class="wmk-card-section" id="dimensions">
+  <h2>What we checked</h2>
+  <div class="wmk-dim-grid">
+    {% for d in dimensions %}
+    <div class="wmk-dim">
+      <div class="wmk-dim__head">
+        <span class="wmk-dim__name">{{ d.name_label }}</span>
+        <span class="wmk-dim__pill wmk-pill--{{ d.status }}">{{ d.status }}</span>
+      </div>
+      <p class="wmk-dim__text">{{ d.sentence }}</p>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="wmk-card-section" id="decisions">
+  <h2>What this means for decisions</h2>
+  {% if decisions %}
+  <ul class="wmk-decisions">
+    {% for d in decisions %}
+    <li><strong>{{ d.dimension_label }}:</strong> {{ d.sentence }}</li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <ul class="wmk-decisions">
+    <li>
+      Use this analysis as you would any well-fit decision input. The
+      checks above are clean enough that the model's recommendations
+      can be acted on with normal caution.
+    </li>
+  </ul>
+  {% endif %}
+</section>
+
+<section class="wmk-card-section" id="not-covered">
+  <h2>What this card does not cover</h2>
+  <p class="wmk-caveat">
+    The Trust Card surfaces failure modes the model can detect from the
+    fit itself. It does not attest to data quality before the fit, the
+    accuracy of channel categorisation, off-policy validity (whether
+    historical patterns will hold under a very different plan), or
+    whether the marketing context matches the assumptions the model was
+    built on. Use it alongside business judgment, not in place of it.
+  </p>
+</section>
+
+<footer class="wmk-card-footer">
+  <span>Run <code>{{ run_id }}</code></span>
+  <span>Fingerprint <code>{{ run_fingerprint }}</code></span>
+  <span>wanamaker {{ package_version }}</span>
+</footer>
+
+</main>
+</body>
+</html>

--- a/src/wanamaker/reports/trust_card_one_pager.py
+++ b/src/wanamaker/reports/trust_card_one_pager.py
@@ -1,0 +1,172 @@
+"""Trust Card one-pager rendering — executive-facing standalone artifact.
+
+The one-pager is the "if you read only one page of this analysis" output.
+It is designed for forwarding to a non-technical executive audience
+(CMO, CFO, CEO) and for printing to a single physical page.
+
+Two design rules differentiate it from the full showcase:
+
+1. **No jargon.** Every dimension is translated to consequence language
+   via ``_trust_card_translations``. The unit test asserts that none of
+   ``credible interval``, ``HDI``, ``R-hat``, ``MCMC``, ``Bayesian``,
+   ``posterior``, ``ESS``, or ``Gelman-Rubin`` appear in the rendered
+   HTML.
+2. **One page.** Print CSS uses ``@page size: auto; margin: 0.5in;`` so
+   it renders on US Letter or A4 without manual sizing.
+
+Per AGENTS.md Hard Rule 2: **no LLM calls for output generation**, ever.
+The verdict sentence is selected from a fixed three-line set; per-dimension
+language comes from the translation dictionary.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from importlib.resources import files
+from typing import Any
+
+from wanamaker.engine.summary import PosteriorSummary
+from wanamaker.reports._trust_card_translations import (
+    consequence_for,
+    decision_for,
+    label_for,
+)
+from wanamaker.trust_card.card import TrustCard, TrustStatus
+
+# Verdict line text — one per status. Fixed phrasing wins over varied
+# phrasing because executives read these scanning for one signal: green
+# / amber / red. Predictable language is the feature.
+_VERDICT_TEXT: dict[str, dict[str, str]] = {
+    "pass": {
+        "label": "Trust Card clean",
+        "sentence": (
+            "Every check on the model passed. The analysis can be acted "
+            "on with normal caution."
+        ),
+    },
+    "moderate": {
+        "label": "Mixed evidence",
+        "sentence": (
+            "The model is broadly trustworthy, with caveats on a few "
+            "checks. Read the items below before strong action."
+        ),
+    },
+    "weak": {
+        "label": "Use with caution",
+        "sentence": (
+            "One or more checks on the model flagged a weakness. Read "
+            "the items below before acting on the analysis."
+        ),
+    },
+    "empty": {
+        "label": "No verdict",
+        "sentence": (
+            "No Trust Card dimensions were computed for this run. The "
+            "full report has the available diagnostics."
+        ),
+    },
+}
+
+
+def _verdict_for(trust_card: TrustCard) -> dict[str, str]:
+    """Return the pill + sentence for the worst dimension's status."""
+    if not trust_card.dimensions:
+        v = _VERDICT_TEXT["empty"]
+        return {"status": "moderate", "label": v["label"], "sentence": v["sentence"]}
+    statuses = {d.status for d in trust_card.dimensions}
+    if TrustStatus.WEAK in statuses:
+        key = "weak"
+    elif TrustStatus.MODERATE in statuses:
+        key = "moderate"
+    else:
+        key = "pass"
+    v = _VERDICT_TEXT[key]
+    return {"status": key, "label": v["label"], "sentence": v["sentence"]}
+
+
+def build_trust_card_one_pager_context(
+    summary: PosteriorSummary,
+    trust_card: TrustCard,
+    *,
+    title: str,
+    run_id: str,
+    generated_at: datetime,
+    package_version: str,
+    run_fingerprint: str,
+) -> dict[str, Any]:
+    """Shape every input the Trust Card one-pager template needs.
+
+    The shaper applies the plain-English translation dictionary to each
+    dimension, picks the verdict line based on the worst status, and
+    builds the per-weak-dimension decision bullets. No technical strings
+    survive into the output.
+    """
+    dimensions = []
+    decisions: list[dict[str, str]] = []
+    for d in trust_card.dimensions:
+        dimensions.append(
+            {
+                "name_label": label_for(d.name),
+                "status": d.status.value,
+                "sentence": consequence_for(d.name, d.status),
+            }
+        )
+        if d.status == TrustStatus.WEAK:
+            decisions.append(
+                {
+                    "dimension_label": label_for(d.name),
+                    "sentence": decision_for(d.name),
+                }
+            )
+
+    period_start, period_end, n_periods = _period_range(summary)
+
+    return {
+        "title": title,
+        "run_id": run_id,
+        "generated_at": generated_at.strftime("%Y-%m-%d"),
+        "package_version": package_version,
+        "run_fingerprint": run_fingerprint or "—",
+        "period_start": period_start,
+        "period_end": period_end,
+        "n_periods": n_periods,
+        "verdict": _verdict_for(trust_card),
+        "dimensions": dimensions,
+        "decisions": decisions,
+    }
+
+
+def _period_range(summary: PosteriorSummary) -> tuple[str, str, int]:
+    """Pull the date range from in-sample predictive periods, when present."""
+    predictive = summary.in_sample_predictive
+    if predictive and predictive.periods:
+        return (
+            str(predictive.periods[0]),
+            str(predictive.periods[-1]),
+            len(predictive.periods),
+        )
+    return ("unknown", "unknown", 0)
+
+
+def _read_stylesheet() -> str:
+    """Read ``trust_card_one_pager.css`` from the package for inlining."""
+    return (
+        files("wanamaker.reports.templates")
+        .joinpath("trust_card_one_pager.css")
+        .read_text(encoding="utf-8")
+    )
+
+
+def render_trust_card_one_pager(context: dict[str, Any]) -> str:
+    """Render the one-pager HTML from a ready-made context.
+
+    The stylesheet is read from package resources at call time and
+    injected so the output is a single self-contained file. Uses the
+    Jinja2 environment configured in ``reports.render``, which
+    autoescapes ``.html.j2`` templates.
+    """
+    from wanamaker.reports.render import _env  # local import to avoid a cycle
+
+    template = _env.get_template("trust_card_one_pager.html.j2")
+    enriched = {**context, "stylesheet": _read_stylesheet()}
+    return template.render(**enriched)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,6 +21,7 @@ def test_help_lists_public_commands() -> None:
         "fit",
         "report",
         "showcase",
+        "trust-card",
         "run",
         "forecast",
         "compare-scenarios",

--- a/tests/unit/test_trust_card_one_pager.py
+++ b/tests/unit/test_trust_card_one_pager.py
@@ -1,0 +1,325 @@
+"""Tests for the executive-facing Trust Card one-pager renderer.
+
+The one-pager is forwarded to non-technical executives, so the assertions
+focus on three contracts:
+
+1. **Self-contained.** Single HTML file, inline CSS, no external assets,
+   no Jinja leakage.
+2. **No jargon.** None of the analyst-facing terms in
+   ``JARGON_BLACKLIST`` appear in the rendered output. This is the
+   load-bearing test — if it fails, the one-pager is no longer
+   executive-friendly even if everything else looks fine.
+3. **Verdict matches the worst dimension.** The big pill at the top is
+   chosen from the worst status across all dimensions; mixed cards do
+   not lull readers with a green pill.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    ConvergenceSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+from wanamaker.reports import (
+    build_trust_card_one_pager_context,
+    render_trust_card_one_pager,
+)
+from wanamaker.reports._trust_card_translations import JARGON_BLACKLIST
+from wanamaker.trust_card.card import TrustCard, TrustDimension, TrustStatus
+
+
+def _channel(name: str) -> ChannelContributionSummary:
+    return ChannelContributionSummary(
+        channel=name,
+        mean_contribution=5000.0,
+        hdi_low=4500.0,
+        hdi_high=5500.0,
+        roi_mean=2.0,
+        roi_hdi_low=1.8,
+        roi_hdi_high=2.2,
+        observed_spend_min=10.0,
+        observed_spend_max=50.0,
+        spend_invariant=False,
+    )
+
+
+def _summary(*channels: ChannelContributionSummary) -> PosteriorSummary:
+    periods = ["2024-01-01", "2024-01-08", "2024-01-15"]
+    return PosteriorSummary(
+        channel_contributions=list(channels),
+        convergence=ConvergenceSummary(
+            max_r_hat=1.005,
+            min_ess_bulk=500.0,
+            n_divergences=0,
+            n_chains=4,
+            n_draws=1000,
+        ),
+        in_sample_predictive=PredictiveSummary(
+            periods=periods,
+            mean=[100.0] * len(periods),
+            hdi_low=[90.0] * len(periods),
+            hdi_high=[110.0] * len(periods),
+        ),
+    )
+
+
+def _card(*dims: tuple[str, TrustStatus, str]) -> TrustCard:
+    return TrustCard(
+        dimensions=[
+            TrustDimension(name=name, status=status, explanation=expl)
+            for (name, status, expl) in dims
+        ]
+    )
+
+
+def _render(card: TrustCard, **overrides) -> str:
+    summary = _summary(_channel("paid_search"))
+    defaults = {
+        "title": "Test One-Pager",
+        "run_id": "abc123de_20260101T000000Z",
+        "generated_at": datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+        "package_version": "0.1.0",
+        "run_fingerprint": "abc123de4567890f",
+    }
+    defaults.update(overrides)
+    context = build_trust_card_one_pager_context(summary, card, **defaults)
+    return render_trust_card_one_pager(context)
+
+
+# ---------------------------------------------------------------------------
+# Self-contained
+# ---------------------------------------------------------------------------
+
+
+def test_renders_to_self_contained_html() -> None:
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(card)
+
+    assert html.startswith("<!doctype html>")
+    assert "</html>" in html
+    assert "<style>" in html and "</style>" in html
+    assert "<link" not in html
+    assert "<script" not in html
+    assert "https://" not in html
+    assert "{{" not in html
+    assert "{%" not in html
+
+
+def test_includes_required_sections() -> None:
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(card)
+
+    for section_id in ("dimensions", "decisions", "not-covered"):
+        assert f'id="{section_id}"' in html, f"missing #{section_id}"
+
+
+def test_size_under_threshold() -> None:
+    """The one-pager should stay tiny for email forwarding."""
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        ("holdout_accuracy", TrustStatus.PASS, "OK."),
+        ("refresh_stability", TrustStatus.PASS, "OK."),
+        ("prior_sensitivity", TrustStatus.PASS, "OK."),
+        ("saturation_identifiability", TrustStatus.PASS, "OK."),
+        ("lift_test_consistency", TrustStatus.PASS, "OK."),
+    )
+    html = _render(card)
+    assert len(html) < 25_000, f"one-pager grew to {len(html)} bytes"
+
+
+# ---------------------------------------------------------------------------
+# Plain-English guard — the load-bearing test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "card",
+    [
+        _card(("convergence", TrustStatus.PASS, "OK.")),
+        _card(("convergence", TrustStatus.MODERATE, "OK.")),
+        _card(("convergence", TrustStatus.WEAK, "OK.")),
+        _card(
+            ("convergence", TrustStatus.PASS, "Max R-hat is 1.005 across all parameters."),
+            ("holdout_accuracy", TrustStatus.MODERATE, "Holdout MAPE is 12%."),
+            (
+                "saturation_identifiability",
+                TrustStatus.WEAK,
+                "Affiliate spend is invariant; saturation curve from priors only.",
+            ),
+            (
+                "prior_sensitivity",
+                TrustStatus.PASS,
+                "Posterior is robust to ±50% prior perturbations.",
+            ),
+            (
+                "lift_test_consistency",
+                TrustStatus.PASS,
+                "Posterior agrees with provided lift tests.",
+            ),
+            ("refresh_stability", TrustStatus.PASS, "Movements explained."),
+        ),
+    ],
+)
+def test_no_jargon_appears_in_rendered_output(card: TrustCard) -> None:
+    """The whole point of the one-pager: no analyst jargon survives.
+
+    Even when the underlying ``TrustDimension.explanation`` contains
+    technical terms, the rendered one-pager uses the translated strings
+    from ``_trust_card_translations`` instead.
+
+    Acronyms (HDI, ESS, MCMC) must be matched case-sensitively with
+    word boundaries so they don't false-positive against substrings like
+    ``weakness`` or ``Express``.
+    """
+    import re
+
+    html = _render(card)
+    for term in JARGON_BLACKLIST:
+        # Word-boundary, case-sensitive match. Catches "ESS" but not "ess"
+        # inside "weakness"; catches "Bayesian" but not arbitrary substrings.
+        pattern = r"\b" + re.escape(term) + r"\b"
+        match = re.search(pattern, html)
+        assert match is None, (
+            f"jargon term {term!r} leaked into the one-pager output: "
+            f"...{html[max(0, match.start() - 20):match.end() + 20]}..."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verdict matches the worst dimension
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_pass_when_all_pass() -> None:
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        ("holdout_accuracy", TrustStatus.PASS, "OK."),
+    )
+    html = _render(card)
+    assert "wmk-verdict--pass" in html
+    assert "wmk-pill--pass" in html
+    assert "Trust Card clean" in html
+
+
+def test_verdict_moderate_when_only_moderates() -> None:
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        ("holdout_accuracy", TrustStatus.MODERATE, "Mixed."),
+    )
+    html = _render(card)
+    assert "wmk-verdict--moderate" in html
+    assert "Mixed evidence" in html
+
+
+def test_verdict_weak_when_any_weak() -> None:
+    """The worst dimension wins — a single weak still tints the verdict red."""
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        ("holdout_accuracy", TrustStatus.PASS, "OK."),
+        ("saturation_identifiability", TrustStatus.WEAK, "Insufficient spend variation."),
+    )
+    html = _render(card)
+    assert "wmk-verdict--weak" in html
+    assert "Use with caution" in html
+
+
+def test_verdict_handles_empty_card() -> None:
+    card = TrustCard(dimensions=[])
+    html = _render(card)
+    assert "No verdict" in html or "No Trust Card dimensions" in html
+
+
+# ---------------------------------------------------------------------------
+# Decisions block
+# ---------------------------------------------------------------------------
+
+
+def test_decisions_lists_one_bullet_per_weak_dimension() -> None:
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        ("saturation_identifiability", TrustStatus.WEAK, "Insufficient spend variation."),
+        ("prior_sensitivity", TrustStatus.WEAK, "Sensitive to priors."),
+    )
+    html = _render(card)
+    # Two weak dimensions -> two <li> entries inside the decisions section.
+    decisions_start = html.index('id="decisions"')
+    decisions_end = html.index('id="not-covered"')
+    decisions_block = html[decisions_start:decisions_end]
+    assert decisions_block.count("<li>") == 2
+
+
+def test_decisions_default_when_all_pass() -> None:
+    card = _card(
+        ("convergence", TrustStatus.PASS, "OK."),
+        ("holdout_accuracy", TrustStatus.PASS, "OK."),
+    )
+    html = _render(card)
+    assert "acted on with normal caution" in html
+
+
+# ---------------------------------------------------------------------------
+# Per-dimension cell uses translated label and translated text
+# ---------------------------------------------------------------------------
+
+
+def test_dimensions_use_friendly_labels() -> None:
+    card = _card(
+        ("saturation_identifiability", TrustStatus.WEAK, "Insufficient spend variation."),
+    )
+    html = _render(card)
+    # Friendly label appears; raw underscored name does not.
+    assert "Diminishing-returns curves" in html
+    assert "saturation_identifiability" not in html
+
+
+def test_dimensions_use_translated_text_not_raw_explanation() -> None:
+    """The technical explanation should not survive into the one-pager —
+    only the translated consequence sentence."""
+    card = _card(
+        (
+            "convergence",
+            TrustStatus.WEAK,
+            "Max R-hat is 1.27, well above the 1.01 threshold.",
+        ),
+    )
+    html = _render(card)
+    assert "Max R-hat" not in html
+    assert "did not settle cleanly" in html
+
+
+# ---------------------------------------------------------------------------
+# Title and escape safety
+# ---------------------------------------------------------------------------
+
+
+def test_title_appears_in_h1_and_html_title() -> None:
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(card, title="Q4 2026 Trust Card")
+    assert "<title>Q4 2026 Trust Card</title>" in html
+    assert "<h1>Q4 2026 Trust Card</h1>" in html
+
+
+@pytest.mark.parametrize("malicious", ["<script>x()</script>", "</style>", "&"])
+def test_title_is_html_escaped(malicious: str) -> None:
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(card, title=malicious)
+    assert "<script>x()</script>" not in html
+
+
+# ---------------------------------------------------------------------------
+# Print contract
+# ---------------------------------------------------------------------------
+
+
+def test_print_css_present() -> None:
+    """The @page rule is what makes the one-pager print to one sheet."""
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(card)
+    assert "@page" in html
+    assert "@media print" in html


### PR DESCRIPTION
## Summary

First slice of PR A from the polish-the-reports plan. Adds `wanamaker trust-card --run-id <id>` that renders a single self-contained HTML one-pager — the "if you read only one page of this analysis, read this" output, designed for forwarding to non-technical executives.

~8 KB on a typical run. Prints to a single page on US Letter or A4. No JS, no CDN, no external assets.

## What's in it

- **Verdict band:** big pill (green / amber / red) chosen from the worst dimension, plus a fixed three-line sentence per status. Predictable phrasing > varied phrasing for executive comms.
- **Six-dimension status grid:** each dimension translated to consequence language. No "credible interval", "HDI", "R-hat", "MCMC", "Bayesian", "posterior", "ESS", or "Gelman-Rubin" appears in the rendered output — a unit test asserts this on the rendered HTML so the guarantee can't drift.
- **"What this means for decisions":** one bullet per weak dimension (with practical caveats), or a default "use as you would any well-fit decision input" when clean.
- **"What this card does not cover":** stops execs over-trusting it. Names data quality, off-policy validity, marketing context.
- **Footer:** run ID and fingerprint for audit trail.

## Design choices

- **Plain-English translation dictionary** ([`_trust_card_translations.py`](src/wanamaker/reports/_trust_card_translations.py)) is a small mapping from `(dimension, status)` → consequence sentence and `dimension` → decision sentence. Keeps the technical text in the showcase/report and the executive text on the one-pager.
- **Separate command, not a `--one-pager` flag on `showcase`** — different artifact, different audience, different filename.
- **Auto-rendered from `wanamaker run --example`** alongside the Markdown report and the HTML showcase, so the demo flow produces all three artifacts in a single command.

## Validation

- **23 new unit tests** in [`test_trust_card_one_pager.py`](tests/unit/test_trust_card_one_pager.py): self-contained HTML, section presence, the no-jargon guard (parameterised across pass/moderate/weak/mixed cards), verdict matching the worst dimension, decision-bullet logic, plain-English labels in dimension cards, HTML escaping, print CSS.
- **Full unit suite:** 625 passed (was 605 + 20 new — 23 added but a couple of existing tests already covered the same trust-card builder).
- **Lint clean** on all new files.
- **Smoke test:** synthetic run renders to 8.3 KB, no SVGs, no `<script>`, no `<link>`, jargon-free.

## Test plan

- [ ] `wanamaker run --example public_benchmark` produces `trust_card.html` alongside `showcase.html` and `report.md`
- [ ] `wanamaker trust-card --run-id <id> --open` opens the one-pager in a browser
- [ ] Browser print preview shows it as a single page on US Letter and A4
- [ ] Forward the file as an email attachment and confirm it renders standalone

## What's next in PR A

This was the load-bearing first piece. Still to come in the same plan:

- Response curves (per-channel diminishing-returns chart) in the showcase
- Contribution waterfall chart in the showcase
- Side-by-side scenario block polish

Each can land as its own PR or be batched once the design language for these is settled (the one-pager establishes most of it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)