### PR TITLE
Document the new report formats: showcase, trust-card, export

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ measurement without a PhD program.
 
 **Status:** Active pre-1.0 development. The combined BRD/PRD is locked at v0.4
 and lives in [`docs/wanamaker_brd_prd.md`](docs/wanamaker_brd_prd.md). The
-core local workflow is now in place: `diagnose`, `fit`, `report`, `forecast`,
-`compare-scenarios`, `recommend-ramp`, `refresh`, and
-`run --example public_benchmark`.
+core local workflow is now in place: `diagnose`, `fit`, `report`, `showcase`,
+`trust-card`, `export`, `forecast`, `compare-scenarios`, `recommend-ramp`,
+`refresh`, and `run --example public_benchmark`.
 
 ## What this is for
 
@@ -54,10 +54,17 @@ wanamaker run --example public_benchmark
 
 That's the whole thing. The command runs the readiness diagnostic, fits a
 quick-mode Bayesian model on the bundled `public_benchmark` dataset, and
-prints the executive summary plus the Model Trust Card. The full report
-is also written to `.wanamaker/runs/<run_id>/report.md`, and an HTML
-showcase suitable for emailing is rendered alongside it. Expect a few
-minutes on a modern laptop.
+prints the executive summary plus the Model Trust Card. Four artifacts land
+in `.wanamaker/runs/<run_id>/`:
+
+| File | Audience | Purpose |
+|---|---|---|
+| `report.md` | analyst | Full executive summary + Trust Card in Markdown — git-friendly, paste into Slack |
+| `showcase.html` | stakeholders | Self-contained HTML with channel charts, response curves, waterfall — email this |
+| `trust_card.html` | executives | One-page plain-English Trust Card — forward when "do I trust this MMM?" comes up |
+| `summary.xlsx` | analysts | Structured tables (channels, ROI, parameters, scenarios) for pivots and slicing |
+
+Expect a few minutes on a modern laptop.
 
 ## Try it without installing
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -45,7 +45,7 @@ The command prints a run ID. Use that run ID with `report`, `forecast`, and
 
 ### `wanamaker report`
 
-Render the executive summary and Model Trust Card for a completed run.
+Render the Markdown executive summary and Model Trust Card for a completed run.
 
 ```bash
 wanamaker report --run-id <run_id>
@@ -56,6 +56,63 @@ wanamaker report --run-id <run_id>
 | `--run-id` | string | required | Existing run ID under the artifact directory. |
 | `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
 | `--output` | path | `<run_dir>/report.md` | Markdown report path. |
+
+### `wanamaker showcase`
+
+Render a single self-contained HTML showcase suitable for forwarding to
+stakeholders. Bundles channel charts, response curves, ROI, the contribution
+waterfall, the Trust Card, and an optional side-by-side scenario comparison.
+
+```bash
+wanamaker showcase --run-id <run_id>
+wanamaker showcase --run-id <run_id> --scenario base.csv --scenario alt.csv
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--run-id` | string | required | Existing run ID under the artifact directory. |
+| `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
+| `--output` | path | `<run_dir>/showcase.html` | Output HTML path. |
+| `--title` | string | `"Wanamaker MMM — <run_id short>"` | Override the showcase title. |
+| `--scenario` | path, repeatable | none | Plan CSV to forecast and overlay. Pass multiple times for side-by-side comparison; the first plan is the baseline for the delta column. |
+| `--open` | flag | false | Open the rendered showcase in the default browser. |
+
+### `wanamaker trust-card`
+
+Render the executive-facing Trust Card one-pager. Single self-contained HTML
+file designed for forwarding to non-technical readers and printing to one
+physical page.
+
+```bash
+wanamaker trust-card --run-id <run_id>
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--run-id` | string | required | Existing run ID under the artifact directory. |
+| `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
+| `--output` | path | `<run_dir>/trust_card.html` | Output HTML path. |
+| `--title` | string | `"Wanamaker MMM — <run_id short>"` | Override the title. |
+| `--open` | flag | false | Open the rendered one-pager in the default browser. |
+
+### `wanamaker export`
+
+Export a run's structured tables to an analyst-friendly Excel workbook.
+Sheets: Summary, Channels, Trust Card, Parameters, optional Refresh diff,
+optional Scenarios. Numbers are stored as numbers (not formatted strings) so
+formulas and pivots work directly.
+
+```bash
+wanamaker export --run-id <run_id> --format excel
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--run-id` | string | required | Existing run ID under the artifact directory. |
+| `--format` | string | `excel` | Export format. Currently only `excel` (.xlsx) is implemented. |
+| `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
+| `--output` | path | `<run_dir>/summary.xlsx` | Output workbook path. |
+| `--scenario` | path, repeatable | none | Plan CSV to forecast and include as a row in the Scenarios sheet. |
 
 ### `wanamaker forecast`
 

--- a/docs/cmo_guide.md
+++ b/docs/cmo_guide.md
@@ -292,7 +292,10 @@ Useful artifacts include:
 | `summary.json` | Stores the engine-neutral posterior summary used by reports. |
 | `trust_card.json` | Stores the credibility audit. |
 | `refresh_diff.json` | Stores the movement explanation for a refresh run. |
-| `report.md` | The stakeholder-facing report. |
+| `report.md` | Markdown executive summary + Trust Card — analyst-facing review. |
+| `showcase.html` | Single-file HTML with charts, response curves, and the Trust Card — the "show your CMO" artifact. |
+| `trust_card.html` | One-page plain-English Trust Card — forward when "do I trust this MMM?" comes up. |
+| `summary.xlsx` | Structured tables (channels, ROI, parameters, scenarios) for analysts who want to pivot. |
 
 These artifacts make it possible to answer "what did we know when we made this
 decision?"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -145,29 +145,71 @@ The run directory contains files such as:
 | `timestamp.txt` | Fit timestamp |
 | `engine.txt` | Engine name and version |
 
-## Step 3: Render The Report
+## Step 3: Render The Reports
 
-Use the run ID from the fit command:
+Use the run ID from the fit command. Wanamaker can produce four output formats
+from one fitted run; pick the ones that match your audience.
+
+### Markdown report — analyst-facing
 
 ```bash
 wanamaker report --run-id <run_id>
 ```
 
-By default, this writes:
-
-```text
-.wanamaker/runs/<run_id>/report.md
-```
-
-The report includes:
-
-- an executive summary
-- channel contribution and ROI language
-- uncertainty-aware wording
-- the Model Trust Card
+Writes `.wanamaker/runs/<run_id>/report.md`. Includes the executive summary,
+channel contribution and ROI language, uncertainty-aware wording, and the Model
+Trust Card. Best for git-tracked review and pasting into Slack.
 
 The executive summary is deterministic template output. Wanamaker does not use
 LLM calls to generate product reports.
+
+### HTML showcase — stakeholder-facing
+
+```bash
+wanamaker showcase --run-id <run_id>
+```
+
+Writes `.wanamaker/runs/<run_id>/showcase.html`: a single self-contained HTML
+file with all CSS and SVG charts inlined. No JS, no CDN, no external assets, so
+it renders identically in browsers, email previews, and print. Includes a
+contribution waterfall, channel bars with credible-interval whiskers, ROI dot
+plot, per-channel response (saturation) curves, and the Trust Card panel.
+
+For side-by-side scenario comparison, pass plan CSVs:
+
+```bash
+wanamaker showcase --run-id <run_id> \
+    --scenario base.csv --scenario alt.csv
+```
+
+The first plan is treated as the baseline for the comparison table's delta
+column.
+
+### Trust Card one-pager — executive-facing
+
+```bash
+wanamaker trust-card --run-id <run_id>
+```
+
+Writes `.wanamaker/runs/<run_id>/trust_card.html`: a single-page artifact
+designed for forwarding to non-technical executives. Plain-English translations
+of every Trust Card dimension (no jargon — no "credible interval", "R-hat",
+"MCMC"), a verdict pill, and a short "what this means for decisions" block.
+Prints to one page on US Letter or A4.
+
+### Excel workbook — analyst slicing
+
+```bash
+wanamaker export --run-id <run_id> --format excel
+```
+
+Writes `.wanamaker/runs/<run_id>/summary.xlsx`. Sheets: Summary, Channels,
+Trust Card, Parameters, optional Refresh diff, optional Scenarios. Numbers are
+stored as numbers (not formatted strings) so analysts can pivot and compute on
+them directly.
+
+> **Tip:** `wanamaker run --example public_benchmark` runs the diagnostic, fit,
+> and *all four* report formats in one command. Use it as the canonical demo.
 
 ## Step 4: Read The Trust Card
 


### PR DESCRIPTION
## Summary

Closes the docs gap left by the recent report-polish PRs. The HTML showcase (#72), Trust Card one-pager (#83), and Excel export (#93) shipped without proportional doc updates — new readers running `wanamaker --help` saw three commands the docs didn't explain.

This PR adds full coverage in the four user-facing surfaces: README, quickstart, CLI reference, and the CMO guide.

## Changes

**[README.md](README.md)**
- Status line now lists `showcase`, `trust-card`, `export` alongside the existing core commands.
- The "One-command end-to-end example" section now lists all four artifacts produced by `wanamaker run --example` with audience and purpose for each:

  | File | Audience | Purpose |
  |---|---|---|
  | `report.md` | analyst | Markdown executive summary + Trust Card |
  | `showcase.html` | stakeholders | Self-contained HTML, email-ready |
  | `trust_card.html` | executives | One-page plain-English Trust Card |
  | `summary.xlsx` | analysts | Structured tables for slicing |

**[docs/quickstart.md](docs/quickstart.md)** — Step 3 ("Render The Report") becomes "Render The Reports" and expands into four labelled sub-sections (Markdown, showcase HTML, one-pager, Excel) with the relevant CLI command and audience for each. Adds a tip pointing back at `run --example` as the canonical demo.

**[docs/api_reference.md](docs/api_reference.md)** — New `wanamaker showcase`, `wanamaker trust-card`, and `wanamaker export` sections in the CLI reference, ordered between `report` and `forecast` to match the module docstring order. Each documents `--run-id`, `--output`, `--scenario` (where applicable), and behaviour.

**[docs/cmo_guide.md](docs/cmo_guide.md)** — Artifact table extended with `showcase.html`, `trust_card.html`, and `summary.xlsx` with business-purpose framing. The previous `report.md` line that called itself "stakeholder-facing" is reframed as "analyst-facing review" since the showcase + one-pager are the truly stakeholder-facing artifacts now.

## Validation

- `mkdocs build --strict` — passes (no broken cross-references)
- 666 unit tests still pass (no Python or behavior changes)
- Manual review against actual command surfaces

## Test plan

- [ ] Build the docs site and visually scan the new sections
- [ ] Run `wanamaker --help` and confirm every listed command appears in the CLI reference
- [ ] Run `wanamaker run --example public_benchmark` and confirm all four artifacts the README/quickstart promise are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)