### PR TITLE
Add `wanamaker export --format excel` for analyst workbooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "jinja2>=3.1",
     "matplotlib>=3.8",
     "seaborn>=0.13",
+    "openpyxl>=3.1",
 ]
 
 [project.optional-dependencies]

--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -7,6 +7,7 @@ Core commands per FR-6.3 plus the HTML showcase:
     wanamaker report --run-id <run_id>
     wanamaker showcase --run-id <run_id>
     wanamaker trust-card --run-id <run_id>
+    wanamaker export --run-id <run_id> --format excel
     wanamaker forecast --run-id <run_id> --plan <plan.csv>
     wanamaker compare-scenarios --run-id <run_id> --plans <p1.csv> <p2.csv> ...
     wanamaker recommend-ramp --run-id <run_id> --baseline <base.csv> --target <alt.csv>
@@ -714,6 +715,165 @@ def trust_card(
         webbrowser.open(output_path.resolve().as_uri())
 
 
+@app.command()
+def export(
+    run_id: str = typer.Option(..., "--run-id"),
+    format: str = typer.Option(  # noqa: A002 — CLI flag name is "format"
+        "excel",
+        "--format",
+        help=(
+            "Export format. Currently 'excel' (.xlsx). PDF and PowerPoint "
+            "are not supported in this release; use the browser print path "
+            "from the showcase HTML for PDF."
+        ),
+    ),
+    artifact_dir: Path = typer.Option(
+        Path(".wanamaker"),
+        "--artifact-dir",
+        help="Root of the runs directory (default: .wanamaker).",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        help="Path to save the export. Default: <run_dir>/summary.xlsx.",
+    ),
+    scenario: list[Path] = typer.Option(
+        [],
+        "--scenario",
+        exists=True,
+        help=(
+            "Optional plan CSV to forecast and include as a row in the "
+            "Scenarios sheet. Pass multiple times to compare plans."
+        ),
+    ),
+) -> None:
+    """Export a run's structured tables to an analyst-friendly Excel workbook.
+
+    Sheets produced: Summary, Channels, Trust Card, Parameters, optional
+    Refresh diff, optional Scenarios. Values are stored as numbers (not
+    formatted strings) so analysts can pivot and compute on them
+    directly.
+    """
+    from datetime import datetime, timezone
+
+    from wanamaker import __version__
+    from wanamaker.artifacts import (
+        deserialize_refresh_diff,
+        deserialize_summary,
+        load_manifest,
+        run_paths,
+    )
+    from wanamaker.config import load_config
+    from wanamaker.reports import WorkbookMetadata, write_excel_workbook
+    from wanamaker.trust_card.compute import build_trust_card
+
+    if format != "excel":
+        typer.echo(
+            typer.style(
+                f"Error: --format {format!r} is not supported in this release. "
+                "Currently only 'excel' is implemented.",
+                fg=typer.colors.RED,
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    paths = run_paths(artifact_dir, run_id)
+    if not paths.config.exists():
+        typer.echo(
+            typer.style(
+                f"Error: run {run_id!r} not found in {artifact_dir / 'runs'}. "
+                "Run 'wanamaker fit' first or check --artifact-dir.",
+                fg=typer.colors.RED,
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if not paths.summary.exists():
+        typer.echo(
+            typer.style(
+                f"Error: summary.json missing for run {run_id!r} at {paths.summary}.",
+                fg=typer.colors.RED,
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    summary = deserialize_summary(paths.summary.read_text())
+
+    refresh_diff = None
+    if paths.refresh_diff.exists():
+        refresh_diff = deserialize_refresh_diff(paths.refresh_diff.read_text())
+
+    cfg = load_config(paths.config)
+    lift_test_priors = _load_lift_priors_if_any(cfg)
+    card = build_trust_card(
+        summary,
+        refresh_diff=refresh_diff,
+        lift_test_priors=lift_test_priors,
+    )
+
+    runtime_mode = cfg.run.runtime_mode
+    run_fingerprint = ""
+    engine_label = "(unknown)"
+    if paths.manifest.exists():
+        try:
+            manifest = load_manifest(paths.manifest.read_text())
+            run_fingerprint = str(manifest.get("run_fingerprint", ""))
+            engine = manifest.get("engine", {}) or {}
+            engine_label = (
+                f"{engine.get('name', '?')} {engine.get('version', '?')}"
+            )
+        except ValueError:
+            engine_label = "(unknown)"
+
+    if summary.in_sample_predictive and summary.in_sample_predictive.periods:
+        periods = summary.in_sample_predictive.periods
+        period_start, period_end = str(periods[0]), str(periods[-1])
+        n_periods = len(periods)
+    else:
+        period_start, period_end, n_periods = "unknown", "unknown", 0
+
+    metadata = WorkbookMetadata(
+        run_id=run_id,
+        period_start=period_start,
+        period_end=period_end,
+        n_periods=n_periods,
+        generated_at=datetime.now(timezone.utc),
+        package_version=__version__,
+        runtime_mode=runtime_mode,
+        engine_label=engine_label,
+        run_fingerprint=run_fingerprint,
+    )
+
+    scenario_forecasts: list[Any] = []
+    scenario_plan_names: list[str] = []
+    if scenario:
+        from wanamaker.forecast.posterior_predictive import forecast as run_forecast
+
+        plan_engine, _, _, _, run_seed = _load_run_for_forecast(
+            artifact_dir, run_id
+        )
+        for plan_path in scenario:
+            typer.echo(f"Forecasting {plan_path} for export…")
+            scenario_forecasts.append(
+                run_forecast(summary, plan_path, run_seed, plan_engine)
+            )
+            scenario_plan_names.append(Path(plan_path).stem)
+
+    output_path = output if output is not None else paths.root / "summary.xlsx"
+    write_excel_workbook(
+        summary,
+        card,
+        output=output_path,
+        metadata=metadata,
+        refresh_diff=refresh_diff,
+        scenarios=scenario_forecasts or None,
+        scenario_plan_names=scenario_plan_names or None,
+    )
+    typer.echo(typer.style(f"Workbook saved: {output_path}", fg=typer.colors.GREEN))
+
+
 _RUN_EXAMPLES: tuple[str, ...] = ("public_benchmark",)
 
 
@@ -837,6 +997,13 @@ def run(
         output=None,
         title=None,
         open_browser=False,
+    )
+    export(
+        run_id=run_id,
+        format="excel",
+        artifact_dir=artifact_dir,
+        output=None,
+        scenario=[],
     )
     typer.echo("")
 

--- a/src/wanamaker/reports/__init__.py
+++ b/src/wanamaker/reports/__init__.py
@@ -11,6 +11,11 @@ an LLM.
 Templates ship inside this subpackage so the package is self-contained.
 """
 
+from wanamaker.reports.excel import (
+    WorkbookMetadata,
+    build_excel_workbook,
+    write_excel_workbook,
+)
 from wanamaker.reports.render import (
     build_executive_summary_context,
     build_ramp_recommendation_context,
@@ -26,6 +31,8 @@ from wanamaker.reports.trust_card_one_pager import (
 )
 
 __all__ = [
+    "WorkbookMetadata",
+    "build_excel_workbook",
     "build_executive_summary_context",
     "build_ramp_recommendation_context",
     "build_showcase_context",
@@ -36,4 +43,5 @@ __all__ = [
     "render_showcase",
     "render_trust_card",
     "render_trust_card_one_pager",
+    "write_excel_workbook",
 ]

--- a/src/wanamaker/reports/excel.py
+++ b/src/wanamaker/reports/excel.py
@@ -1,0 +1,383 @@
+"""Excel workbook export — analyst-facing structured tables.
+
+The HTML showcase and Markdown report are designed for *reading*; the
+Excel workbook is designed for *slicing*. Analysts often want to pivot
+channel contributions, plug ROI estimates into their own spreadsheets,
+or attach a structured table to a board deck. The workbook gives them
+that without re-typing.
+
+Per AGENTS.md Hard Rule 2: **no LLM calls for output generation**, ever.
+The workbook is built from the same posterior summary the other
+report surfaces consume.
+
+Public surface:
+
+- ``build_excel_workbook`` — turn ``PosteriorSummary`` + ``TrustCard``
+  (plus optional run metadata, refresh diff, scenario forecasts) into
+  an in-memory ``openpyxl.Workbook`` ready to be saved.
+- ``write_excel_workbook`` — convenience wrapper that builds and saves
+  to a path in one call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from openpyxl.workbook import Workbook
+
+from wanamaker.engine.summary import PosteriorSummary
+from wanamaker.forecast.posterior_predictive import ForecastResult
+from wanamaker.refresh.diff import RefreshDiff
+from wanamaker.trust_card.card import TrustCard, TrustStatus
+
+
+@dataclass(frozen=True)
+class WorkbookMetadata:
+    """Run-level metadata included in the Summary sheet header."""
+
+    run_id: str
+    period_start: str
+    period_end: str
+    n_periods: int
+    generated_at: datetime
+    package_version: str
+    runtime_mode: str = "(unknown)"
+    engine_label: str = "(unknown)"
+    run_fingerprint: str = ""
+
+
+_HEADER_FILL = "EEF4F8"
+_HEADER_FONT_BOLD = True
+
+
+def _bold(cell: Any) -> None:
+    from openpyxl.styles import Font
+
+    cell.font = Font(bold=True)
+
+
+def _autosize_columns(ws: Any) -> None:
+    """Pick a sensible column width so the workbook opens readable.
+
+    openpyxl doesn't auto-size; we estimate the max content width per
+    column and clamp to ``[10, 60]`` characters.
+    """
+    for column_cells in ws.columns:
+        if not column_cells:
+            continue
+        column_letter = column_cells[0].column_letter
+        longest = 0
+        for cell in column_cells:
+            value = cell.value
+            if value is None:
+                continue
+            length = len(str(value))
+            if length > longest:
+                longest = length
+        ws.column_dimensions[column_letter].width = min(max(longest + 2, 10), 60)
+
+
+def _verdict_label(card: TrustCard) -> str:
+    """Worst-dimension verdict, mirroring the showcase pill logic."""
+    if not card.dimensions:
+        return "no verdict"
+    statuses = {d.status for d in card.dimensions}
+    if TrustStatus.WEAK in statuses:
+        return "weak"
+    if TrustStatus.MODERATE in statuses:
+        return "moderate"
+    return "pass"
+
+
+def _write_summary_sheet(
+    wb: Workbook,
+    summary: PosteriorSummary,
+    trust_card: TrustCard,
+    metadata: WorkbookMetadata,
+) -> None:
+    ws = wb.active
+    ws.title = "Summary"
+
+    rows: list[tuple[str, Any]] = [
+        ("Wanamaker MMM Summary", ""),
+        ("", ""),
+        ("Run ID", metadata.run_id),
+        ("Run fingerprint", metadata.run_fingerprint or "—"),
+        ("Period", f"{metadata.period_start} – {metadata.period_end}"),
+        ("Periods covered", metadata.n_periods),
+        (
+            "Generated (UTC)",
+            metadata.generated_at.strftime("%Y-%m-%d %H:%M"),
+        ),
+        ("Engine", metadata.engine_label),
+        ("Runtime", metadata.runtime_mode),
+        ("Package version", metadata.package_version),
+        ("", ""),
+    ]
+
+    total_media = sum(c.mean_contribution for c in summary.channel_contributions)
+    rows.extend([
+        ("Total media contribution", float(total_media)),
+        ("Trust Card verdict", _verdict_label(trust_card)),
+    ])
+    if summary.channel_contributions:
+        ranked = sorted(
+            summary.channel_contributions,
+            key=lambda c: c.mean_contribution,
+            reverse=True,
+        )
+        top = ranked[0]
+        rows.append((
+            "Top channel by contribution",
+            f"{top.channel} ({top.mean_contribution / total_media:.0%} of media)"
+            if total_media > 0
+            else top.channel,
+        ))
+
+    for idx, (label, value) in enumerate(rows, start=1):
+        ws.cell(row=idx, column=1, value=label)
+        ws.cell(row=idx, column=2, value=value)
+        # Bold either the title row (row 1) or any labeled metadata row from
+        # row 3 onwards; row 2 is intentionally a blank spacer.
+        if label and ((not value and idx == 1) or idx >= 3):
+            _bold(ws.cell(row=idx, column=1))
+
+    _autosize_columns(ws)
+
+
+def _write_channels_sheet(wb: Workbook, summary: PosteriorSummary) -> None:
+    ws = wb.create_sheet("Channels")
+
+    headers = [
+        "Channel",
+        "Mean contribution",
+        "HDI low",
+        "HDI high",
+        "Share of media",
+        "ROI (mean)",
+        "ROI HDI low",
+        "ROI HDI high",
+        "Spend min (observed)",
+        "Spend max (observed)",
+        "Spend invariant",
+    ]
+    for col, header in enumerate(headers, start=1):
+        cell = ws.cell(row=1, column=col, value=header)
+        _bold(cell)
+
+    total_media = sum(c.mean_contribution for c in summary.channel_contributions)
+    ranked = sorted(
+        summary.channel_contributions,
+        key=lambda c: c.mean_contribution,
+        reverse=True,
+    )
+    for r, channel in enumerate(ranked, start=2):
+        share = (
+            channel.mean_contribution / total_media if total_media > 0 else 0.0
+        )
+        values = [
+            channel.channel,
+            float(channel.mean_contribution),
+            float(channel.hdi_low),
+            float(channel.hdi_high),
+            float(share),
+            float(channel.roi_mean) if not channel.spend_invariant else None,
+            float(channel.roi_hdi_low) if not channel.spend_invariant else None,
+            float(channel.roi_hdi_high) if not channel.spend_invariant else None,
+            float(channel.observed_spend_min),
+            float(channel.observed_spend_max),
+            "yes" if channel.spend_invariant else "no",
+        ]
+        for col, value in enumerate(values, start=1):
+            ws.cell(row=r, column=col, value=value)
+
+    _autosize_columns(ws)
+
+
+def _write_trust_card_sheet(wb: Workbook, trust_card: TrustCard) -> None:
+    ws = wb.create_sheet("Trust Card")
+
+    headers = ["Dimension", "Status", "Explanation"]
+    for col, header in enumerate(headers, start=1):
+        cell = ws.cell(row=1, column=col, value=header)
+        _bold(cell)
+
+    if not trust_card.dimensions:
+        ws.cell(row=2, column=1, value="(no dimensions computed)")
+        _autosize_columns(ws)
+        return
+
+    for r, dim in enumerate(trust_card.dimensions, start=2):
+        ws.cell(row=r, column=1, value=dim.name)
+        ws.cell(row=r, column=2, value=dim.status.value)
+        ws.cell(row=r, column=3, value=dim.explanation)
+
+    _autosize_columns(ws)
+
+
+def _write_parameters_sheet(wb: Workbook, summary: PosteriorSummary) -> None:
+    if not summary.parameters:
+        return
+    ws = wb.create_sheet("Parameters")
+
+    headers = ["Parameter", "Mean", "SD", "HDI low", "HDI high", "R-hat", "ESS bulk"]
+    for col, header in enumerate(headers, start=1):
+        cell = ws.cell(row=1, column=col, value=header)
+        _bold(cell)
+
+    for r, param in enumerate(summary.parameters, start=2):
+        ws.cell(row=r, column=1, value=param.name)
+        ws.cell(row=r, column=2, value=float(param.mean))
+        ws.cell(row=r, column=3, value=float(param.sd))
+        ws.cell(row=r, column=4, value=float(param.hdi_low))
+        ws.cell(row=r, column=5, value=float(param.hdi_high))
+        ws.cell(row=r, column=6, value=float(param.r_hat) if param.r_hat is not None else None)
+        ws.cell(
+            row=r, column=7,
+            value=float(param.ess_bulk) if param.ess_bulk is not None else None,
+        )
+
+    _autosize_columns(ws)
+
+
+def _write_refresh_sheet(wb: Workbook, refresh_diff: RefreshDiff) -> None:
+    ws = wb.create_sheet("Refresh diff")
+
+    headers = [
+        "Parameter",
+        "Previous mean",
+        "Current mean",
+        "Previous CI low",
+        "Previous CI high",
+        "Current CI low",
+        "Current CI high",
+        "Movement class",
+    ]
+    for col, header in enumerate(headers, start=1):
+        cell = ws.cell(row=1, column=col, value=header)
+        _bold(cell)
+
+    for r, m in enumerate(refresh_diff.movements, start=2):
+        ws.cell(row=r, column=1, value=m.name)
+        ws.cell(row=r, column=2, value=float(m.previous_mean))
+        ws.cell(row=r, column=3, value=float(m.current_mean))
+        ws.cell(row=r, column=4, value=float(m.previous_ci[0]))
+        ws.cell(row=r, column=5, value=float(m.previous_ci[1]))
+        ws.cell(row=r, column=6, value=float(m.current_ci[0]))
+        ws.cell(row=r, column=7, value=float(m.current_ci[1]))
+        ws.cell(
+            row=r, column=8,
+            value=m.movement_class.value if m.movement_class is not None else "",
+        )
+
+    _autosize_columns(ws)
+
+
+def _write_scenarios_sheet(
+    wb: Workbook,
+    forecasts: list[ForecastResult],
+    plan_names: list[str],
+) -> None:
+    if not forecasts:
+        return
+    ws = wb.create_sheet("Scenarios")
+
+    headers = [
+        "Plan",
+        "Predicted total",
+        "Total HDI low",
+        "Total HDI high",
+        "Δ vs first plan",
+        "Extrapolation flags",
+    ]
+    for col, header in enumerate(headers, start=1):
+        cell = ws.cell(row=1, column=col, value=header)
+        _bold(cell)
+
+    means = [float(sum(f.mean)) for f in forecasts]
+    baseline_total = means[0] if means else 0.0
+    for r, (name, forecast, mean_total) in enumerate(
+        zip(plan_names, forecasts, means, strict=True), start=2,
+    ):
+        ws.cell(row=r, column=1, value=name)
+        ws.cell(row=r, column=2, value=mean_total)
+        ws.cell(row=r, column=3, value=float(sum(forecast.hdi_low)))
+        ws.cell(row=r, column=4, value=float(sum(forecast.hdi_high)))
+        ws.cell(
+            row=r, column=5,
+            value=mean_total - baseline_total if r > 2 else 0.0,
+        )
+        ws.cell(row=r, column=6, value=len(forecast.extrapolation_flags))
+
+    _autosize_columns(ws)
+
+
+def build_excel_workbook(
+    summary: PosteriorSummary,
+    trust_card: TrustCard,
+    *,
+    metadata: WorkbookMetadata,
+    refresh_diff: RefreshDiff | None = None,
+    scenarios: list[ForecastResult] | None = None,
+    scenario_plan_names: list[str] | None = None,
+) -> Workbook:
+    """Build the analyst-facing Excel workbook in memory.
+
+    Sheets:
+    - **Summary** — run metadata, headline numbers, Trust Card verdict.
+    - **Channels** — one row per channel with contribution + ROI + observed
+      spend range + spend-invariant flag, ranked by mean contribution.
+    - **Trust Card** — one row per dimension (name, status, explanation).
+    - **Parameters** — one row per posterior parameter (mean, SD, HDI,
+      R-hat, ESS bulk). Skipped when no parameters are available.
+    - **Refresh diff** — one row per parameter movement (only when a
+      refresh diff is supplied).
+    - **Scenarios** — one row per forecast (only when scenarios are
+      supplied), with delta vs the first plan.
+
+    Returns the in-memory ``Workbook``; pair with ``Workbook.save(path)``
+    or use ``write_excel_workbook`` to combine in one call.
+    """
+    from openpyxl import Workbook as _Workbook
+
+    wb = _Workbook()
+    _write_summary_sheet(wb, summary, trust_card, metadata)
+    _write_channels_sheet(wb, summary)
+    _write_trust_card_sheet(wb, trust_card)
+    _write_parameters_sheet(wb, summary)
+    if refresh_diff is not None:
+        _write_refresh_sheet(wb, refresh_diff)
+    if scenarios:
+        names = list(scenario_plan_names) if scenario_plan_names else []
+        if len(names) < len(scenarios):
+            names += [f"scenario_{i + 1}" for i in range(len(names), len(scenarios))]
+        _write_scenarios_sheet(wb, list(scenarios), names[: len(scenarios)])
+    return wb
+
+
+def write_excel_workbook(
+    summary: PosteriorSummary,
+    trust_card: TrustCard,
+    *,
+    output: Path,
+    metadata: WorkbookMetadata,
+    refresh_diff: RefreshDiff | None = None,
+    scenarios: list[ForecastResult] | None = None,
+    scenario_plan_names: list[str] | None = None,
+) -> Path:
+    """Build the workbook and save it to ``output``. Returns ``output``."""
+    wb = build_excel_workbook(
+        summary,
+        trust_card,
+        metadata=metadata,
+        refresh_diff=refresh_diff,
+        scenarios=scenarios,
+        scenario_plan_names=scenario_plan_names,
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    wb.save(output)
+    return output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -22,6 +22,7 @@ def test_help_lists_public_commands() -> None:
         "report",
         "showcase",
         "trust-card",
+        "export",
         "run",
         "forecast",
         "compare-scenarios",

--- a/tests/unit/test_excel_export.py
+++ b/tests/unit/test_excel_export.py
@@ -1,0 +1,372 @@
+"""Tests for the analyst-facing Excel workbook export.
+
+These cover the structural promises of the workbook: which sheets are
+present, that headline numbers match the inputs (channel contributions,
+ROI, total media), that spend-invariant channels are flagged, that
+optional sheets (Refresh diff, Scenarios) only appear when their inputs
+are supplied, and that the file can be round-tripped via openpyxl.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    ConvergenceSummary,
+    ParameterSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+from wanamaker.forecast.posterior_predictive import (
+    ExtrapolationFlag,
+    ForecastResult,
+)
+from wanamaker.refresh.classify import MovementClass
+from wanamaker.refresh.diff import ParameterMovement, RefreshDiff
+from wanamaker.reports import (
+    WorkbookMetadata,
+    build_excel_workbook,
+    write_excel_workbook,
+)
+from wanamaker.trust_card.card import TrustCard, TrustDimension, TrustStatus
+
+
+def _channel(
+    name: str,
+    *,
+    contribution: float = 5000.0,
+    spend_invariant: bool = False,
+    roi_mean: float = 2.0,
+) -> ChannelContributionSummary:
+    return ChannelContributionSummary(
+        channel=name,
+        mean_contribution=contribution,
+        hdi_low=contribution * 0.9,
+        hdi_high=contribution * 1.1,
+        roi_mean=roi_mean,
+        roi_hdi_low=roi_mean * 0.8,
+        roi_hdi_high=roi_mean * 1.2,
+        observed_spend_min=100.0,
+        observed_spend_max=500.0,
+        spend_invariant=spend_invariant,
+    )
+
+
+def _summary(
+    *channels: ChannelContributionSummary,
+    parameters: list[ParameterSummary] | None = None,
+) -> PosteriorSummary:
+    return PosteriorSummary(
+        parameters=list(parameters) if parameters else [],
+        channel_contributions=list(channels),
+        convergence=ConvergenceSummary(
+            max_r_hat=1.005,
+            min_ess_bulk=500.0,
+            n_divergences=0,
+            n_chains=4,
+            n_draws=1000,
+        ),
+        in_sample_predictive=PredictiveSummary(
+            periods=["2024-01-01", "2024-06-01", "2024-12-31"],
+            mean=[100.0, 100.0, 100.0],
+            hdi_low=[90.0, 90.0, 90.0],
+            hdi_high=[110.0, 110.0, 110.0],
+        ),
+    )
+
+
+def _card(*dims: tuple[str, TrustStatus, str]) -> TrustCard:
+    return TrustCard(
+        dimensions=[
+            TrustDimension(name=name, status=status, explanation=expl)
+            for (name, status, expl) in dims
+        ]
+    )
+
+
+def _metadata() -> WorkbookMetadata:
+    return WorkbookMetadata(
+        run_id="abc12345_20260101T000000Z",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        n_periods=52,
+        generated_at=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        package_version="0.1.0",
+        runtime_mode="quick",
+        engine_label="pymc 5.10.0",
+        run_fingerprint="abc12345def67890",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sheet presence
+# ---------------------------------------------------------------------------
+
+
+def test_default_workbook_has_summary_channels_trust_card_sheets() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "Clean."))
+
+    wb = build_excel_workbook(summary, card, metadata=_metadata())
+    assert wb.sheetnames == ["Summary", "Channels", "Trust Card"]
+
+
+def test_parameters_sheet_appears_when_parameters_present() -> None:
+    summary = _summary(
+        _channel("paid_search"),
+        parameters=[
+            ParameterSummary(
+                name="channel.paid_search.ec50",
+                mean=3000.0,
+                sd=200.0,
+                hdi_low=2600.0,
+                hdi_high=3400.0,
+                r_hat=1.001,
+                ess_bulk=950.0,
+            ),
+        ],
+    )
+    card = _card(("convergence", TrustStatus.PASS, "Clean."))
+
+    wb = build_excel_workbook(summary, card, metadata=_metadata())
+    assert "Parameters" in wb.sheetnames
+
+
+def test_refresh_sheet_appears_only_when_diff_supplied() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "Clean."))
+    diff = RefreshDiff(
+        previous_run_id="prev",
+        current_run_id="curr",
+        movements=[
+            ParameterMovement(
+                name="channel.paid_search.roi",
+                previous_mean=2.0,
+                current_mean=2.05,
+                previous_ci=(1.8, 2.2),
+                current_ci=(1.85, 2.25),
+                movement_class=MovementClass.WITHIN_PRIOR_CI,
+            ),
+        ],
+    )
+
+    wb_no_diff = build_excel_workbook(summary, card, metadata=_metadata())
+    wb_with_diff = build_excel_workbook(
+        summary, card, metadata=_metadata(), refresh_diff=diff
+    )
+
+    assert "Refresh diff" not in wb_no_diff.sheetnames
+    assert "Refresh diff" in wb_with_diff.sheetnames
+
+
+def test_scenarios_sheet_appears_only_when_scenarios_supplied() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "Clean."))
+    forecast = ForecastResult(
+        periods=["2026-01-05", "2026-01-12"],
+        mean=[1000.0, 1100.0],
+        hdi_low=[900.0, 980.0],
+        hdi_high=[1100.0, 1220.0],
+        extrapolation_flags=[],
+        spend_invariant_channels=[],
+    )
+
+    wb_no = build_excel_workbook(summary, card, metadata=_metadata())
+    wb_yes = build_excel_workbook(
+        summary,
+        card,
+        metadata=_metadata(),
+        scenarios=[forecast],
+        scenario_plan_names=["q1_plan"],
+    )
+
+    assert "Scenarios" not in wb_no.sheetnames
+    assert "Scenarios" in wb_yes.sheetnames
+
+
+# ---------------------------------------------------------------------------
+# Channel sheet content
+# ---------------------------------------------------------------------------
+
+
+def test_channels_sheet_one_row_per_channel_ranked_by_contribution() -> None:
+    summary = _summary(
+        _channel("small", contribution=1000.0),
+        _channel("big", contribution=10_000.0),
+        _channel("middle", contribution=5000.0),
+    )
+    card = _card()
+
+    wb = build_excel_workbook(summary, card, metadata=_metadata())
+    ws = wb["Channels"]
+
+    # Header + 3 rows.
+    rows = list(ws.iter_rows(values_only=True))
+    assert len(rows) == 4
+    assert rows[0][0] == "Channel"
+    assert rows[1][0] == "big"
+    assert rows[2][0] == "middle"
+    assert rows[3][0] == "small"
+
+
+def test_channels_sheet_marks_spend_invariant() -> None:
+    summary = _summary(
+        _channel("active"),
+        _channel("flat", spend_invariant=True),
+    )
+    card = _card()
+
+    wb = build_excel_workbook(summary, card, metadata=_metadata())
+    ws = wb["Channels"]
+
+    rows = list(ws.iter_rows(values_only=True))
+    headers = list(rows[0])
+    invariant_col = headers.index("Spend invariant")
+    roi_col = headers.index("ROI (mean)")
+
+    by_name = {row[0]: row for row in rows[1:]}
+    assert by_name["active"][invariant_col] == "no"
+    assert by_name["flat"][invariant_col] == "yes"
+    # ROI cells for spend-invariant channels are blank, not zero.
+    assert by_name["flat"][roi_col] is None
+    assert by_name["active"][roi_col] is not None
+
+
+def test_channels_sheet_share_of_media_is_a_proportion() -> None:
+    summary = _summary(
+        _channel("a", contribution=4000.0),
+        _channel("b", contribution=1000.0),
+    )
+    card = _card()
+
+    wb = build_excel_workbook(summary, card, metadata=_metadata())
+    ws = wb["Channels"]
+    rows = list(ws.iter_rows(values_only=True))
+    share_col = list(rows[0]).index("Share of media")
+    by_name = {row[0]: row for row in rows[1:]}
+    # 4000 / 5000 = 0.8 ; 1000 / 5000 = 0.2
+    assert abs(by_name["a"][share_col] - 0.8) < 1e-9
+    assert abs(by_name["b"][share_col] - 0.2) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Summary sheet content
+# ---------------------------------------------------------------------------
+
+
+def test_summary_sheet_includes_total_media_and_verdict() -> None:
+    summary = _summary(
+        _channel("a", contribution=3000.0),
+        _channel("b", contribution=2000.0),
+    )
+    card = _card(
+        ("convergence", TrustStatus.PASS, "Clean."),
+        ("saturation_identifiability", TrustStatus.WEAK, "Affiliate flat."),
+    )
+
+    wb = build_excel_workbook(summary, card, metadata=_metadata())
+    ws = wb["Summary"]
+
+    label_to_value = {row[0]: row[1] for row in ws.iter_rows(values_only=True) if row[0]}
+
+    assert label_to_value["Total media contribution"] == 5000.0
+    assert label_to_value["Trust Card verdict"] == "weak"
+    assert "a" in str(label_to_value["Top channel by contribution"])
+
+
+# ---------------------------------------------------------------------------
+# Trust Card sheet
+# ---------------------------------------------------------------------------
+
+
+def test_trust_card_sheet_one_row_per_dimension() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(
+        ("convergence", TrustStatus.PASS, "Clean."),
+        ("holdout_accuracy", TrustStatus.MODERATE, "Mixed."),
+    )
+
+    wb = build_excel_workbook(summary, card, metadata=_metadata())
+    ws = wb["Trust Card"]
+    rows = list(ws.iter_rows(values_only=True))
+    assert len(rows) == 3  # header + 2 dimensions
+    assert rows[1][0] == "convergence"
+    assert rows[1][1] == "pass"
+    assert rows[2][0] == "holdout_accuracy"
+    assert rows[2][1] == "moderate"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_workbook_round_trips_through_openpyxl(tmp_path: Path) -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card(("convergence", TrustStatus.PASS, "Clean."))
+
+    output = tmp_path / "summary.xlsx"
+    write_excel_workbook(summary, card, output=output, metadata=_metadata())
+
+    assert output.exists()
+    assert output.stat().st_size > 0
+
+    wb = load_workbook(output, read_only=True)
+    assert "Summary" in wb.sheetnames
+    assert "Channels" in wb.sheetnames
+    assert "Trust Card" in wb.sheetnames
+
+
+# ---------------------------------------------------------------------------
+# Scenarios sheet
+# ---------------------------------------------------------------------------
+
+
+def test_scenarios_sheet_delta_is_zero_for_first_plan_then_signed_for_others() -> None:
+    summary = _summary(_channel("paid_search"))
+    card = _card()
+
+    def fr(mean: float) -> ForecastResult:
+        return ForecastResult(
+            periods=["2026-01-05", "2026-01-12"],
+            mean=[mean, mean],
+            hdi_low=[mean * 0.9, mean * 0.9],
+            hdi_high=[mean * 1.1, mean * 1.1],
+            extrapolation_flags=[
+                ExtrapolationFlag(
+                    period="2026-01-05",
+                    channel="paid_search",
+                    planned_spend=900.0,
+                    observed_spend_min=100.0,
+                    observed_spend_max=500.0,
+                    direction="above",
+                ),
+            ],
+            spend_invariant_channels=[],
+        )
+
+    wb = build_excel_workbook(
+        summary,
+        card,
+        metadata=_metadata(),
+        scenarios=[fr(1000), fr(1100), fr(900)],
+        scenario_plan_names=["base", "alt_a", "alt_b"],
+    )
+    ws = wb["Scenarios"]
+    rows = list(ws.iter_rows(values_only=True))
+    headers = list(rows[0])
+    delta_col = headers.index("Δ vs first plan")
+    extrap_col = headers.index("Extrapolation flags")
+
+    # Row 1 = base, baseline; delta is 0.
+    assert rows[1][delta_col] == 0.0
+    # Row 2 = alt_a; total 2200 vs 2000 baseline, delta = +200.
+    assert rows[2][delta_col] == 200.0
+    # Row 3 = alt_b; total 1800 vs 2000 baseline, delta = -200.
+    assert rows[3][delta_col] == -200.0
+    # All scenarios have one extrapolation flag.
+    assert rows[1][extrap_col] == 1


### PR DESCRIPTION
## Summary

PR-B from the polish-the-reports plan. Adds a new top-level `wanamaker export --run-id <id> --format excel` command that emits an analyst-friendly `.xlsx` workbook with the run's structured tables. The HTML showcase, Markdown report, and Trust Card one-pager are for *reading*; this is for *slicing* — pivoting channel contributions, plugging ROIs into other spreadsheets, attaching a structured table to a board deck.

## Sheets produced

| Sheet | Always? | Contents |
|---|---|---|
| **Summary** | yes | Run metadata, total media contribution, Trust Card verdict, top channel |
| **Channels** | yes | One row per channel: contribution + HDI + share + ROI + observed spend range + spend-invariant flag, ranked by contribution |
| **Trust Card** | yes | One row per dimension: name, status, explanation |
| **Parameters** | when present | One row per posterior parameter: mean, SD, HDI, R-hat, ESS bulk |
| **Refresh diff** | when refresh diff present | One row per parameter movement |
| **Scenarios** | when `--scenario` CSVs passed | One row per forecast with delta vs. first plan + extrapolation flag count |

Numbers are stored as numbers (not formatted strings), so pivots and downstream formulas work without re-typing.

## Why a new command rather than a flag

The format axis (`excel` today, possibly `pdf`/`pptx` later) is orthogonal to which run is being exported and to which surface the user is looking at. A dedicated `export` command with `--format` keeps that clean as new formats land. PDF and PowerPoint are explicitly **not** in this PR — the showcase HTML already prints to PDF cleanly via the browser, and PowerPoint is on hold until users actually ask.

## New dependency

`openpyxl>=3.1` is added as a regular dependency. Pure-Python wheel, ~1.5 MB, no system libraries, no compilation — keeps the clean-install promise intact.

## Auto-render in the demo

`wanamaker run --example public_benchmark` now produces all four artifacts in one go: `report.md`, `showcase.html`, `trust_card.html`, and `summary.xlsx`. The demo flow stays one command; the artifact set grows.

## Validation

- **11 new unit tests** in [`test_excel_export.py`](tests/unit/test_excel_export.py): sheet presence (default + conditional cases), channel ranking and spend-invariant rendering, share-of-media proportions, Summary verdict matching the worst dimension, Trust Card row count, scenario delta-vs-first-plan sign correctness, openpyxl round-trip on the saved file.
- **Full unit suite:** 666 passed (was 655 + 11 new).
- **Lint clean** on all new files.
- **Smoke render:** 7.5 KB workbook with the four expected sheets, opens cleanly in openpyxl and Excel.
- CLI smoke test confirms `export` appears in `wanamaker --help`.

## Test plan

- [ ] `wanamaker export --run-id <id> --format excel` produces `<run_dir>/summary.xlsx`
- [ ] Open the file in Excel/Numbers and verify formulas can reference the cells (e.g. `=SUM(Channels!B:B)` matches Total media contribution on Summary)
- [ ] `wanamaker run --example public_benchmark` produces all four artifacts
- [ ] `wanamaker export --run-id <id> --format excel --scenario plan_a.csv --scenario plan_b.csv` adds a populated Scenarios sheet

## What's next

PR-A and PR-B are done. The remaining items from the original brainstorm:
- PDF/PowerPoint export — deferred until users ask
- Documentation updates for the new commands and artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)