### PR TITLE
feat: Support explicit ROI and Outcome schemas for lift-test calibration

### DIFF
--- a/benchmark_data/generate_diagnostic_benchmarks.py
+++ b/benchmark_data/generate_diagnostic_benchmarks.py
@@ -208,9 +208,9 @@ def _generate_lift_test_calibration() -> None:
             "channel": ["paid_search"],
             "test_start": ["2023-09-01"],
             "test_end": ["2023-12-15"],
-            "lift_estimate": [round(true_search_roi, 6)],
-            "ci_lower": [lift_low],
-            "ci_upper": [lift_high],
+            "roi_estimate": [round(true_search_roi, 6)],
+            "roi_ci_lower": [lift_low],
+            "roi_ci_upper": [lift_high],
         }
     )
     lift_tests.to_csv(
@@ -234,9 +234,9 @@ def _generate_lift_test_calibration() -> None:
             "control_columns": [],
             "lift_test_channel": "paid_search",
             "true_roi": true_search_roi,
-            "lift_estimate": round(true_search_roi, 6),
-            "ci_lower": lift_low,
-            "ci_upper": lift_high,
+            "roi_estimate": round(true_search_roi, 6),
+            "roi_ci_lower": lift_low,
+            "roi_ci_upper": lift_high,
             "lift_tests_csv": "lift_test_calibration_lift_tests.csv",
         },
     )

--- a/benchmark_data/lift_test_calibration_lift_tests.csv
+++ b/benchmark_data/lift_test_calibration_lift_tests.csv
@@ -1,2 +1,2 @@
-channel,test_start,test_end,lift_estimate,ci_lower,ci_upper
+channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper
 paid_search,2023-09-01,2023-12-15,1.8,1.6,2.0

--- a/benchmark_data/lift_test_calibration_metadata.json
+++ b/benchmark_data/lift_test_calibration_metadata.json
@@ -1,14 +1,14 @@
 {
-  "ci_lower": 1.6,
-  "ci_upper": 2.0,
   "control_columns": [],
   "dataset": "lift_test_calibration",
   "date_column": "week",
-  "lift_estimate": 1.8,
   "lift_test_channel": "paid_search",
   "lift_tests_csv": "lift_test_calibration_lift_tests.csv",
   "n_weeks": 80,
   "purpose": "Exercises FR-1.3 (lift-test prior wiring) and FR-3.3 (recovered ROI close to known lift). The 'paid_search' channel was simulated with a known true ROI; the companion lift-test CSV reports a 95 % CI centred on that value.",
+  "roi_ci_lower": 1.6,
+  "roi_ci_upper": 2.0,
+  "roi_estimate": 1.8,
   "spend_columns": [
     "paid_search",
     "linear_tv",

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -202,6 +202,11 @@ Unknown fields are rejected.
 | `control_columns` | list of strings | `[]` | Non-media controls such as price, promotions, holidays, or macro indicators. |
 | `lift_test_csv` | path or null | `null` | Optional lift-test calibration CSV. |
 
+For `lift_test_csv`, Wanamaker supports three CSV schemas (all require `channel`, `test_start`, and `test_end` columns):
+- **ROI Schema (Canonical):** Explicit ROI fields using `roi_estimate`, `roi_ci_lower`, and `roi_ci_upper`.
+- **Outcome Schema:** `incremental_outcome`, `incremental_spend`, `ci_lower_outcome`, and `ci_upper_outcome`. Wanamaker calculates ROI internally as outcome / spend.
+- **Legacy Schema:** Legacy lift fields `lift_estimate`, `ci_lower`, and `ci_upper`. Supported with a deprecation warning.
+
 ### `channels`
 
 Each entry describes one spend column.

--- a/docs/examples/lift_test_changes_verdict.md
+++ b/docs/examples/lift_test_changes_verdict.md
@@ -90,13 +90,13 @@ as a one-row CSV:
 
 ```bash
 cat > tutorial_data/lift_tests.csv <<'EOF'
-channel,test_start,test_end,lift_estimate,ci_lower,ci_upper
+channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper
 paid_social,2024-09-01,2024-10-15,0.38,0.30,0.46
 EOF
 ```
 
 The required columns are `channel`, `test_start`, `test_end`,
-`lift_estimate`, `ci_lower`, `ci_upper`. The CI bounds are converted
+`roi_estimate`, `roi_ci_lower`, `roi_ci_upper`. The CI bounds are converted
 into a Gaussian prior on the channel's effect; tighter bounds put more
 weight on the experiment.
 

--- a/src/wanamaker/data/io.py
+++ b/src/wanamaker/data/io.py
@@ -6,9 +6,8 @@ See FR-1.1 in the BRD/PRD for the contract.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import warnings
+from pathlib import Path
 
 import pandas as pd
 

--- a/src/wanamaker/data/io.py
+++ b/src/wanamaker/data/io.py
@@ -14,30 +14,30 @@ import pandas as pd
 
 from wanamaker.config import DataConfig
 
-LIFT_TEST_BASE_COLUMNS = {
+_LIFT_TEST_BASE_COLUMNS = (
     "channel",
     "test_start",
     "test_end",
-}
+)
 
-LIFT_TEST_ROI_COLUMNS = {
+_LIFT_TEST_ROI_COLUMNS = (
     "roi_estimate",
     "roi_ci_lower",
     "roi_ci_upper",
-}
+)
 
-LIFT_TEST_OUTCOME_COLUMNS = {
+_LIFT_TEST_OUTCOME_COLUMNS = (
     "incremental_outcome",
     "incremental_spend",
     "ci_lower_outcome",
     "ci_upper_outcome",
-}
+)
 
-LIFT_TEST_LEGACY_COLUMNS = {
+_LIFT_TEST_LEGACY_COLUMNS = (
     "lift_estimate",
     "ci_lower",
     "ci_upper",
-}
+)
 
 
 def load_input_csv(config: DataConfig) -> pd.DataFrame:
@@ -101,15 +101,15 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
     df = pd.read_csv(path)
     columns = set(df.columns)
 
-    missing_base = LIFT_TEST_BASE_COLUMNS - columns
+    missing_base = set(_LIFT_TEST_BASE_COLUMNS) - columns
     if missing_base:
         raise ValueError(
             f"lift-test CSV {path} is missing required base columns: {sorted(missing_base)}"
         )
 
-    has_roi = LIFT_TEST_ROI_COLUMNS.issubset(columns)
-    has_outcome = LIFT_TEST_OUTCOME_COLUMNS.issubset(columns)
-    has_legacy = LIFT_TEST_LEGACY_COLUMNS.issubset(columns)
+    has_roi = set(_LIFT_TEST_ROI_COLUMNS).issubset(columns)
+    has_outcome = set(_LIFT_TEST_OUTCOME_COLUMNS).issubset(columns)
+    has_legacy = set(_LIFT_TEST_LEGACY_COLUMNS).issubset(columns)
 
     if sum([has_roi, has_outcome, has_legacy]) > 1:
         raise ValueError(
@@ -120,17 +120,18 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
     if not any([has_roi, has_outcome, has_legacy]):
         raise ValueError(
             f"lift-test CSV {path} does not match any supported schema. "
-            f"Required ROI columns: {sorted(LIFT_TEST_ROI_COLUMNS)}, "
-            f"Outcome columns: {sorted(LIFT_TEST_OUTCOME_COLUMNS)}, "
-            f"or Legacy columns: {sorted(LIFT_TEST_LEGACY_COLUMNS)}."
+            f"Required ROI columns: {sorted(_LIFT_TEST_ROI_COLUMNS)}, "
+            f"Outcome columns: {sorted(_LIFT_TEST_OUTCOME_COLUMNS)}, "
+            f"or Legacy columns: {sorted(_LIFT_TEST_LEGACY_COLUMNS)}."
         )
 
     if has_roi:
-        out = df[list(LIFT_TEST_BASE_COLUMNS | LIFT_TEST_ROI_COLUMNS)].copy()
+        out = df[list(_LIFT_TEST_BASE_COLUMNS) + list(_LIFT_TEST_ROI_COLUMNS)].copy()
     elif has_outcome:
-        out = df[list(LIFT_TEST_BASE_COLUMNS | LIFT_TEST_OUTCOME_COLUMNS)].copy()
+        out = df[list(_LIFT_TEST_BASE_COLUMNS) + list(_LIFT_TEST_OUTCOME_COLUMNS)].copy()
+        for col in _LIFT_TEST_OUTCOME_COLUMNS:
+            out[col] = pd.to_numeric(out[col], errors="raise")
         # Ensure incremental_spend is positive before dividing
-        out["incremental_spend"] = pd.to_numeric(out["incremental_spend"], errors="raise")
         if bool((out["incremental_spend"] <= 0).any()):
              raise ValueError(
                 f"lift-test CSV {path} has non-positive incremental_spend"
@@ -138,7 +139,7 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
         out["roi_estimate"] = out["incremental_outcome"] / out["incremental_spend"]
         out["roi_ci_lower"] = out["ci_lower_outcome"] / out["incremental_spend"]
         out["roi_ci_upper"] = out["ci_upper_outcome"] / out["incremental_spend"]
-        out = out.drop(columns=list(LIFT_TEST_OUTCOME_COLUMNS))
+        out = out.drop(columns=list(_LIFT_TEST_OUTCOME_COLUMNS))
     else:  # has_legacy
         warnings.warn(
             f"lift-test CSV {path} uses legacy columns (lift_estimate, ci_lower, ci_upper). "
@@ -147,7 +148,7 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
             FutureWarning,
             stacklevel=2,
         )
-        out = df[list(LIFT_TEST_BASE_COLUMNS | LIFT_TEST_LEGACY_COLUMNS)].copy()
+        out = df[list(_LIFT_TEST_BASE_COLUMNS) + list(_LIFT_TEST_LEGACY_COLUMNS)].copy()
         out = out.rename(
             columns={
                 "lift_estimate": "roi_estimate",

--- a/src/wanamaker/data/io.py
+++ b/src/wanamaker/data/io.py
@@ -8,14 +8,32 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import warnings
+
 import pandas as pd
 
 from wanamaker.config import DataConfig
 
-LIFT_TEST_REQUIRED_COLUMNS = {
+LIFT_TEST_BASE_COLUMNS = {
     "channel",
     "test_start",
     "test_end",
+}
+
+LIFT_TEST_ROI_COLUMNS = {
+    "roi_estimate",
+    "roi_ci_lower",
+    "roi_ci_upper",
+}
+
+LIFT_TEST_OUTCOME_COLUMNS = {
+    "incremental_outcome",
+    "incremental_spend",
+    "ci_lower_outcome",
+    "ci_upper_outcome",
+}
+
+LIFT_TEST_LEGACY_COLUMNS = {
     "lift_estimate",
     "ci_lower",
     "ci_upper",
@@ -53,35 +71,91 @@ def load_input_csv(config: DataConfig) -> pd.DataFrame:
 def load_lift_test_csv(path: Path) -> pd.DataFrame:
     """Load a lift-test calibration CSV (FR-1.3).
 
-    Required columns: channel, test_start, test_end, lift_estimate,
-    ci_lower, ci_upper.
+    Supported schemas:
+    - ROI (recommended): channel, test_start, test_end, roi_estimate,
+      roi_ci_lower, roi_ci_upper
+    - Outcome: channel, test_start, test_end, incremental_outcome,
+      incremental_spend, ci_lower_outcome, ci_upper_outcome
+    - Legacy (deprecated): channel, test_start, test_end, lift_estimate,
+      ci_lower, ci_upper
 
-    The returned frame preserves the required column names, parses test dates,
-    converts numeric lift fields to floats, and rejects ambiguous duplicate
-    channel rows. Conversion from confidence intervals to ``LiftPrior`` objects
-    is handled by ``wanamaker.model.builder``.
+    The returned frame converts any schema into the canonical ROI columns,
+    parses test dates, converts numeric fields to floats, and rejects
+    ambiguous duplicate channel rows or mixed schemas. Conversion from
+    confidence intervals to ``LiftPrior`` objects is handled by
+    ``wanamaker.model.builder``.
 
     Args:
         path: Path to the lift-test CSV.
 
     Returns:
-        Validated lift-test results, one row per channel.
+        Validated lift-test results, one row per channel, with canonical
+        ROI columns (roi_estimate, roi_ci_lower, roi_ci_upper).
 
     Raises:
         FileNotFoundError: If ``path`` does not exist.
-        ValueError: If required columns are missing, dates/numbers cannot be
-            parsed, intervals are invalid, or a channel appears more than once.
+        ValueError: If required columns are missing, mixed schemas are used,
+            dates/numbers cannot be parsed, intervals are invalid, or a
+            channel appears more than once.
     """
     df = pd.read_csv(path)
-    missing = LIFT_TEST_REQUIRED_COLUMNS - set(df.columns)
-    if missing:
+    columns = set(df.columns)
+
+    missing_base = LIFT_TEST_BASE_COLUMNS - columns
+    if missing_base:
         raise ValueError(
-            f"lift-test CSV {path} is missing required columns: {sorted(missing)}"
+            f"lift-test CSV {path} is missing required base columns: {sorted(missing_base)}"
         )
 
-    out = df[
-        ["channel", "test_start", "test_end", "lift_estimate", "ci_lower", "ci_upper"]
-    ].copy()
+    has_roi = LIFT_TEST_ROI_COLUMNS.issubset(columns)
+    has_outcome = LIFT_TEST_OUTCOME_COLUMNS.issubset(columns)
+    has_legacy = LIFT_TEST_LEGACY_COLUMNS.issubset(columns)
+
+    if sum([has_roi, has_outcome, has_legacy]) > 1:
+        raise ValueError(
+            f"lift-test CSV {path} mixes multiple schemas (ROI, Outcome, Legacy). "
+            "Please use exactly one schema."
+        )
+
+    if not any([has_roi, has_outcome, has_legacy]):
+        raise ValueError(
+            f"lift-test CSV {path} does not match any supported schema. "
+            f"Required ROI columns: {sorted(LIFT_TEST_ROI_COLUMNS)}, "
+            f"Outcome columns: {sorted(LIFT_TEST_OUTCOME_COLUMNS)}, "
+            f"or Legacy columns: {sorted(LIFT_TEST_LEGACY_COLUMNS)}."
+        )
+
+    if has_roi:
+        out = df[list(LIFT_TEST_BASE_COLUMNS | LIFT_TEST_ROI_COLUMNS)].copy()
+    elif has_outcome:
+        out = df[list(LIFT_TEST_BASE_COLUMNS | LIFT_TEST_OUTCOME_COLUMNS)].copy()
+        # Ensure incremental_spend is positive before dividing
+        out["incremental_spend"] = pd.to_numeric(out["incremental_spend"], errors="raise")
+        if bool((out["incremental_spend"] <= 0).any()):
+             raise ValueError(
+                f"lift-test CSV {path} has non-positive incremental_spend"
+            )
+        out["roi_estimate"] = out["incremental_outcome"] / out["incremental_spend"]
+        out["roi_ci_lower"] = out["ci_lower_outcome"] / out["incremental_spend"]
+        out["roi_ci_upper"] = out["ci_upper_outcome"] / out["incremental_spend"]
+        out = out.drop(columns=list(LIFT_TEST_OUTCOME_COLUMNS))
+    else:  # has_legacy
+        warnings.warn(
+            f"lift-test CSV {path} uses legacy columns (lift_estimate, ci_lower, ci_upper). "
+            "Please migrate to explicit ROI columns (roi_estimate, roi_ci_lower, roi_ci_upper) "
+            "or Outcome columns.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        out = df[list(LIFT_TEST_BASE_COLUMNS | LIFT_TEST_LEGACY_COLUMNS)].copy()
+        out = out.rename(
+            columns={
+                "lift_estimate": "roi_estimate",
+                "ci_lower": "roi_ci_lower",
+                "ci_upper": "roi_ci_upper",
+            }
+        )
+
     out["channel"] = out["channel"].astype(str).str.strip()
     if bool((out["channel"] == "").any()):
         raise ValueError(f"lift-test CSV {path} contains blank channel names")
@@ -102,14 +176,14 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
             f"lift-test CSV {path} has test_end before test_start for channels: {channels}"
         )
 
-    for column in ("lift_estimate", "ci_lower", "ci_upper"):
+    for column in ("roi_estimate", "roi_ci_lower", "roi_ci_upper"):
         out[column] = pd.to_numeric(out[column], errors="raise")
 
-    bad_intervals = out["ci_upper"] <= out["ci_lower"]
+    bad_intervals = out["roi_ci_upper"] <= out["roi_ci_lower"]
     if bool(bad_intervals.any()):
         channels = sorted(out.loc[bad_intervals, "channel"].tolist())
         raise ValueError(
-            f"lift-test CSV {path} has ci_upper <= ci_lower for channels: {channels}"
+            f"lift-test CSV {path} has roi_ci_upper <= roi_ci_lower for channels: {channels}"
         )
 
     return out

--- a/src/wanamaker/model/builder.py
+++ b/src/wanamaker/model/builder.py
@@ -103,14 +103,14 @@ def _load_lift_test_priors(cfg: WanamakerConfig) -> dict[str, LiftPrior]:
 
     priors: dict[str, LiftPrior] = {}
     for row in lift_tests.itertuples(index=False):
-        interval_width = float(row.ci_upper) - float(row.ci_lower)
+        interval_width = float(row.roi_ci_upper) - float(row.roi_ci_lower)
         sd_roi = interval_width / (2.0 * _NORMAL_95_Z)
         if not math.isfinite(sd_roi) or sd_roi <= 0.0:
             raise ValueError(
                 f"lift-test CSV produced a non-positive prior sd for channel {row.channel!r}"
             )
         priors[str(row.channel)] = LiftPrior(
-            mean_roi=float(row.lift_estimate),
+            mean_roi=float(row.roi_estimate),
             sd_roi=sd_roi,
             confidence=0.95,
         )

--- a/src/wanamaker/model/spec.py
+++ b/src/wanamaker/model/spec.py
@@ -94,7 +94,8 @@ class LiftPrior:
 
     Attributes:
         mean_roi: Point estimate of revenue per unit of spend from the
-            lift test.  Used as the mean of the Normal coefficient prior.
+            lift test (e.g. roi_estimate). Used as the mean of the Normal
+            coefficient prior.
         sd_roi: Standard deviation of the ROI estimate from the lift test.
             Wider intervals result in a less informative calibration prior.
             Must be strictly positive.

--- a/tests/unit/test_benchmark_loaders.py
+++ b/tests/unit/test_benchmark_loaders.py
@@ -124,9 +124,9 @@ class TestLiftTestCalibration:
     def test_lift_test_ci_brackets_estimate(self) -> None:
         _, lift_tests, _ = load_lift_test_calibration()
         row = lift_tests.iloc[0]
-        assert row["ci_lower"] <= row["lift_estimate"] <= row["ci_upper"]
+        assert row["roi_ci_lower"] <= row["roi_estimate"] <= row["roi_ci_upper"]
         # Tight CI — keeps the lift-test prior informative.
-        assert (row["ci_upper"] - row["ci_lower"]) < 1.0
+        assert (row["roi_ci_upper"] - row["roi_ci_lower"]) < 1.0
 
 
 class TestTargetLeakage:

--- a/tests/unit/test_diagnostic_benchmarks.py
+++ b/tests/unit/test_diagnostic_benchmarks.py
@@ -114,6 +114,6 @@ class TestLiftTestCalibrationDatasetSchema:
         # The reported lift estimate is the true ROI by construction;
         # validating they round-trip through the metadata + CSV catches a
         # generator that drifts away from the documented contract.
-        assert row["lift_estimate"] == metadata["lift_estimate"]
-        assert row["ci_lower"] <= true_roi <= row["ci_upper"]
+        assert row["roi_estimate"] == metadata["roi_estimate"]
+        assert row["roi_ci_lower"] <= true_roi <= row["roi_ci_upper"]
         assert row["channel"] == metadata["lift_test_channel"]

--- a/tests/unit/test_lift_test_calibration.py
+++ b/tests/unit/test_lift_test_calibration.py
@@ -43,40 +43,40 @@ def _config(tmp_path: Path, lift_test_csv: Path | None = None) -> WanamakerConfi
 def test_load_lift_test_csv_parses_dates_and_numeric_fields(tmp_path: Path) -> None:
     path = _write_lift_csv(
         tmp_path,
-        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
         "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
     )
 
     df = load_lift_test_csv(path)
 
-    assert list(df.columns) == [
+    assert set(df.columns) == {
         "channel",
         "test_start",
         "test_end",
-        "lift_estimate",
-        "ci_lower",
-        "ci_upper",
-    ]
+        "roi_estimate",
+        "roi_ci_lower",
+        "roi_ci_upper",
+    }
     assert df.loc[0, "channel"] == "search"
     assert pd.api.types.is_datetime64_any_dtype(df["test_start"])
-    assert df.loc[0, "lift_estimate"] == pytest.approx(2.0)
+    assert df.loc[0, "roi_estimate"] == pytest.approx(2.0)
 
 
 def test_load_lift_test_csv_requires_all_columns(tmp_path: Path) -> None:
     path = _write_lift_csv(
         tmp_path,
-        "channel,test_start,test_end,lift_estimate,ci_lower\n"
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower\n"
         "search,2024-01-01,2024-01-14,2.0,1.2\n",
     )
 
-    with pytest.raises(ValueError, match="missing required columns"):
+    with pytest.raises(ValueError, match="does not match any supported schema"):
         load_lift_test_csv(path)
 
 
 def test_load_lift_test_csv_rejects_duplicate_channel_rows(tmp_path: Path) -> None:
     path = _write_lift_csv(
         tmp_path,
-        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
         "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n"
         "search,2024-02-01,2024-02-14,2.2,1.4,3.0\n",
     )
@@ -88,18 +88,58 @@ def test_load_lift_test_csv_rejects_duplicate_channel_rows(tmp_path: Path) -> No
 def test_load_lift_test_csv_rejects_invalid_interval(tmp_path: Path) -> None:
     path = _write_lift_csv(
         tmp_path,
-        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
         "search,2024-01-01,2024-01-14,2.0,2.8,1.2\n",
     )
 
-    with pytest.raises(ValueError, match="ci_upper <= ci_lower"):
+    with pytest.raises(ValueError, match="roi_ci_upper <= roi_ci_lower"):
+        load_lift_test_csv(path)
+
+
+def test_load_lift_test_csv_warns_on_legacy_schema(tmp_path: Path) -> None:
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
+    )
+
+    with pytest.warns(FutureWarning, match="uses legacy columns"):
+        df = load_lift_test_csv(path)
+
+    assert "roi_estimate" in df.columns
+    assert df.loc[0, "roi_estimate"] == pytest.approx(2.0)
+
+
+def test_load_lift_test_csv_handles_outcome_schema(tmp_path: Path) -> None:
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,incremental_outcome,incremental_spend,ci_lower_outcome,ci_upper_outcome\n"
+        "search,2024-01-01,2024-01-14,100,50,60,140\n",
+    )
+
+    df = load_lift_test_csv(path)
+
+    assert "roi_estimate" in df.columns
+    assert df.loc[0, "roi_estimate"] == pytest.approx(2.0)
+    assert df.loc[0, "roi_ci_lower"] == pytest.approx(1.2)
+    assert df.loc[0, "roi_ci_upper"] == pytest.approx(2.8)
+
+
+def test_load_lift_test_csv_rejects_mixed_schemas(tmp_path: Path) -> None:
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper,lift_estimate,ci_lower,ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.2,2.8,2.0,1.2,2.8\n",
+    )
+
+    with pytest.raises(ValueError, match="mixes multiple schemas"):
         load_lift_test_csv(path)
 
 
 def test_build_model_spec_converts_lift_tests_to_priors(tmp_path: Path) -> None:
     lift_csv = _write_lift_csv(
         tmp_path,
-        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
         "search,2024-01-01,2024-01-14,2.0,1.216014,2.783986\n",
     )
 
@@ -115,7 +155,7 @@ def test_build_model_spec_converts_lift_tests_to_priors(tmp_path: Path) -> None:
 def test_build_model_spec_rejects_lift_test_for_unknown_channel(tmp_path: Path) -> None:
     lift_csv = _write_lift_csv(
         tmp_path,
-        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
         "social,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
     )
 
@@ -127,7 +167,7 @@ def test_lift_tests_do_not_modify_adstock_or_saturation_priors(tmp_path: Path) -
     base = build_model_spec(_config(tmp_path))
     lift_csv = _write_lift_csv(
         tmp_path,
-        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
         "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
     )
     calibrated = build_model_spec(_config(tmp_path, lift_csv))
@@ -152,7 +192,7 @@ class _FakePM:
 def test_pymc_coefficient_prior_uses_lift_prior_when_present(tmp_path: Path) -> None:
     lift_csv = _write_lift_csv(
         tmp_path,
-        "channel,test_start,test_end,lift_estimate,ci_lower,ci_upper\n"
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
         "search,2024-01-01,2024-01-14,2.0,1.216014,2.783986\n",
     )
     spec = build_model_spec(_config(tmp_path, lift_csv))

--- a/tests/unit/test_lift_test_calibration.py
+++ b/tests/unit/test_lift_test_calibration.py
@@ -49,14 +49,14 @@ def test_load_lift_test_csv_parses_dates_and_numeric_fields(tmp_path: Path) -> N
 
     df = load_lift_test_csv(path)
 
-    assert set(df.columns) == {
+    assert list(df.columns) == [
         "channel",
         "test_start",
         "test_end",
         "roi_estimate",
         "roi_ci_lower",
         "roi_ci_upper",
-    }
+    ]
     assert df.loc[0, "channel"] == "search"
     assert pd.api.types.is_datetime64_any_dtype(df["test_start"])
     assert df.loc[0, "roi_estimate"] == pytest.approx(2.0)
@@ -133,6 +133,18 @@ def test_load_lift_test_csv_rejects_mixed_schemas(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError, match="mixes multiple schemas"):
+        load_lift_test_csv(path)
+
+
+def test_load_lift_test_csv_outcome_schema_rejects_non_numeric(tmp_path: Path) -> None:
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,incremental_outcome,incremental_spend,ci_lower_outcome,ci_upper_outcome\n"
+        "search,2024-01-01,2024-01-14,abc,50,60,140\n",
+    )
+
+    # pd.to_numeric(errors="raise") drops down to a base ValueError
+    with pytest.raises(ValueError, match="Unable to parse string"):
         load_lift_test_csv(path)
 
 


### PR DESCRIPTION
Added explicit ROI and Outcome schemas to lift-test CSVs to address ambiguity with 'lift' terminology (Issue #77). Legacy 'lift_estimate' columns are still supported but emit a FutureWarning. Updated parsing logic, specs, and tests accordingly.

---
*PR created automatically by Jules for task [7511121429052111787](https://jules.google.com/task/7511121429052111787) started by @mbagalman*