### PR TITLE
Side-by-side scenario comparison in the HTML showcase

### DIFF
--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -459,13 +459,14 @@ def showcase(
         "--title",
         help="Override the showcase title. Default: 'Wanamaker MMM — <run_id short>'.",
     ),
-    scenario: Path | None = typer.Option(
-        None,
+    scenario: list[Path] = typer.Option(
+        [],
         "--scenario",
         exists=True,
         help=(
-            "Optional plan CSV. When provided, the showcase includes a "
-            "forecast section for that plan."
+            "Optional plan CSV. Pass multiple times to compare plans "
+            "side-by-side; the first plan is treated as the baseline for "
+            "the delta column in the comparison table."
         ),
     ),
     open_browser: bool = typer.Option(
@@ -478,7 +479,8 @@ def showcase(
 
     The showcase bundles the executive summary, channel contributions
     (with credible intervals), ROI table, the Trust Card, and an optional
-    scenario forecast into one file with all CSS and SVG charts inlined.
+    side-by-side forecast comparison (one or more ``--scenario`` plans)
+    into one file with all CSS and SVG charts inlined.
     """
     import webbrowser
     from datetime import datetime
@@ -550,17 +552,20 @@ def showcase(
         paths.data_hash.read_text().strip() if paths.data_hash.exists() else ""
     )
 
-    scenario_forecast = None
-    scenario_plan_name = None
-    if scenario is not None:
+    scenario_forecasts: list[Any] = []
+    scenario_plan_names: list[str] = []
+    if scenario:
         from wanamaker.forecast.posterior_predictive import forecast as run_forecast
 
         plan_engine, _, _, _, run_seed = _load_run_for_forecast(
             artifact_dir, run_id
         )
-        typer.echo(f"Forecasting {scenario} for showcase…")
-        scenario_forecast = run_forecast(summary, scenario, run_seed, plan_engine)
-        scenario_plan_name = Path(scenario).stem
+        for plan_path in scenario:
+            typer.echo(f"Forecasting {plan_path} for showcase…")
+            scenario_forecasts.append(
+                run_forecast(summary, plan_path, run_seed, plan_engine)
+            )
+            scenario_plan_names.append(Path(plan_path).stem)
 
     advisor_lines = _safe_advisor_recommendations(
         summary, spend_by_channel=spend_by_channel,
@@ -578,8 +583,8 @@ def showcase(
         run_fingerprint=run_fingerprint,
         engine_label=engine_label or "(unknown)",
         refresh_diff=refresh_diff,
-        scenario_forecast=scenario_forecast,
-        scenario_plan_name=scenario_plan_name,
+        scenarios=scenario_forecasts,
+        scenario_plan_names=scenario_plan_names,
         advisor_recommendations=advisor_lines,
     )
 
@@ -823,7 +828,7 @@ def run(
         artifact_dir=artifact_dir,
         output=None,
         title=None,
-        scenario=None,
+        scenario=[],
         open_browser=False,
     )
     trust_card(

--- a/src/wanamaker/reports/_charts.py
+++ b/src/wanamaker/reports/_charts.py
@@ -28,6 +28,16 @@ _MODERATE = "#d97706"
 _WEAK = "#dc2626"
 _GRID = "#e2e8f0"
 
+# Distinct lines for overlay charts. First entry is the canonical primary so
+# single-scenario overlays look identical to the legacy one-scenario chart.
+_SCENARIO_PALETTE = (
+    "#2b5876",   # primary deep blue
+    "#c2410c",   # burnt orange
+    "#15803d",   # forest green
+    "#7c3aed",   # violet
+    "#0891b2",   # cyan
+)
+
 # Fonts: stack of system fonts. No external font files.
 _FONT_FAMILY = (
     "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, "
@@ -411,6 +421,173 @@ def scenario_delta_svg(
     )
 
     # Y-axis label.
+    parts.append(
+        f'<text x="{left_pad}" y="{height - 12}" '
+        f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+        f'text-anchor="start">Period</text>'
+    )
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def multi_scenario_overlay_svg(scenarios: Sequence[dict[str, Any]]) -> str:
+    """Overlay 1–N forecast scenarios on a single mean+HDI chart.
+
+    Each scenario dict must include:
+      - ``name``: str (shown in the legend)
+      - ``periods``: list[str]
+      - ``mean``: list[float]
+      - ``hdi_low``: list[float]
+      - ``hdi_high``: list[float]
+
+    All scenarios must share the same period labels in the same order;
+    that's the realistic case for compared plans against the same fitted
+    model. When period lists differ the chart degrades to an empty
+    placeholder rather than guessing alignment.
+
+    Up to ``len(_SCENARIO_PALETTE)`` scenarios get distinct colors;
+    additional ones cycle. With one scenario the result is visually
+    equivalent to ``scenario_delta_svg`` so this helper is safe to use
+    as a drop-in replacement.
+    """
+    if not scenarios:
+        return _empty_chart_svg("No forecast available.")
+
+    # Validate alignment: all scenarios must share identical period labels.
+    base_periods = list(scenarios[0]["periods"])
+    n = len(base_periods)
+    if n == 0:
+        return _empty_chart_svg("No forecast available.")
+    for s in scenarios:
+        if (
+            list(s["periods"]) != base_periods
+            or len(s["mean"]) != n
+            or len(s["hdi_low"]) != n
+            or len(s["hdi_high"]) != n
+        ):
+            return _empty_chart_svg(
+                "Forecast scenarios must share the same period labels."
+            )
+
+    width = 720
+    height = 300
+    top_pad = 56  # extra room for the legend
+    bottom_pad = 48
+    left_pad = 80
+    right_pad = 24
+
+    plot_width = width - left_pad - right_pad
+    plot_height = height - top_pad - bottom_pad
+
+    y_min = min(min(s["hdi_low"]) for s in scenarios)
+    y_max = max(max(s["hdi_high"]) for s in scenarios)
+    if y_max == y_min:
+        y_max = y_min + 1.0
+    y_pad = (y_max - y_min) * 0.05
+    y_min -= y_pad
+    y_max += y_pad
+
+    def x(i: int) -> float:
+        if n == 1:
+            return left_pad + plot_width / 2
+        return left_pad + (i / (n - 1)) * plot_width
+
+    def y(value: float) -> float:
+        return top_pad + (1.0 - (value - y_min) / (y_max - y_min)) * plot_height
+
+    parts: list[str] = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {width} {height}" '
+        f'role="img" '
+        f'aria-label="Forecast comparison across {len(scenarios)} scenario(s)" '
+        f'class="wmk-chart wmk-chart--scenario-overlay">'
+    )
+
+    # Y-axis grid + labels.
+    for frac in (0.0, 0.25, 0.5, 0.75, 1.0):
+        gy = top_pad + (1 - frac) * plot_height
+        gv = y_min + frac * (y_max - y_min)
+        parts.append(
+            f'<line x1="{left_pad}" y1="{gy:.1f}" '
+            f'x2="{left_pad + plot_width}" y2="{gy:.1f}" '
+            f'stroke="{_GRID}" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<text x="{left_pad - 8}" y="{gy + 4:.1f}" '
+            f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="end">{_fmt_int(gv)}</text>'
+        )
+
+    # Legend at the top-left of the plot.
+    legend_y = top_pad - 26
+    legend_x = left_pad
+    for idx, scenario in enumerate(scenarios):
+        color = _SCENARIO_PALETTE[idx % len(_SCENARIO_PALETTE)]
+        # Color swatch
+        parts.append(
+            f'<rect x="{legend_x:.1f}" y="{legend_y:.1f}" '
+            f'width="14" height="3" fill="{color}"/>'
+        )
+        # Label
+        parts.append(
+            f'<text x="{legend_x + 20:.1f}" y="{legend_y + 5:.1f}" '
+            f'fill="{_INK}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="start">{escape(str(scenario["name"]))}</text>'
+        )
+        # Advance: swatch (14) + gap (6) + name width (estimated) + spacing.
+        # Use a heuristic 7 px per char so labels don't collide too often.
+        legend_x += 14 + 6 + 7 * len(str(scenario["name"])) + 18
+
+    # Ribbons first (drawn under the lines), then lines on top.
+    for idx, scenario in enumerate(scenarios):
+        color = _SCENARIO_PALETTE[idx % len(_SCENARIO_PALETTE)]
+        upper = " ".join(
+            f"{x(i):.1f},{y(scenario['hdi_high'][i]):.1f}" for i in range(n)
+        )
+        lower = " ".join(
+            f"{x(i):.1f},{y(scenario['hdi_low'][i]):.1f}"
+            for i in reversed(range(n))
+        )
+        parts.append(
+            f'<polygon points="{upper} {lower}" '
+            f'fill="{color}" fill-opacity="0.15" stroke="none"/>'
+        )
+
+    for idx, scenario in enumerate(scenarios):
+        color = _SCENARIO_PALETTE[idx % len(_SCENARIO_PALETTE)]
+        line_points = " ".join(
+            f"{x(i):.1f},{y(scenario['mean'][i]):.1f}" for i in range(n)
+        )
+        parts.append(
+            f'<polyline points="{line_points}" '
+            f'fill="none" stroke="{color}" stroke-width="2" '
+            f'stroke-linejoin="round"/>'
+        )
+
+    # X-axis: first / midpoint / last period labels.
+    indices = [0, n - 1]
+    if n > 2:
+        indices.insert(1, n // 2)
+    seen = set()
+    for i in indices:
+        if i in seen:
+            continue
+        seen.add(i)
+        label_x = x(i)
+        parts.append(
+            f'<text x="{label_x:.1f}" y="{height - bottom_pad + 18}" '
+            f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '
+            f'text-anchor="middle">{escape(str(base_periods[i]))}</text>'
+        )
+
+    # Axis frame.
+    parts.append(
+        f'<line x1="{left_pad}" y1="{top_pad + plot_height}" '
+        f'x2="{left_pad + plot_width}" y2="{top_pad + plot_height}" '
+        f'stroke="{_MUTED}" stroke-width="1"/>'
+    )
     parts.append(
         f'<text x="{left_pad}" y="{height - 12}" '
         f'fill="{_MUTED}" font-family="{_FONT_FAMILY}" font-size="11" '

--- a/src/wanamaker/reports/showcase.py
+++ b/src/wanamaker/reports/showcase.py
@@ -30,9 +30,9 @@ from wanamaker.refresh.diff import RefreshDiff
 from wanamaker.reports._charts import (
     contribution_bars_svg,
     contribution_waterfall_svg,
+    multi_scenario_overlay_svg,
     response_curves_svg,
     roi_dotplot_svg,
-    scenario_delta_svg,
 )
 from wanamaker.reports.render import (
     build_executive_summary_context,
@@ -158,6 +158,62 @@ def _scenario_block(
     }
 
 
+def _scenarios_block(
+    forecasts: list[ForecastResult],
+    plan_names: list[str],
+) -> dict[str, Any] | None:
+    """Build the multi-scenario context: per-scenario series, comparison table.
+
+    The first entry is treated as the baseline for delta computation in the
+    table; subsequent rows show ``mean_total − baseline_mean_total``. With
+    a single scenario the comparison table just shows that one row and the
+    delta column reads zero.
+    """
+    if not forecasts:
+        return None
+
+    rows: list[dict[str, Any]] = []
+    series: list[dict[str, Any]] = []
+    aggregated_extrap: dict[str, set[str]] = {}
+    for name, forecast in zip(plan_names, forecasts, strict=True):
+        block = _scenario_block(forecast, plan_name=name, baseline_total=None)
+        rows.append(
+            {
+                "plan_name": block["plan_name"],
+                "mean_total": block["mean_total"],
+                "hdi_low_total": block["hdi_low_total"],
+                "hdi_high_total": block["hdi_high_total"],
+                "extrapolation_count": len(block["extrapolation_warnings"]),
+            }
+        )
+        series.append(
+            {
+                "name": block["plan_name"],
+                "periods": block["periods"],
+                "mean": block["mean"],
+                "hdi_low": block["hdi_low"],
+                "hdi_high": block["hdi_high"],
+            }
+        )
+        aggregated_extrap[block["plan_name"]] = set(block["extrapolation_warnings"])
+
+    baseline_mean = rows[0]["mean_total"] if rows else 0.0
+    for row in rows:
+        row["delta_vs_baseline"] = row["mean_total"] - baseline_mean
+
+    # Sorted alphabetically by channel for stable rendering across runs.
+    extrap_summary = sorted({c for cs in aggregated_extrap.values() for c in cs})
+
+    return {
+        "rows": rows,
+        "series": series,
+        "any_extrapolation": bool(extrap_summary),
+        "extrapolation_warnings": extrap_summary,
+        # Convenience for the single-scenario prose paragraph.
+        "single": rows[0] if len(rows) == 1 else None,
+    }
+
+
 def build_showcase_context(
     summary: PosteriorSummary,
     trust_card: TrustCard,
@@ -173,7 +229,8 @@ def build_showcase_context(
     refresh_diff: RefreshDiff | None = None,
     scenario_forecast: ForecastResult | None = None,
     scenario_plan_name: str | None = None,
-    baseline_total: float | None = None,
+    scenarios: Iterable[ForecastResult] | None = None,
+    scenario_plan_names: Iterable[str] | None = None,
     advisor_recommendations: Iterable[str] | None = None,
 ) -> dict[str, Any]:
     """Shape every input the showcase template needs.
@@ -182,6 +239,12 @@ def build_showcase_context(
     fields and trust-card per-channel saturation rendering, then adds the
     showcase-only chrome (verdict pill, decision notes, charts, footer
     metadata).
+
+    Scenario inputs accept either the legacy single-scenario form
+    (``scenario_forecast`` + ``scenario_plan_name``) or a list
+    (``scenarios`` + ``scenario_plan_names``). The two are concatenated;
+    the first entry in the resulting list is treated as the baseline for
+    the comparison table's delta column.
     """
     exec_ctx = build_executive_summary_context(
         summary,
@@ -204,20 +267,28 @@ def build_showcase_context(
         for d in trust_ctx["dimensions"]
     ]
 
-    scenario_block: dict[str, Any] | None = None
-    scenario_chart_svg = ""
+    forecasts_list: list[ForecastResult] = []
+    names_list: list[str] = []
     if scenario_forecast is not None:
-        scenario_block = _scenario_block(
-            scenario_forecast,
-            plan_name=scenario_plan_name or "scenario",
-            baseline_total=baseline_total,
-        )
-        scenario_chart_svg = scenario_delta_svg(
-            scenario_block["periods"],
-            scenario_block["mean"],
-            scenario_block["hdi_low"],
-            scenario_block["hdi_high"],
-        )
+        forecasts_list.append(scenario_forecast)
+        names_list.append(scenario_plan_name or "scenario")
+    if scenarios is not None:
+        extra_forecasts = list(scenarios)
+        extra_names = list(scenario_plan_names) if scenario_plan_names else []
+        if len(extra_names) < len(extra_forecasts):
+            extra_names += [
+                f"scenario_{i + 1 + len(forecasts_list)}"
+                for i in range(len(extra_names), len(extra_forecasts))
+            ]
+        forecasts_list.extend(extra_forecasts)
+        names_list.extend(extra_names[: len(extra_forecasts)])
+
+    scenario_block = _scenarios_block(forecasts_list, names_list)
+    scenario_chart_svg = (
+        multi_scenario_overlay_svg(scenario_block["series"])
+        if scenario_block is not None
+        else ""
+    )
 
     refresh_narrative = (
         _refresh_narrative(refresh_diff) if refresh_diff is not None else None
@@ -226,9 +297,9 @@ def build_showcase_context(
     response_curve_channels = _response_curve_channels(summary, exec_ctx["channels"])
     response_curves_chart_svg = response_curves_svg(response_curve_channels)
 
-    baseline_total = _baseline_total(summary)
+    non_media_baseline = _baseline_total(summary)
     waterfall_chart_svg = contribution_waterfall_svg(
-        baseline_total, exec_ctx["channels"]
+        non_media_baseline, exec_ctx["channels"]
     )
 
     return {

--- a/src/wanamaker/reports/templates/showcase.html.j2
+++ b/src/wanamaker/reports/templates/showcase.html.j2
@@ -167,25 +167,60 @@
 
 {% if scenario %}
 <section id="scenario">
-  <h2>Forecast: {{ scenario.plan_name }}</h2>
+  {% if scenario.single %}
+  <h2>Forecast: {{ scenario.single.plan_name }}</h2>
   <p class="wmk-prose">
     Predicted total over the plan window:
-    <strong>{{ "{:,.0f}".format(scenario.mean_total) }}</strong>
+    <strong>{{ "{:,.0f}".format(scenario.single.mean_total) }}</strong>
     (95% credible interval
-    {{ "{:,.0f}".format(scenario.hdi_low_total) }}–{{ "{:,.0f}".format(scenario.hdi_high_total) }}).
-    {% if scenario.baseline_total is not none %}
-    That is a change of <strong>{{ "{:+,.0f}".format(scenario.delta) }}</strong>
-    versus the baseline plan.
-    {% endif %}
+    {{ "{:,.0f}".format(scenario.single.hdi_low_total) }}–{{ "{:,.0f}".format(scenario.single.hdi_high_total) }}).
   </p>
-  {{ scenario_chart_svg | safe }}
-  {% if scenario.extrapolation_warnings %}
+  {% else %}
+  <h2>Forecast comparison</h2>
   <p class="wmk-prose">
-    <strong>Extrapolation warning:</strong> the following channels exceed the
-    spend range observed during training and the model has no direct
-    evidence at those levels —
+    {{ scenario.rows | length }} plans compared. Delta is each plan's
+    predicted total minus the first plan's predicted total — read it as
+    <em>"how much more (or less) the model expects from this plan,
+    compared with {{ scenario.rows[0].plan_name }}"</em>.
+  </p>
+  {% endif %}
+
+  {{ scenario_chart_svg | safe }}
+
+  <table class="wmk-table">
+    <thead>
+      <tr>
+        <th>Plan</th>
+        <th class="wmk-num">Predicted total</th>
+        <th class="wmk-num">95% credible interval</th>
+        <th class="wmk-num">Δ vs first plan</th>
+        <th class="wmk-num">Extrapolation flags</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for row in scenario.rows %}
+      <tr>
+        <td><code>{{ row.plan_name }}</code></td>
+        <td class="wmk-num">{{ "{:,.0f}".format(row.mean_total) }}</td>
+        <td class="wmk-num">
+          {{ "{:,.0f}".format(row.hdi_low_total) }}–{{ "{:,.0f}".format(row.hdi_high_total) }}
+        </td>
+        <td class="wmk-num">
+          {% if loop.index0 == 0 %}—{% else %}{{ "{:+,.0f}".format(row.delta_vs_baseline) }}{% endif %}
+        </td>
+        <td class="wmk-num">{{ row.extrapolation_count }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  {% if scenario.any_extrapolation %}
+  <p class="wmk-prose">
+    <strong>Extrapolation warning:</strong> one or more plans exceed the
+    spend range observed during training for the following channels —
     {% for w in scenario.extrapolation_warnings %}<code>{{ w }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
-    Treat as a staged-test candidate, not as proof the move is safe.
+    Treat affected rows as staged-test candidates, not as proof the move
+    is safe.
   </p>
   {% endif %}
 </section>

--- a/tests/unit/test_charts.py
+++ b/tests/unit/test_charts.py
@@ -14,6 +14,7 @@ import xml.etree.ElementTree as ET
 from wanamaker.reports._charts import (
     contribution_bars_svg,
     contribution_waterfall_svg,
+    multi_scenario_overlay_svg,
     response_curves_svg,
     roi_dotplot_svg,
     scenario_delta_svg,
@@ -182,6 +183,94 @@ def test_scenario_delta_handles_single_period() -> None:
     )
     # Should still parse; line collapses to a single point but ribbon is valid.
     _parse(svg)
+
+
+# ---------------------------------------------------------------------------
+# multi_scenario_overlay_svg
+# ---------------------------------------------------------------------------
+
+
+def _scenario(name: str, mean_value: float = 1000.0) -> dict:
+    return {
+        "name": name,
+        "periods": ["2026-01-05", "2026-01-12", "2026-01-19"],
+        "mean": [mean_value, mean_value + 100, mean_value + 50],
+        "hdi_low": [mean_value - 100, mean_value, mean_value - 60],
+        "hdi_high": [mean_value + 100, mean_value + 200, mean_value + 160],
+    }
+
+
+def test_multi_scenario_overlay_one_polyline_per_scenario() -> None:
+    scenarios = [_scenario("a"), _scenario("b"), _scenario("c")]
+    svg = multi_scenario_overlay_svg(scenarios)
+    root = _parse(svg)
+
+    polylines = list(root.iter("{http://www.w3.org/2000/svg}polyline"))
+    polygons = list(root.iter("{http://www.w3.org/2000/svg}polygon"))
+    assert len(polylines) == 3
+    assert len(polygons) == 3
+
+
+def test_multi_scenario_overlay_renders_legend_with_each_name() -> None:
+    scenarios = [_scenario("plan_alpha"), _scenario("plan_beta")]
+    svg = multi_scenario_overlay_svg(scenarios)
+
+    assert "plan_alpha" in svg
+    assert "plan_beta" in svg
+
+
+def test_multi_scenario_overlay_uses_distinct_colors_for_first_few_scenarios() -> None:
+    scenarios = [_scenario("a"), _scenario("b")]
+    svg = multi_scenario_overlay_svg(scenarios)
+
+    # The two distinct stroke colors should both appear.
+    assert "#2b5876" in svg  # primary
+    assert "#c2410c" in svg  # second-palette color
+
+
+def test_multi_scenario_overlay_handles_empty_input() -> None:
+    svg = multi_scenario_overlay_svg([])
+    root = _parse(svg)
+    assert root.attrib.get("class", "").endswith("wmk-chart--empty")
+
+
+def test_multi_scenario_overlay_falls_back_on_period_mismatch() -> None:
+    """Different period labels across scenarios -> empty placeholder."""
+    a = _scenario("a")
+    b = _scenario("b")
+    b["periods"] = ["2027-01-05", "2027-01-12", "2027-01-19"]  # different dates
+    svg = multi_scenario_overlay_svg([a, b])
+    root = _parse(svg)
+    assert root.attrib.get("class", "").endswith("wmk-chart--empty")
+    assert "share the same period labels" in svg
+
+
+def test_multi_scenario_overlay_falls_back_on_mismatched_series_lengths() -> None:
+    a = _scenario("a")
+    a["mean"] = [1000.0, 1100.0]  # mismatched length vs periods (which has 3)
+    svg = multi_scenario_overlay_svg([a])
+    root = _parse(svg)
+    assert root.attrib.get("class", "").endswith("wmk-chart--empty")
+
+
+def test_multi_scenario_overlay_is_deterministic() -> None:
+    scenarios = [_scenario("a"), _scenario("b")]
+    assert multi_scenario_overlay_svg(scenarios) == multi_scenario_overlay_svg(
+        scenarios
+    )
+
+
+def test_multi_scenario_overlay_handles_single_scenario_like_legacy() -> None:
+    """N=1 should still produce a usable chart (drop-in replacement for the
+    old single-scenario chart)."""
+    svg = multi_scenario_overlay_svg([_scenario("solo")])
+    root = _parse(svg)
+
+    polylines = list(root.iter("{http://www.w3.org/2000/svg}polyline"))
+    polygons = list(root.iter("{http://www.w3.org/2000/svg}polygon"))
+    assert len(polylines) == 1
+    assert len(polygons) == 1
+    assert "solo" in svg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_showcase.py
+++ b/tests/unit/test_showcase.py
@@ -396,10 +396,91 @@ def test_scenario_section_appears_when_forecast_supplied() -> None:
     )
 
     assert 'id="scenario"' in html
-    assert "wmk-chart--scenario" in html
+    assert "wmk-chart--scenario-overlay" in html
     assert "q1_plan" in html
     assert "Extrapolation warning" in html
     assert "paid_search" in html
+
+
+def test_multiple_scenarios_render_comparison_table_and_overlay() -> None:
+    """Two scenarios: overlay chart + table with deltas vs the first plan."""
+    summary = _summary(
+        _channel("paid_search", spend_min=100.0, spend_max=500.0)
+    )
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    periods = ["2026-01-05", "2026-01-12", "2026-01-19"]
+    baseline = ForecastResult(
+        periods=periods,
+        mean=[1000.0, 1100.0, 1050.0],
+        hdi_low=[900.0, 980.0, 940.0],
+        hdi_high=[1100.0, 1220.0, 1160.0],
+        extrapolation_flags=[],
+        spend_invariant_channels=[],
+    )
+    alternative = ForecastResult(
+        periods=periods,
+        mean=[1100.0, 1200.0, 1150.0],
+        hdi_low=[1000.0, 1080.0, 1040.0],
+        hdi_high=[1200.0, 1320.0, 1260.0],
+        extrapolation_flags=[],
+        spend_invariant_channels=[],
+    )
+    html = _render(
+        summary,
+        card,
+        scenarios=[baseline, alternative],
+        scenario_plan_names=["base", "alt"],
+    )
+
+    assert 'id="scenario"' in html
+    assert "wmk-chart--scenario-overlay" in html
+    # Both plans appear in the legend / table.
+    assert "base" in html
+    assert "alt" in html
+    # Comparison table is present with both rows.
+    assert "Predicted total" in html
+    assert "Δ vs first plan" in html
+    # Delta for the second row is +300 (3300 alt total − 3150 baseline total).
+    assert "+300" in html or "+ 300" in html
+
+
+def test_legacy_and_new_scenario_apis_can_be_combined() -> None:
+    """Passing scenario_forecast (legacy) and scenarios= (new) concatenates them.
+
+    The legacy entry comes first and acts as the baseline for the delta
+    column, matching the documented "first plan = baseline" rule.
+    """
+    summary = _summary(
+        _channel("paid_search", spend_min=100.0, spend_max=500.0)
+    )
+    card = _card(("convergence", TrustStatus.PASS, "OK."))
+    periods = ["2026-01-05", "2026-01-12"]
+
+    def fr(mean: float) -> ForecastResult:
+        return ForecastResult(
+            periods=periods,
+            mean=[mean, mean],
+            hdi_low=[mean - 100, mean - 100],
+            hdi_high=[mean + 100, mean + 100],
+            extrapolation_flags=[],
+            spend_invariant_channels=[],
+        )
+
+    html = _render(
+        summary,
+        card,
+        scenario_forecast=fr(1000),
+        scenario_plan_name="legacy_first",
+        scenarios=[fr(1200)],
+        scenario_plan_names=["new_second"],
+    )
+
+    assert "legacy_first" in html
+    assert "new_second" in html
+    # Legacy shows up first; "Δ vs first plan" reads against it.
+    legacy_idx = html.index("legacy_first")
+    new_idx = html.index("new_second")
+    assert legacy_idx < new_idx
 
 
 def test_refresh_section_appears_when_diff_supplied() -> None:


### PR DESCRIPTION
## Summary

Final slice of PR-A from the polish-the-reports plan (after #83 one-pager, #84 response curves, #91 waterfall). The showcase now accepts multiple `--scenario` plans and renders them overlaid on a single mean+HDI chart with a legend, plus a comparison table showing each plan's predicted total, 95% credible interval, delta vs. the first plan, and per-plan extrapolation-flag counts.

The existing `compare-scenarios` Markdown command already answered "rank these plans" — this closes the visual gap so a CMO seeing the showcase can compare two or three budget mixes at a glance.

## Behaviour

```bash
wanamaker showcase --run-id <id> --scenario base.csv --scenario alt.csv --scenario aggressive.csv
```

- N=1: prose paragraph + chart + 1-row comparison table (visually identical to the previous single-scenario rendering, just with a slightly nicer table beneath).
- N≥2: comparison heading + overlaid lines + ribbons + multi-row table with delta column.
- All scenarios must share the same period labels — different plans against the same fitted model already do, so this is a non-issue in practice. Mismatched periods fall back to an empty placeholder rather than guessing alignment.

## Implementation

- **New chart helper:** `multi_scenario_overlay_svg(scenarios)` in [`_charts.py`](src/wanamaker/reports/_charts.py). Uses a 5-color palette so first 5 plans are visually distinct; ribbons render at 0.15 fill-opacity so overlap stays readable.
- **Context shaper:** `build_showcase_context` accepts `scenarios=[ForecastResult, ...]` and `scenario_plan_names=[...]` alongside the legacy `scenario_forecast=` / `scenario_plan_name=` API. Both are concatenated; the first scenario in the result is the baseline for the delta column.
- **Template:** scenario section gets a prose paragraph for N=1, a comparison heading for N≥2, and an always-rendered table.
- **CLI:** `--scenario` is now repeatable (`list[Path]` with default `[]`).

## Validation

- **8 new chart tests** in [`test_charts.py`](tests/unit/test_charts.py): one polyline + one polygon per scenario, distinct colors for first few scenarios, legend includes each name, period-mismatch fallback, mismatched-series-length fallback, deterministic output, single-scenario equivalence.
- **2 new showcase integration tests** in [`test_showcase.py`](tests/unit/test_showcase.py): multi-scenario rendering produces overlay + comparison table with deltas, legacy + new API can be combined cleanly.
- **Existing single-scenario test updated** for the new chart class name (`wmk-chart--scenario-overlay` instead of the old `wmk-chart--scenario`).
- **Full unit suite:** 655 passed (was 645 + 10 new).
- **Lint clean** on all touched files.
- **Smoke render:** 23 KB, 5 inline SVGs, three scenario polylines, comparison table with deltas.

## Test plan

- [ ] `wanamaker showcase --run-id <id> --scenario base.csv --scenario alt.csv` renders both
- [ ] `wanamaker run --example public_benchmark` still produces a single-scenario-free showcase identically
- [ ] Open multi-scenario showcase in browser and email-preview to confirm the overlay reads cleanly

## What's done in PR-A and what's next

PR-A is complete:
- ✅ #83 Trust Card one-pager
- ✅ #84 per-channel response curves
- ✅ #91 contribution waterfall
- ✅ This PR: side-by-side scenario comparison

PR-B comes next: `--export excel` via `openpyxl` (channel contributions, ROI, scenario tables exported as a workbook). Smaller, single new dep, pure-Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)