### PR TITLE
Add executive-facing ramp ladder visualization (closes #87)

### DIFF
--- a/docs/risk_adjusted_allocation.md
+++ b/docs/risk_adjusted_allocation.md
@@ -360,6 +360,47 @@ but the lower-tail risk is too large and most of the move is outside observed
 spend ranges.
 ```
 
+## Reading the Decision Ladder
+
+The Markdown report leads with a six-column ladder, one row per ramp
+fraction:
+
+| Ramp | Expected lift | Downside risk | Historical support | Trust Card gate | Verdict |
+|---:|---:|---:|---|---|---|
+| 10% | +$54,000 | 4% | in range | pass | pass (selected) |
+| 25% | +$135,000 | 9% | in range | pass | pass |
+| 50% | +$255,000 | 17% | mild | pass | fail |
+| 75% | +$340,000 | 24% | severe | pass | fail |
+| 100% | +$405,000 | 31% | severe | pass | fail |
+
+How to read each column:
+
+- **Ramp** — the partial move evaluated, in 10/25/50/75/100% of the
+  baseline → target delta.
+- **Expected lift** — posterior mean increment vs. the baseline plan.
+  Signed integer, rounded to whole units of the target metric.
+- **Downside risk** — posterior probability of a "material loss" relative
+  to baseline (the threshold defaults to 5% of baseline outcome). A
+  one-number summary; the analyst-detail table at the bottom of the
+  report exposes the underlying CVaR and q05.
+- **Historical support** — three buckets: ``in range`` (every channel
+  stays inside its training-window spend range), ``mild`` (some flagged
+  cells but the extrapolation gate did not trigger), ``severe`` (the
+  extrapolation gate failed at this fraction).
+- **Trust Card gate** — ``pass`` unless a weak Trust Card dimension
+  caps this fraction below the requested move.
+- **Verdict** — ``pass`` or ``fail``. The recommended fraction (the
+  largest passing one) is marked ``(selected)``.
+
+Below the ladder the report lists, for each fraction that failed,
+plain-English bullets explaining *which* gates failed and *why*. That
+part is the part to forward when a stakeholder asks "why didn't we go
+to 50%?"
+
+The bottom of the report includes a "Sizing detail (for analysts)"
+table that preserves the Kelly-style sizing math, q05, CVaR, and the
+raw failed-gate names for analysts who want to audit the verdict.
+
 ## Integration With Existing Wanamaker Concepts
 
 ### Scenario Comparison

--- a/src/wanamaker/reports/render.py
+++ b/src/wanamaker/reports/render.py
@@ -236,23 +236,34 @@ def build_ramp_recommendation_context(
         "do_not_recommend": "Do not recommend",
     }
     candidates = []
+    recommended_fraction = float(recommendation.recommended_fraction)
     for candidate in recommendation.candidates:
+        failed = list(candidate.failed_gates)
+        extrap_count = len(candidate.extrapolation_flags)
+        is_selected = abs(float(candidate.fraction) - recommended_fraction) < 1e-9
         candidates.append({
             "fraction": float(candidate.fraction),
             "fraction_label": f"{candidate.fraction:.0%}",
             "expected_increment": float(candidate.expected_increment),
+            "expected_lift_label": _signed_int(candidate.expected_increment),
             "probability_positive": float(candidate.probability_positive),
             "probability_material_loss": float(candidate.probability_material_loss),
+            "downside_risk_label": f"{candidate.probability_material_loss:.0%}",
             "q05_increment": float(candidate.q05_increment),
             "cvar_5": float(candidate.cvar_5),
             "largest_move_share": float(candidate.largest_move_share),
             "fractional_kelly": float(candidate.fractional_kelly),
             "passes": bool(candidate.passes),
-            "failed_gates": list(candidate.failed_gates),
+            "failed_gates": failed,
             "failed_gates_label": (
-                ", ".join(candidate.failed_gates) if candidate.failed_gates else "none"
+                ", ".join(failed) if failed else "none"
             ),
-            "extrapolation_count": len(candidate.extrapolation_flags),
+            "extrapolation_count": extrap_count,
+            "historical_support_label": _historical_support_label(failed, extrap_count),
+            "trust_card_gate_label": "fail" if "trust_card" in failed else "pass",
+            "verdict_label": "pass" if candidate.passes else "fail",
+            "is_selected": is_selected,
+            "failure_reasons": _failure_reasons(failed, candidate),
         })
 
     return {
@@ -355,3 +366,76 @@ def _refresh_narrative(refresh_diff: RefreshDiff) -> Mapping[str, Any]:
         "unexplained_fraction": fraction,
         "movements_by_class": classes,
     }
+
+
+# ---------------------------------------------------------------------------
+# Ramp ladder helpers — keep the executive output decision-friendly while
+# preserving the analyst-detail table at the bottom of the report.
+# ---------------------------------------------------------------------------
+
+
+def _signed_int(value: float) -> str:
+    """Format a signed integer with thousands separators (``+1,234`` / ``-1,234``).
+
+    Uses ASCII ``-`` for negatives so the rendered Markdown reads without
+    surprises under any platform encoding (the file lands on Windows
+    runners that default to cp1252, not UTF-8).
+    """
+    rounded = int(round(value))
+    if rounded == 0:
+        return "0"
+    sign = "+" if rounded > 0 else "-"
+    return f"{sign}{abs(rounded):,}"
+
+
+def _historical_support_label(failed_gates: list[str], extrap_count: int) -> str:
+    """Three-bucket plain-English label for the Historical-support column.
+
+    Uses the existing extrapolation gate as the "severe" boundary so the
+    bucket lines up with the gate-failure logic — no new thresholds.
+    """
+    if "extrapolation" in failed_gates:
+        return "severe"
+    if extrap_count > 0:
+        return "mild"
+    return "in range"
+
+
+# Plain-English explanation for each gate name the engine emits.
+_GATE_EXPLANATIONS: dict[str, str] = {
+    "p_positive": "low probability of beating baseline",
+    "p_material_loss": "downside risk too high",
+    "cvar_5": "worst-case tail loss too large",
+    "trust_card": "Trust Card caps the move",
+    "fractional_kelly": "exceeds the risk-adjusted sizing cap",
+    "extrapolation": "exceeds historical spend range",
+}
+
+
+def _failure_reasons(failed_gates: list[str], candidate: Any) -> list[str]:
+    """Plain-English bullet text for each failed gate, with concrete numbers."""
+    if not failed_gates:
+        return []
+    reasons: list[str] = []
+    for gate in failed_gates:
+        base = _GATE_EXPLANATIONS.get(gate, gate)
+        if gate == "p_material_loss":
+            reasons.append(
+                f"{base} ({candidate.probability_material_loss:.0%} chance of "
+                "a material loss)"
+            )
+        elif gate == "p_positive":
+            reasons.append(
+                f"{base} (P(beats baseline) = "
+                f"{candidate.probability_positive:.0%})"
+            )
+        elif gate == "extrapolation":
+            n = len(candidate.extrapolation_flags)
+            reasons.append(f"{base} ({n} cell(s) outside training range)")
+        elif gate == "fractional_kelly":
+            reasons.append(
+                f"{base} (sizing cap = {candidate.fractional_kelly:.0%})"
+            )
+        else:
+            reasons.append(base)
+    return reasons

--- a/src/wanamaker/reports/templates/ramp_recommendation.md.j2
+++ b/src/wanamaker/reports/templates/ramp_recommendation.md.j2
@@ -1,7 +1,7 @@
 {# Risk-adjusted allocation ramp template (FR-5.6).
 
-   Voice: dry, direct, deterministic. This report explains how far the
-   model supports moving from a baseline plan toward a target plan.
+   Voice: dry, direct, deterministic. Leads with a decision-friendly
+   ladder; analyst-detail metrics live at the bottom.
 #}
 # Risk-adjusted ramp recommendation
 
@@ -23,23 +23,46 @@
 Blocking reason: `{{ blocking_reason }}`
 {% endif %}
 
-## Candidate Gates
+## Decision ladder
 
 {% if candidates %}
-| Ramp | Gate status | Expected increment | P(improvement) | P(material loss) | q05 increment | CVaR 5 | Largest move share | Kelly cap | Failed gates | Extrapolation flags |
-|---:|---|---:|---:|---:|---:|---:|---:|---:|---|---:|
+| Ramp | Expected lift | Downside risk | Historical support | Trust Card gate | Verdict |
+|---:|---:|---:|---|---|---|
 {% for c in candidates %}
-| {{ c.fraction_label }} | {% if c.passes %}pass{% else %}fail{% endif %} | {{ "{:,.0f}".format(c.expected_increment) }} | {{ "{:.0%}".format(c.probability_positive) }} | {{ "{:.0%}".format(c.probability_material_loss) }} | {{ "{:,.0f}".format(c.q05_increment) }} | {{ "{:,.0f}".format(c.cvar_5) }} | {{ "{:.0%}".format(c.largest_move_share) }} | {{ "{:.0%}".format(c.fractional_kelly) }} | {{ c.failed_gates_label }} | {{ c.extrapolation_count }} |
+| {{ c.fraction_label }} | {{ c.expected_lift_label }} | {{ c.downside_risk_label }} | {{ c.historical_support_label }} | {{ c.trust_card_gate_label }} | {{ c.verdict_label }}{% if c.is_selected %} (selected){% endif %} |
 {% endfor %}
 {% else %}
-No positive ramp candidates were evaluated. The recommendation was blocked before
-candidate scoring.
+No positive ramp candidates were evaluated. The recommendation was blocked
+before candidate scoring.
 {% endif %}
 
-## How To Use This
+{% set failed_candidates = candidates | rejectattr("passes") | list %}
+{% if failed_candidates %}
+## Why each fraction's verdict
+
+{% for c in failed_candidates %}
+- **{{ c.fraction_label }} (fail):** {% for reason in c.failure_reasons %}{{ reason }}{% if not loop.last %}; {% endif %}{% endfor %}.
+{% endfor %}
+{% endif %}
+
+## How to use this
 
 This is not an automatic budget optimizer. It evaluates how much of the
-user-supplied target plan is analytically supported right now. If the verdict is
-`stage`, adopt the recommended fraction and refresh after new data arrives. If
-the verdict is `test_first`, the next useful action is better evidence, not a
-larger immediate move.
+user-supplied target plan is analytically supported right now. If the
+verdict is `stage`, adopt the recommended fraction and refresh after new
+data arrives. If the verdict is `test_first`, the next useful action is
+better evidence, not a larger immediate move.
+
+## Sizing detail (for analysts)
+
+The ladder above hides Kelly-style sizing math behind the
+"risk-adjusted sizing cap" gate. The table below preserves the raw
+metrics so analysts can audit the verdict.
+
+{% if candidates %}
+| Ramp | P(improve) | P(material loss) | q05 increment | CVaR 5 | Largest move share | Sizing cap | Failed gates |
+|---:|---:|---:|---:|---:|---:|---:|---|
+{% for c in candidates %}
+| {{ c.fraction_label }} | {{ "{:.0%}".format(c.probability_positive) }} | {{ "{:.0%}".format(c.probability_material_loss) }} | {{ "{:,.0f}".format(c.q05_increment) }} | {{ "{:,.0f}".format(c.cvar_5) }} | {{ "{:.0%}".format(c.largest_move_share) }} | {{ "{:.0%}".format(c.fractional_kelly) }} | {{ c.failed_gates_label }} |
+{% endfor %}
+{% endif %}

--- a/tests/unit/test_cli_recommend_ramp.py
+++ b/tests/unit/test_cli_recommend_ramp.py
@@ -271,7 +271,9 @@ def test_each_ramp_status_is_reachable_through_cli(
     assert report.exists()
     body = report.read_text()
     assert f"(`{expected_status}`)" in body
-    assert "## Candidate Gates" in body
+    assert "## Decision ladder" in body
+    # The analyst-detail "Sizing detail" table preserves the failed_gates
+    # column; verify it lands when there is at least one fail.
     if expected_status != "do_not_recommend":
         assert "Failed gates" in body
 
@@ -290,7 +292,13 @@ def test_report_contains_risk_table_failed_gates_and_advisor_handoff(
     assert result.exit_code == 0, result.output
 
     body = (run_dir / "ramp_base_to_alt.md").read_text()
-    assert "| Ramp | Gate status | Expected increment | P(improvement) |" in body
+    # Decision ladder is the lead executive-facing table.
+    assert (
+        "| Ramp | Expected lift | Downside risk | Historical support | "
+        "Trust Card gate | Verdict |"
+    ) in body
+    # Analyst detail table is preserved at the bottom.
+    assert "## Sizing detail (for analysts)" in body
     assert "extrapolation" in body
     assert "A test on `search` would most reduce the binding gate." in body
 

--- a/tests/unit/test_ramp_ladder.py
+++ b/tests/unit/test_ramp_ladder.py
@@ -1,0 +1,441 @@
+"""Tests for the executive-facing ramp ladder visualization.
+
+Covers issue #87's acceptance criteria:
+
+- Ramp Markdown includes a per-fraction ladder with pass/fail reasons.
+- Selected ramp fraction is easy to identify.
+- All four statuses render: ``proceed``, ``stage``, ``test_first``,
+  ``do_not_recommend``.
+- At least one failure due to extrapolation, one due to downside risk,
+  one due to Trust Card gating.
+
+Tests build ``RampRecommendation`` objects directly and feed them
+through ``build_ramp_recommendation_context`` + the Markdown template.
+No engine is invoked — these tests stay at the rendering layer.
+"""
+
+from __future__ import annotations
+
+from wanamaker.forecast.posterior_predictive import ExtrapolationFlag
+from wanamaker.forecast.ramp import RampCandidate, RampRecommendation
+from wanamaker.reports import (
+    build_ramp_recommendation_context,
+    render_ramp_recommendation,
+)
+
+
+def _candidate(
+    fraction: float,
+    *,
+    expected_increment: float = 1000.0,
+    p_positive: float = 0.92,
+    p_material_loss: float = 0.05,
+    q05_increment: float = -200.0,
+    cvar_5: float = -300.0,
+    largest_move_share: float = 0.10,
+    fractional_kelly: float = 0.50,
+    extrapolation_flags: list[ExtrapolationFlag] | None = None,
+    failed_gates: list[str] | None = None,
+) -> RampCandidate:
+    failed = failed_gates or []
+    return RampCandidate(
+        fraction=fraction,
+        total_spend_by_channel={"paid_search": 10000.0},
+        expected_increment=expected_increment,
+        probability_positive=p_positive,
+        probability_material_loss=p_material_loss,
+        q05_increment=q05_increment,
+        cvar_5=cvar_5,
+        largest_move_share=largest_move_share,
+        fractional_kelly=fractional_kelly,
+        extrapolation_flags=extrapolation_flags or [],
+        passes=not failed,
+        failed_gates=failed,
+    )
+
+
+def _recommendation(
+    candidates: list[RampCandidate],
+    *,
+    recommended_fraction: float,
+    status: str = "stage",
+    explanation: str = "Stage 25%.",
+    blocking_reason: str | None = None,
+) -> RampRecommendation:
+    return RampRecommendation(
+        baseline_plan_name="base",
+        target_plan_name="alt",
+        recommended_fraction=recommended_fraction,
+        status=status,  # type: ignore[arg-type]
+        candidates=candidates,
+        explanation=explanation,
+        blocking_reason=blocking_reason,
+    )
+
+
+def _render(rec: RampRecommendation) -> str:
+    ctx = build_ramp_recommendation_context(
+        rec,
+        run_id="abc12345",
+        baseline_path="base.csv",
+        target_path="alt.csv",
+    )
+    return render_ramp_recommendation(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Context shaping
+# ---------------------------------------------------------------------------
+
+
+def test_context_marks_recommended_fraction_as_selected() -> None:
+    cands = [
+        _candidate(0.10),
+        _candidate(0.25),
+        _candidate(0.50, failed_gates=["p_material_loss"]),
+    ]
+    rec = _recommendation(cands, recommended_fraction=0.25, status="stage")
+    ctx = build_ramp_recommendation_context(
+        rec, run_id="x", baseline_path="b.csv", target_path="t.csv",
+    )
+
+    selected = [c for c in ctx["candidates"] if c["is_selected"]]
+    assert len(selected) == 1
+    assert selected[0]["fraction"] == 0.25
+
+
+def test_historical_support_buckets() -> None:
+    """`extrapolation` in failed_gates → severe; flags but no fail → mild;
+    no flags → in range."""
+    cands = [
+        _candidate(0.10),  # in range
+        _candidate(
+            0.25,
+            extrapolation_flags=[
+                ExtrapolationFlag(
+                    period="2026-01-05",
+                    channel="paid_search",
+                    planned_spend=900.0,
+                    observed_spend_min=100.0,
+                    observed_spend_max=500.0,
+                    direction="above",
+                ),
+            ],
+        ),  # mild
+        _candidate(
+            0.50,
+            extrapolation_flags=[
+                ExtrapolationFlag(
+                    period=f"2026-01-{i:02d}",
+                    channel="paid_search",
+                    planned_spend=900.0,
+                    observed_spend_min=100.0,
+                    observed_spend_max=500.0,
+                    direction="above",
+                )
+                for i in range(5, 12)
+            ],
+            failed_gates=["extrapolation"],
+        ),  # severe
+    ]
+    rec = _recommendation(cands, recommended_fraction=0.10, status="stage")
+    ctx = build_ramp_recommendation_context(
+        rec, run_id="x", baseline_path="b.csv", target_path="t.csv",
+    )
+    labels = [c["historical_support_label"] for c in ctx["candidates"]]
+    assert labels == ["in range", "mild", "severe"]
+
+
+def test_failure_reasons_translate_each_gate_into_plain_english() -> None:
+    cand = _candidate(
+        1.0,
+        p_positive=0.40,
+        p_material_loss=0.30,
+        cvar_5=-2000.0,
+        fractional_kelly=0.25,
+        extrapolation_flags=[
+            ExtrapolationFlag(
+                period="2026-01-05",
+                channel="paid_search",
+                planned_spend=900.0,
+                observed_spend_min=100.0,
+                observed_spend_max=500.0,
+                direction="above",
+            )
+        ],
+        failed_gates=[
+            "p_positive",
+            "p_material_loss",
+            "cvar_5",
+            "trust_card",
+            "fractional_kelly",
+            "extrapolation",
+        ],
+    )
+    rec = _recommendation([cand], recommended_fraction=0.0, status="do_not_recommend")
+    ctx = build_ramp_recommendation_context(
+        rec, run_id="x", baseline_path="b.csv", target_path="t.csv",
+    )
+    reasons = ctx["candidates"][0]["failure_reasons"]
+    text = " | ".join(reasons)
+
+    # Every failed gate produced a translation.
+    assert len(reasons) == 6
+    assert "low probability of beating baseline" in text
+    assert "downside risk too high" in text
+    assert "worst-case tail loss too large" in text
+    assert "Trust Card caps the move" in text
+    assert "exceeds the risk-adjusted sizing cap" in text
+    assert "exceeds historical spend range" in text
+    # Concrete numbers attached where they aid the reader.
+    assert "30% chance of a material loss" in text
+    assert "P(beats baseline) = 40%" in text
+    assert "1 cell(s) outside training range" in text
+    assert "sizing cap = 25%" in text
+
+
+def test_no_failure_reasons_for_passing_candidates() -> None:
+    cand = _candidate(0.25)
+    rec = _recommendation([cand], recommended_fraction=0.25, status="stage")
+    ctx = build_ramp_recommendation_context(
+        rec, run_id="x", baseline_path="b.csv", target_path="t.csv",
+    )
+    assert ctx["candidates"][0]["failure_reasons"] == []
+
+
+def test_signed_int_formatting_for_expected_lift() -> None:
+    """Positive lift gets +; negative gets ASCII -; zero is just 0."""
+    cands = [
+        _candidate(0.10, expected_increment=1234.6),
+        _candidate(0.25, expected_increment=-1500.4),
+        _candidate(0.50, expected_increment=0.0),
+    ]
+    rec = _recommendation(cands, recommended_fraction=0.10, status="stage")
+    ctx = build_ramp_recommendation_context(
+        rec, run_id="x", baseline_path="b.csv", target_path="t.csv",
+    )
+    labels = [c["expected_lift_label"] for c in ctx["candidates"]]
+    assert labels == ["+1,235", "-1,500", "0"]
+
+
+# ---------------------------------------------------------------------------
+# Template output — covers the issue's acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+def test_decision_ladder_header_matches_spec() -> None:
+    rec = _recommendation([_candidate(0.10)], recommended_fraction=0.10, status="stage")
+    body = _render(rec)
+    assert (
+        "| Ramp | Expected lift | Downside risk | Historical support | "
+        "Trust Card gate | Verdict |"
+    ) in body
+
+
+def test_selected_fraction_is_visually_marked() -> None:
+    cands = [
+        _candidate(0.10),
+        _candidate(0.25),
+        _candidate(0.50, failed_gates=["p_material_loss"]),
+    ]
+    rec = _recommendation(cands, recommended_fraction=0.25, status="stage")
+    body = _render(rec)
+
+    # Only the 25% row shows the (selected) marker.
+    selected_lines = [line for line in body.splitlines() if "(selected)" in line]
+    assert len(selected_lines) == 1
+    assert "25%" in selected_lines[0]
+
+
+def test_why_each_fractions_verdict_section_explains_failures() -> None:
+    cands = [
+        _candidate(0.10),
+        _candidate(
+            0.25,
+            failed_gates=["extrapolation"],
+            extrapolation_flags=[
+                ExtrapolationFlag(
+                    period=f"2026-01-{i:02d}",
+                    channel="paid_search",
+                    planned_spend=900.0,
+                    observed_spend_min=100.0,
+                    observed_spend_max=500.0,
+                    direction="above",
+                )
+                for i in (5, 12, 19)
+            ],
+        ),
+    ]
+    rec = _recommendation(cands, recommended_fraction=0.10, status="stage")
+    body = _render(rec)
+
+    assert "Why each fraction's verdict" in body
+    # Plain-English explanation appears for the failing fraction.
+    assert "exceeds historical spend range" in body
+    assert "(3 cell(s) outside training range)" in body
+
+
+def test_no_kelly_language_in_executive_ladder() -> None:
+    """`Kelly` only appears in the analyst-detail section, not in the lead
+    ladder. Per the issue: don't use Kelly language in executive output."""
+    cand = _candidate(1.0, fractional_kelly=0.25, failed_gates=["fractional_kelly"])
+    rec = _recommendation([cand], recommended_fraction=0.0, status="do_not_recommend")
+    body = _render(rec)
+
+    ladder_start = body.index("## Decision ladder")
+    detail_start = body.index("## Sizing detail (for analysts)")
+    ladder_section = body[ladder_start:detail_start]
+    assert "Kelly" not in ladder_section
+    assert "kelly" not in ladder_section
+    # The analyst-detail section may legitimately use the word.
+    assert "Kelly" in body[detail_start:]
+
+
+def test_analyst_detail_table_preserves_raw_metrics() -> None:
+    cand = _candidate(0.25, p_positive=0.85, q05_increment=-100.0, cvar_5=-150.0)
+    rec = _recommendation([cand], recommended_fraction=0.25, status="stage")
+    body = _render(rec)
+
+    detail_start = body.index("## Sizing detail (for analysts)")
+    detail = body[detail_start:]
+    assert "P(improve)" in detail
+    assert "CVaR 5" in detail
+    assert "q05 increment" in detail
+
+
+# ---------------------------------------------------------------------------
+# All four statuses render
+# ---------------------------------------------------------------------------
+
+
+def test_proceed_status_renders() -> None:
+    cand = _candidate(1.0)
+    rec = _recommendation(
+        [cand],
+        recommended_fraction=1.0,
+        status="proceed",
+        explanation="Full move is supported.",
+    )
+    body = _render(rec)
+    assert "(`proceed`)" in body
+    assert "Recommended ramp: **100%**" in body
+
+
+def test_stage_status_renders_and_marks_partial_fraction() -> None:
+    cands = [
+        _candidate(0.10),
+        _candidate(0.25),
+        _candidate(0.50, failed_gates=["p_material_loss"]),
+        _candidate(1.0, failed_gates=["p_material_loss", "cvar_5"]),
+    ]
+    rec = _recommendation(cands, recommended_fraction=0.25, status="stage")
+    body = _render(rec)
+    assert "(`stage`)" in body
+    assert "Recommended ramp: **25%**" in body
+    # All four candidates appear in the ladder.
+    for label in ("10%", "25%", "50%", "100%"):
+        assert label in body
+
+
+def test_test_first_status_renders_with_evidence_gate_failures() -> None:
+    """`test_first` is the route when only evidence gates (extrapolation,
+    trust_card, fractional_kelly) failed at higher fractions."""
+    cands = [
+        _candidate(
+            0.10, failed_gates=["extrapolation"],
+            extrapolation_flags=[
+                ExtrapolationFlag(
+                    period="2026-01-05",
+                    channel="paid_search",
+                    planned_spend=900.0,
+                    observed_spend_min=100.0,
+                    observed_spend_max=500.0,
+                    direction="above",
+                )
+            ],
+        ),
+        _candidate(0.25, failed_gates=["trust_card"]),
+    ]
+    rec = _recommendation(
+        cands, recommended_fraction=0.0, status="test_first",
+        explanation="Run an experiment first.",
+    )
+    body = _render(rec)
+    assert "(`test_first`)" in body
+    # The Trust Card gate column shows fail for the 25% row.
+    twentyfive_line = next(
+        line for line in body.splitlines()
+        if line.startswith("| 25%") and "Verdict" not in line
+    )
+    assert "fail" in twentyfive_line
+
+
+def test_do_not_recommend_status_renders_with_blocking_reason() -> None:
+    rec = _recommendation(
+        [],
+        recommended_fraction=0.0,
+        status="do_not_recommend",
+        explanation="Spend-invariant channel reallocation is unsafe.",
+        blocking_reason="spend_invariant_reallocation",
+    )
+    body = _render(rec)
+    assert "(`do_not_recommend`)" in body
+    assert "Blocking reason: `spend_invariant_reallocation`" in body
+    # No candidate ladder when blocked up-front.
+    assert "blocked\nbefore candidate scoring" in body
+
+
+# ---------------------------------------------------------------------------
+# Specific failure-driver coverage (issue acceptance)
+# ---------------------------------------------------------------------------
+
+
+def test_extrapolation_driven_failure_appears_in_why_section() -> None:
+    cand = _candidate(
+        0.50,
+        failed_gates=["extrapolation"],
+        extrapolation_flags=[
+            ExtrapolationFlag(
+                period="2026-01-05",
+                channel="ctv",
+                planned_spend=20000.0,
+                observed_spend_min=8000.0,
+                observed_spend_max=15000.0,
+                direction="above",
+            )
+        ],
+    )
+    rec = _recommendation([cand], recommended_fraction=0.0, status="test_first")
+    body = _render(rec)
+
+    why_start = body.index("Why each fraction's verdict")
+    why_section = body[why_start:body.index("## How to use this", why_start)]
+    assert "exceeds historical spend range" in why_section
+
+
+def test_downside_risk_driven_failure_appears_in_why_section() -> None:
+    cand = _candidate(
+        0.50,
+        p_material_loss=0.30,
+        failed_gates=["p_material_loss"],
+    )
+    rec = _recommendation([cand], recommended_fraction=0.0, status="do_not_recommend")
+    body = _render(rec)
+
+    why_start = body.index("Why each fraction's verdict")
+    why_section = body[why_start:body.index("## How to use this", why_start)]
+    assert "downside risk too high" in why_section
+    assert "30% chance of a material loss" in why_section
+
+
+def test_trust_card_driven_failure_appears_in_why_section() -> None:
+    cand = _candidate(
+        0.50,
+        failed_gates=["trust_card"],
+    )
+    rec = _recommendation([cand], recommended_fraction=0.10, status="stage")
+    body = _render(rec)
+
+    why_start = body.index("Why each fraction's verdict")
+    why_section = body[why_start:body.index("## How to use this", why_start)]
+    assert "Trust Card caps the move" in why_section


### PR DESCRIPTION
## Summary

Closes #87. The `wanamaker recommend-ramp` Markdown report now leads with a six-column **decision ladder** — Ramp / Expected lift / Downside risk / Historical support / Trust Card gate / Verdict — with the selected fraction marked. Below it, a **"Why each fraction's verdict"** section lists plain-English reasons for every failed candidate. The previous wide gate-metrics table is preserved at the bottom under **"Sizing detail (for analysts)"** so analysts still get raw Kelly / CVaR / q05.

## Why

The previous 11-column table read like an analyst dump. Executives reviewing a ramp decision want a scannable verdict per fraction with clear failure reasons, not a wall of statistics. This matches issue #87's spec exactly.

## What it looks like

```markdown
## Decision ladder

| Ramp | Expected lift | Downside risk | Historical support | Trust Card gate | Verdict |
|---:|---:|---:|---|---|---|
| 10% | +54,000 | 4% | in range | pass | pass |
| 25% | +135,000 | 9% | in range | pass | pass (selected) |
| 50% | +255,000 | 17% | mild | pass | fail |
| 100% | +405,000 | 31% | severe | pass | fail |

## Why each fraction's verdict

- **50% (fail):** downside risk too high (17% chance of a material loss).
- **100% (fail):** exceeds historical spend range (4 cell(s) outside training range); downside risk too high (31% chance of a material loss).
```

## Design choices

- **Three buckets for "Historical support"** — `in range` / `mild` / `severe` — keyed off the existing extrapolation gate trigger (no new thresholds invented).
- **No "Kelly" language in the lead ladder** per the issue guideline. The term is renamed "risk-adjusted sizing cap" in failure reasons and stays in the analyst-detail section's "Sizing cap" column. A test asserts `"Kelly"` does not appear between the `## Decision ladder` and `## Sizing detail (for analysts)` headings.
- **Selected fraction marked with `(selected)`** (ASCII — Markdown reads cleanly under cp1252 on Windows runners; was the cause of an earlier encoding-driven test failure).
- **Failure reasons attach concrete numbers** where they help: `"30% chance of a material loss"`, `"1 cell(s) outside training range"`, `"sizing cap = 25%"`.

## Acceptance criteria coverage (from issue #87)

| Criterion | Where verified |
|---|---|
| Per-fraction ladder with pass/fail reasons | `test_decision_ladder_header_matches_spec` + `test_why_each_fractions_verdict_section_explains_failures` |
| Selected ramp fraction easy to identify | `test_selected_fraction_is_visually_marked` |
| All four statuses render | `test_proceed_status_renders` / `_stage_` / `_test_first_` / `_do_not_recommend_` |
| Extrapolation-driven failure | `test_extrapolation_driven_failure_appears_in_why_section` |
| Downside-risk-driven failure | `test_downside_risk_driven_failure_appears_in_why_section` |
| Trust-Card-driven failure | `test_trust_card_driven_failure_appears_in_why_section` |
| Docs explain how to read the ladder | New "Reading the Decision Ladder" section in `docs/risk_adjusted_allocation.md` |

## Validation

- **17 new unit tests** in [`tests/unit/test_ramp_ladder.py`](tests/unit/test_ramp_ladder.py) covering context-shaping (selected marker, historical-support buckets, failure-reason translation, signed lift formatting), template output (header, marker placement, no-Kelly-in-lead invariant, analyst-detail preservation), all four statuses, and the three named failure drivers.
- **Existing tests updated** in [`tests/unit/test_cli_recommend_ramp.py`](tests/unit/test_cli_recommend_ramp.py) to assert the new lead ladder + the preserved analyst-detail table.
- **Full unit suite:** 683 passed (was 666 + 17 new).
- **Lint clean** on touched Python files.
- **mkdocs strict build** passes — new docs section verified.

## Test plan

- [ ] `wanamaker recommend-ramp --run-id <id> --baseline base.csv --target alt.csv` produces a Markdown report whose first table is the new ladder
- [ ] Manually verify the `(selected)` marker lands on the correct row for `proceed` (100% selected), `stage` (e.g. 25% selected), `test_first` (no candidate selected — fraction 0), `do_not_recommend` (no candidate selected)
- [ ] Eyeball the failure-reason bullets read like sentences a CMO would understand

🤖 Generated with [Claude Code](https://claude.com/claude-code)