### PR TITLE
Add contribution waterfall to the HTML showcase

### DIFF
--- a/src/wanamaker/reports/_charts.py
+++ b/src/wanamaker/reports/_charts.py
@@ -421,6 +421,120 @@ def scenario_delta_svg(
     return "".join(parts)
 
 
+def contribution_waterfall_svg(
+    baseline_total: float,
+    channels: Sequence[dict[str, Any]],
+) -> str:
+    """Horizontal cumulative waterfall: baseline + channels = total.
+
+    The chart answers "where does the revenue come from?" at a glance.
+    Each segment is a contiguous horizontal rectangle; the baseline is
+    rendered in a muted fill and channels in primary blue, with thin
+    white separators so adjacent segments are visually distinct. The
+    rightmost label states the total.
+
+    ``channels`` matches the dicts produced by ``_channel_view`` in
+    ``render.py`` (already pre-ranked by mean contribution). Only
+    ``name`` and ``contribution_mean`` are required; spend-invariant and
+    other fields are ignored — this chart shows headline magnitudes
+    only, not credibility nuance (that lives in the bar chart with HDI
+    whiskers).
+
+    ``baseline_total`` may be 0 or negative; in either case the chart
+    still composes (baseline is omitted or shown with a small placeholder).
+    """
+    channels = [c for c in channels if c.get("contribution_mean", 0.0) > 0]
+    if not channels and baseline_total <= 0:
+        return _empty_chart_svg("No contributions to display.")
+
+    width = 720
+    height = 160
+    top_pad = 40
+    left_pad = 12
+    right_pad = 12
+    bar_h = 36
+    bar_y = top_pad + 18
+    bar_top = bar_y
+    bar_bottom = bar_y + bar_h
+
+    # Total = baseline + channels. Width is scaled so total fills the plot.
+    contribs = [
+        (str(c["name"]), float(c["contribution_mean"])) for c in channels
+    ]
+    total = max(baseline_total, 0.0) + sum(value for _, value in contribs)
+    plot_w = width - left_pad - right_pad
+    if total <= 0:
+        return _empty_chart_svg("No contributions to display.")
+
+    def x_of(running_total: float) -> float:
+        return left_pad + (running_total / total) * plot_w
+
+    parts: list[str] = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {width} {height}" '
+        f'role="img" '
+        f'aria-label="Contribution waterfall: baseline plus media equals total" '
+        f'class="wmk-chart wmk-chart--waterfall">'
+    )
+
+    segments: list[tuple[str, float, str]] = []
+    if baseline_total > 0:
+        segments.append(("Baseline", float(baseline_total), _MUTED))
+    for name, value in contribs:
+        segments.append((name, value, _PRIMARY))
+
+    running = 0.0
+    for label, value, fill in segments:
+        seg_x = x_of(running)
+        seg_w = (value / total) * plot_w
+        parts.append(
+            f'<rect x="{seg_x:.1f}" y="{bar_top}" '
+            f'width="{max(seg_w, 0.5):.1f}" height="{bar_h}" '
+            f'fill="{fill}"/>'
+        )
+        # Top label: channel name (skip when segment is too narrow).
+        if seg_w >= 36:
+            parts.append(
+                f'<text x="{seg_x + seg_w / 2:.1f}" y="{bar_top - 6:.1f}" '
+                f'fill="{_INK}" font-family="{_FONT_FAMILY}" font-size="11" '
+                f'font-weight="500" text-anchor="middle">{escape(label)}</text>'
+            )
+        # Bottom label: numeric value (skip when too narrow).
+        if seg_w >= 48:
+            parts.append(
+                f'<text x="{seg_x + seg_w / 2:.1f}" y="{bar_bottom + 14:.1f}" '
+                f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="10" '
+                f'text-anchor="middle">{_fmt_int(value)}</text>'
+            )
+        # Thin white separator between segments.
+        parts.append(
+            f'<line x1="{seg_x + seg_w:.1f}" y1="{bar_top}" '
+            f'x2="{seg_x + seg_w:.1f}" y2="{bar_bottom}" '
+            f'stroke="white" stroke-width="1.5"/>'
+        )
+        running += value
+
+    # Total label at the right end.
+    parts.append(
+        f'<text x="{left_pad + plot_w:.1f}" y="{bar_top - 22:.1f}" '
+        f'fill="{_INK}" font-family="{_FONT_FAMILY}" font-size="13" '
+        f'font-weight="600" text-anchor="end">'
+        f'Total: {_fmt_int(total)}</text>'
+    )
+
+    # Caption below.
+    parts.append(
+        f'<text x="{left_pad + plot_w / 2:.1f}" y="{height - 8}" '
+        f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+        f'text-anchor="middle">'
+        f'Modelled target = baseline + each channel’s contribution</text>'
+    )
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
 def response_curves_svg(channels: Sequence[dict[str, Any]]) -> str:
     """Small-multiples grid of saturation curves, one panel per channel.
 

--- a/src/wanamaker/reports/showcase.py
+++ b/src/wanamaker/reports/showcase.py
@@ -29,6 +29,7 @@ from wanamaker.refresh.classify import MovementClass, unexplained_fraction
 from wanamaker.refresh.diff import RefreshDiff
 from wanamaker.reports._charts import (
     contribution_bars_svg,
+    contribution_waterfall_svg,
     response_curves_svg,
     roi_dotplot_svg,
     scenario_delta_svg,
@@ -225,6 +226,11 @@ def build_showcase_context(
     response_curve_channels = _response_curve_channels(summary, exec_ctx["channels"])
     response_curves_chart_svg = response_curves_svg(response_curve_channels)
 
+    baseline_total = _baseline_total(summary)
+    waterfall_chart_svg = contribution_waterfall_svg(
+        baseline_total, exec_ctx["channels"]
+    )
+
     return {
         # Header / footer.
         "title": title,
@@ -248,6 +254,7 @@ def build_showcase_context(
         "has_invariant_channels": trust_ctx["has_invariant_channels"],
         # Charts.
         "contribution_chart_svg": contribution_bars_svg(exec_ctx["channels"]),
+        "waterfall_chart_svg": waterfall_chart_svg,
         "roi_chart_svg": roi_dotplot_svg(exec_ctx["channels"]),
         "response_curves_chart_svg": response_curves_chart_svg,
         "scenario_chart_svg": scenario_chart_svg,
@@ -255,6 +262,26 @@ def build_showcase_context(
         "scenario": scenario_block,
         "refresh_narrative": refresh_narrative,
     }
+
+
+def _baseline_total(summary: PosteriorSummary) -> float:
+    """Modelled non-media baseline contribution over the training period.
+
+    Computed as ``sum(in_sample_predictive.mean) − sum(channel_contributions)``.
+    For a well-fitted model the predictive sum is the modelled total target
+    over the period; subtracting media yields what the target would have
+    been at baseline (intercept + controls). When the predictive summary
+    is missing or smaller than total media, returns 0.0 — the waterfall
+    chart degrades to a media-only stack.
+    """
+    predictive = summary.in_sample_predictive
+    if predictive is None or not predictive.mean:
+        return 0.0
+    total_predicted = float(sum(predictive.mean))
+    total_media = float(
+        sum(c.mean_contribution for c in summary.channel_contributions)
+    )
+    return max(total_predicted - total_media, 0.0)
 
 
 def _response_curve_channels(

--- a/src/wanamaker/reports/templates/showcase.html.j2
+++ b/src/wanamaker/reports/templates/showcase.html.j2
@@ -93,6 +93,17 @@
   {% endif %}
 </section>
 
+<section id="contribution-waterfall">
+  <h2>Where the modelled target comes from</h2>
+  <p class="wmk-chart-caption">
+    Cumulative breakdown of the modelled target over the training period.
+    The non-media baseline (intercept and controls) plus each channel's
+    contribution adds up to the total. Channel order matches the
+    contribution table below.
+  </p>
+  {{ waterfall_chart_svg | safe }}
+</section>
+
 <section id="channel-contributions">
   <h2>Channel contributions</h2>
   <p class="wmk-chart-caption">

--- a/tests/unit/test_charts.py
+++ b/tests/unit/test_charts.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 
 from wanamaker.reports._charts import (
     contribution_bars_svg,
+    contribution_waterfall_svg,
     response_curves_svg,
     roi_dotplot_svg,
     scenario_delta_svg,
@@ -289,3 +290,107 @@ def test_response_curves_curve_passes_through_origin() -> None:
     # First point is below or equal the last point in plot space (curve
     # rises as spend increases — bigger y-pixel = lower contribution).
     assert fy >= ly
+
+
+# ---------------------------------------------------------------------------
+# contribution_waterfall_svg
+# ---------------------------------------------------------------------------
+
+
+def test_waterfall_one_segment_per_channel_plus_baseline() -> None:
+    channels = [
+        _channel("ch_a", contribution_mean=5000),
+        _channel("ch_b", contribution_mean=3000),
+        _channel("ch_c", contribution_mean=1000),
+    ]
+    svg = contribution_waterfall_svg(baseline_total=10000, channels=channels)
+    root = _parse(svg)
+
+    rects = list(root.iter("{http://www.w3.org/2000/svg}rect"))
+    # One rect per channel + one for baseline.
+    assert len(rects) == 4
+
+
+def test_waterfall_skips_baseline_segment_when_zero() -> None:
+    channels = [
+        _channel("ch_a", contribution_mean=5000),
+        _channel("ch_b", contribution_mean=3000),
+    ]
+    svg = contribution_waterfall_svg(baseline_total=0.0, channels=channels)
+    root = _parse(svg)
+
+    rects = list(root.iter("{http://www.w3.org/2000/svg}rect"))
+    assert len(rects) == 2
+    assert ">Baseline<" not in svg
+
+
+def test_waterfall_total_label_is_sum_of_segments() -> None:
+    channels = [
+        _channel("ch_a", contribution_mean=5000),
+        _channel("ch_b", contribution_mean=2500),
+    ]
+    svg = contribution_waterfall_svg(baseline_total=10000, channels=channels)
+    # 10000 + 5000 + 2500 = 17500 -> "Total: 17,500"
+    assert "Total: 17,500" in svg
+
+
+def test_waterfall_drops_zero_or_negative_channels() -> None:
+    """Channels with non-positive contribution don't get a segment."""
+    channels = [
+        _channel("ch_a", contribution_mean=5000),
+        _channel("ch_zero", contribution_mean=0),
+        _channel("ch_neg", contribution_mean=-100),
+    ]
+    svg = contribution_waterfall_svg(baseline_total=10000, channels=channels)
+    root = _parse(svg)
+
+    rects = list(root.iter("{http://www.w3.org/2000/svg}rect"))
+    # baseline + ch_a only.
+    assert len(rects) == 2
+    assert "ch_zero" not in svg
+    assert "ch_neg" not in svg
+
+
+def test_waterfall_handles_empty_input() -> None:
+    svg = contribution_waterfall_svg(baseline_total=0, channels=[])
+    root = _parse(svg)
+    assert root.attrib.get("class", "").endswith("wmk-chart--empty")
+
+
+def test_waterfall_handles_negative_baseline_as_zero() -> None:
+    """A negative baseline shouldn't break the chart — it's treated as 0."""
+    channels = [_channel("ch_a", contribution_mean=5000)]
+    svg = contribution_waterfall_svg(baseline_total=-1000, channels=channels)
+    root = _parse(svg)
+
+    rects = list(root.iter("{http://www.w3.org/2000/svg}rect"))
+    # baseline omitted, just one channel.
+    assert len(rects) == 1
+    assert "Total: 5,000" in svg
+
+
+def test_waterfall_is_deterministic() -> None:
+    channels = [
+        _channel("ch_a", contribution_mean=5000),
+        _channel("ch_b", contribution_mean=3000),
+    ]
+    a = contribution_waterfall_svg(baseline_total=10000, channels=channels)
+    b = contribution_waterfall_svg(baseline_total=10000, channels=channels)
+    assert a == b
+
+
+def test_waterfall_segment_widths_are_proportional() -> None:
+    """A segment that's twice as big should be drawn twice as wide."""
+    import re
+
+    channels = [
+        _channel("ch_a", contribution_mean=4000),
+        _channel("ch_b", contribution_mean=2000),
+    ]
+    svg = contribution_waterfall_svg(baseline_total=0, channels=channels)
+    widths = [
+        float(m) for m in re.findall(r'<rect[^>]*width="([\d.]+)"', svg)
+    ]
+    assert len(widths) == 2
+    # 2:1 ratio between the two channels.
+    assert abs(widths[0] / widths[1] - 2.0) < 0.05

--- a/tests/unit/test_showcase.py
+++ b/tests/unit/test_showcase.py
@@ -180,6 +180,7 @@ def test_includes_all_required_sections() -> None:
     for section_id in (
         "verdict",
         "executive-summary",
+        "contribution-waterfall",
         "channel-contributions",
         "channel-roi",
         "response-curves",
@@ -209,10 +210,11 @@ def test_charts_inline_as_svg() -> None:
     card = _card(("convergence", TrustStatus.PASS, "OK."))
     html = _render(summary, card)
 
-    # Three SVGs minimum (contribution + ROI + response curves). Scenario
-    # chart only when --scenario is supplied; tested separately.
+    # Four SVGs minimum (waterfall + contribution + ROI + response curves).
+    # Scenario chart only when --scenario is supplied; tested separately.
     svg_count = html.count("<svg")
-    assert svg_count >= 3, f"expected >= 3 inline SVGs, got {svg_count}"
+    assert svg_count >= 4, f"expected >= 4 inline SVGs, got {svg_count}"
+    assert "wmk-chart--waterfall" in html
     assert "wmk-chart--contributions" in html
     assert "wmk-chart--roi" in html
     assert "wmk-chart--response-curves" in html
@@ -261,6 +263,45 @@ def test_verdict_pill_moderate_when_only_moderates() -> None:
 
     assert "wmk-pill--moderate" in html
     assert "Mixed evidence" in html
+
+
+# ---------------------------------------------------------------------------
+# Contribution waterfall
+# ---------------------------------------------------------------------------
+
+
+def test_waterfall_baseline_derived_from_predictive_minus_media() -> None:
+    """Baseline = sum(in_sample_predictive.mean) − sum(channel contributions).
+
+    Here the predictive mean is 100 per period × 3 periods = 300; channel
+    contribution is 5,000. Negative gap is clamped to 0 in the helper, so
+    the waterfall renders media-only.
+    """
+    summary = _summary(_channel("paid_search", contribution=5000.0))
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card)
+
+    assert 'id="contribution-waterfall"' in html
+    assert "wmk-chart--waterfall" in html
+    # Predicted total (300) < media (5000), so baseline clamps to 0 and the
+    # waterfall shows only the media segment.
+    assert ">Baseline<" not in html
+    # The total label reflects the visible total (just media in this case).
+    assert "Total: 5,000" in html
+
+
+def test_waterfall_includes_baseline_when_predictive_exceeds_media() -> None:
+    """When predictive > media, the baseline segment shows up."""
+    summary = _summary(
+        _channel("paid_search", contribution=200.0),  # tiny media
+        periods=["2024-01-01", "2024-01-08", "2024-01-15"],
+    )
+    # Predictive mean is 100 per period × 3 = 300; media = 200; baseline = 100.
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    html = _render(summary, card)
+
+    assert ">Baseline<" in html
+    assert "Total: 300" in html
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Third slice of the polish-the-reports plan (after the Trust Card one-pager in #83 and per-channel response curves in #84). Adds a horizontal cumulative waterfall that answers "where does the modelled target come from?" — non-media baseline (intercept + controls) plus each channel's contribution = modelled total, drawn as one continuous segmented bar with a total label on the right.

## What's in it

- **Baseline + media segments**: muted-grey baseline followed by primary-blue channel segments, white separators between, channel ranking matches the contribution table below.
- **Top labels** name each segment; **bottom labels** show the numeric contribution. Narrow segments (< 36 px) skip the top label, very narrow ones (< 48 px) skip the bottom label as well, so wide-channel-mix runs don't collide.
- **Total label** ("Total: 24,xxx,xxx") sits at the right end, sized larger so it reads as the headline number.
- **Graceful degradation**: when `in_sample_predictive` is missing or smaller than total media, baseline clamps to 0 and the waterfall renders media-only.
- **Hand-rolled SVG**, byte-deterministic, no new deps. Same conventions as the other chart helpers.

## Where the data comes from

```python
baseline_total = sum(summary.in_sample_predictive.mean) - sum(channel_contributions)
```

This is the modelled non-media baseline over the training period. Subtracting media from the modelled predictive sum cleanly captures "what the target would have been at baseline" (intercept + controls). Negative gaps clamp to 0 so the chart never breaks on poor fits.

## Validation

- **8 new chart-helper tests** in [`test_charts.py`](tests/unit/test_charts.py): one segment per channel + baseline, baseline omitted when zero, total label correctness, drops zero/negative-contribution channels, empty-input handling, negative-baseline handling, deterministic output, segment widths proportional to contribution.
- **2 new showcase integration tests** in [`test_showcase.py`](tests/unit/test_showcase.py): baseline derived correctly when predictive ≤ media (clamps to 0), baseline appears when predictive > media.
- **Existing showcase tests updated** to expect 4 inline SVGs (waterfall + bar + ROI + response curves) and a `contribution-waterfall` section.
- **Full unit suite:** 645 passed (was 635 + 10 new).
- **Lint clean** on all touched Python files.
- **Smoke render:** 24 KB total showcase, 4 inline SVGs, waterfall section with baseline + media segments + total label.

## What's left

- **Side-by-side scenario block polish** — last PR-A piece, smaller than this one.
- **PR-B:** `--export excel` via `openpyxl`.

Each as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)