### PR TITLE
Add product terminology guardrails (closes #90)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,3 +201,24 @@ Wanamaker is a Blue Ocean play — its differentiation comes from honesty about 
 - When the model can't tell the user something, say so plainly. "TV spend was constant during the model period — we can't estimate its saturation from data; the curve shown is from prior knowledge only." Not "Insufficient variance for parameter identifiability."
 - Avoid AI-sparkle phrases like "powered by," "intelligent," "smart," "advanced." This project's credibility comes from being unflashy.
 - The project name comes from the apocryphal John Wanamaker quote about half of advertising spend being wasted. The misattribution is part of the story — a quote about measurement uncertainty whose own provenance is uncertain.
+
+## Product terminology: decision language, not optimizer language
+
+Wanamaker is a decision-support tool, not a constrained-optimization budget engine. The BRD/PRD intentionally defers true inverse optimization because it carries high model-overconfidence risk. **User-facing copy must respect that line.** Use the phrasing that says "the model evaluated the plan you supplied" rather than "the model found the optimal plan."
+
+**Use** — these are the right phrases for v1 outputs and docs:
+
+- "candidate scenarios" / "suggested scenarios" / "bounded candidate plans"
+- "scenario comparison"
+- "risk-adjusted ramp"
+- "largest defensible move"
+
+**Avoid** — these imply the model produced a globally optimal answer, which it does not:
+
+- "optimized budget"
+- "optimal allocation"
+- "best budget"
+- "guaranteed lift"
+- "maximize ROI" used as a promise or product goal
+
+The unit test `tests/unit/test_terminology_guardrails.py` enforces this on every Jinja2 template under `src/wanamaker/reports/templates/` and every Python helper in `src/wanamaker/reports/` that injects literal copy. If you have a legitimate reason to *discuss* one of the banned phrases (for example, to tell readers "Wanamaker does not produce an optimized budget"), do so in contributor-facing or design docs (this file, `docs/architecture.md`, `docs/risk_adjusted_allocation.md`) — those are out of scope for the guardrail test.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,8 @@ Three principles shape every architectural decision:
 2. **Engine-isolated core.** PyMC is the selected Bayesian engine, but feature code must still interface through `wanamaker.engine` and never import PyMC directly.
 3. **Local-first, always.** No module in the core code path may import an HTTP client, telemetry library, or LLM SDK. This is enforced by a CI test (`tests/test_no_network_in_core.py`), not just convention.
 
+A fourth principle governs language rather than structure: **decision-support, not optimizer-grade promises.** User-facing output uses cautious phrasing ("candidate scenarios", "risk-adjusted ramp", "largest defensible move") and avoids phrases that imply the model has produced a globally optimal answer ("optimized budget", "optimal allocation", "best budget", "guaranteed lift", "maximize ROI" as a promise). The full list lives in `AGENTS.md` (at the repository root, under "Product terminology") and is enforced by `tests/unit/test_terminology_guardrails.py` against every report template and helper module.
+
 ---
 
 ## 2. Repository Layout

--- a/tests/unit/test_terminology_guardrails.py
+++ b/tests/unit/test_terminology_guardrails.py
@@ -1,0 +1,154 @@
+"""Issue #90: Product terminology guardrails.
+
+Wanamaker is a decision-support tool, not a constrained-optimization
+budget engine. User-facing output must use cautious decision language
+("candidate scenarios", "risk-adjusted ramp", "largest defensible
+move") and avoid optimizer-grade promises ("optimized budget", "optimal
+allocation", "best budget", "guaranteed lift", "maximize ROI" as a
+promise).
+
+The full rule lives in ``AGENTS.md`` under "Product terminology". This
+test enforces it on:
+
+1. Every Jinja2 template under ``src/wanamaker/reports/templates/``.
+2. Every Python helper in ``src/wanamaker/reports/`` that injects
+   literal copy into a rendered artifact (decision notes, verdict
+   text, gate explanations, etc.).
+
+Contributor-facing or design docs (``AGENTS.md``, ``docs/architecture.md``,
+``docs/risk_adjusted_allocation.md``) are out of scope — those
+legitimately discuss the banned phrases when explaining what Wanamaker
+does *not* do.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Mirrors the "Avoid" list in AGENTS.md → "Product terminology". Keep in
+# sync; this is the load-bearing definition for the test, AGENTS.md is
+# the load-bearing definition for humans.
+BANNED_PHRASES: tuple[str, ...] = (
+    "optimized budget",
+    "optimal allocation",
+    "best budget",
+    "guaranteed lift",
+    "maximize roi",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORTS_DIR = REPO_ROOT / "src" / "wanamaker" / "reports"
+TEMPLATES_DIR = REPORTS_DIR / "templates"
+
+
+def _matches_in(text: str) -> list[str]:
+    """Return banned phrases that appear in ``text`` (case-insensitive)."""
+    lowered = text.lower()
+    return [phrase for phrase in BANNED_PHRASES if phrase in lowered]
+
+
+def _template_files() -> list[Path]:
+    return sorted(TEMPLATES_DIR.glob("*.j2"))
+
+
+def _reports_python_files() -> list[Path]:
+    """Python files in ``src/wanamaker/reports/`` that emit user-facing copy.
+
+    Excludes ``__init__.py`` (re-exports only, no literal copy) but keeps
+    every other module — context shapers, verdict text, decision notes,
+    chart helpers, Excel exporter — since any of them could leak banned
+    phrasing into rendered output.
+    """
+    return sorted(p for p in REPORTS_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+@pytest.mark.parametrize("path", _template_files(), ids=lambda p: p.name)
+def test_no_banned_phrases_in_jinja_templates(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    matches = _matches_in(text)
+    assert not matches, (
+        f"{path.relative_to(REPO_ROOT)} contains banned phrase(s): {matches}. "
+        "See AGENTS.md → 'Product terminology' for the rule and "
+        "approved alternatives."
+    )
+
+
+@pytest.mark.parametrize("path", _reports_python_files(), ids=lambda p: p.name)
+def test_no_banned_phrases_in_reports_python_modules(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    matches = _matches_in(text)
+    assert not matches, (
+        f"{path.relative_to(REPO_ROOT)} contains banned phrase(s): {matches}. "
+        "See AGENTS.md → 'Product terminology' for the rule and "
+        "approved alternatives."
+    )
+
+
+def test_guardrail_at_least_one_template_was_scanned() -> None:
+    """Sanity: glob picked up the templates that exist today.
+
+    Catches the silent-failure mode where a future repo restructure
+    moves the templates and the guardrail test passes by scanning
+    nothing.
+    """
+    templates = _template_files()
+    assert templates, "no .j2 templates were discovered under TEMPLATES_DIR"
+    names = {p.name for p in templates}
+    # The five templates we ship today must all be in scope. If one is
+    # renamed or removed, update this set deliberately.
+    expected = {
+        "executive_summary.md.j2",
+        "trust_card.md.j2",
+        "ramp_recommendation.md.j2",
+        "showcase.html.j2",
+        "trust_card_one_pager.html.j2",
+    }
+    missing = expected - names
+    assert not missing, f"expected templates not found: {missing}"
+
+
+def test_guardrail_at_least_one_python_helper_was_scanned() -> None:
+    """Sanity: glob picked up the Python helpers that emit copy.
+
+    Same silent-failure guard as above for the Python side.
+    """
+    helpers = _reports_python_files()
+    assert helpers, "no Python helpers discovered under REPORTS_DIR"
+    names = {p.name for p in helpers}
+    # At minimum the showcase shaper, the one-pager shaper, and the
+    # render module must be in scope. Update deliberately if the layout
+    # moves.
+    expected_minimum = {"showcase.py", "trust_card_one_pager.py", "render.py"}
+    missing = expected_minimum - names
+    assert not missing, f"expected helpers not found: {missing}"
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("This plan is the optimized budget.", ["optimized budget"]),
+        ("We compute the OPTIMAL ALLOCATION at scale.", ["optimal allocation"]),
+        ("Pick the best budget.", ["best budget"]),
+        ("Guaranteed lift on every channel.", ["guaranteed lift"]),
+        ("We Maximize ROI subject to constraints.", ["maximize roi"]),
+        # Multiple in the same blob.
+        (
+            "The optimized budget gives a guaranteed lift.",
+            ["optimized budget", "guaranteed lift"],
+        ),
+        # Defensive mention with the negation does still match — the
+        # guardrail can't tell context from text. That is *why* the
+        # scan is scoped to template + helper files only; design docs
+        # that legitimately discuss the banned terms are out of scope.
+        ('Wanamaker does not produce an "optimized budget."', ["optimized budget"]),
+        # No matches.
+        ("Risk-adjusted ramp recommendation for paid_search.", []),
+        ("", []),
+    ],
+)
+def test_matcher_catches_known_violations(
+    text: str, expected: list[str],
+) -> None:
+    assert _matches_in(text) == expected


### PR DESCRIPTION
## Summary

Closes #90. Sets up the language-discipline contract before the scenario-generation cluster (#85, #86, #88, #89) starts shipping, so the rule is in place before there's a candidate-generation feature to mis-name.

Wanamaker is a decision-support tool, not a constrained-optimization budget engine. User-facing copy must respect that line: cautious phrasing in (**"candidate scenarios", "risk-adjusted ramp", "largest defensible move"**), optimizer-grade promises out (**"optimized budget", "optimal allocation", "best budget", "guaranteed lift", "maximize ROI" as a promise**).

## Changes

**[AGENTS.md](AGENTS.md)** — new "Product terminology: decision language, not optimizer language" section, adjacent to the existing "A note on the project's voice" section. Lists approved and banned phrases, explains the rationale, and points at the guardrail test that enforces it.

**[docs/architecture.md](docs/architecture.md)** — brief cross-reference under "Design Philosophy" so a contributor scanning the architecture doc finds the rule without knowing to look in AGENTS.md.

**[tests/unit/test_terminology_guardrails.py](tests/unit/test_terminology_guardrails.py)** — parameterised guardrail test:
- Scans every `.j2` template under `src/wanamaker/reports/templates/` (5 templates).
- Scans every Python helper under `src/wanamaker/reports/` excluding `__init__.py` (6 modules).
- Case-insensitive matching for all 5 banned phrases.
- Two sanity tests catch the silent-failure mode where a future repo restructure leaves the guardrail scanning nothing — both glob lookups must find at least the templates / helpers we ship today.
- A matcher unit test confirms the regex catches known violations and ignores clean copy.

## Audit of current code

Zero violations across templates and helpers. The defensive uses in `docs/risk_adjusted_allocation.md` ("the recommended framing is *not* 'optimized budget'") are intentionally out of scope — contributor and design docs legitimately discuss the banned phrases when explaining what Wanamaker does *not* do. The test scope is narrowed to template + helper files for exactly this reason.

## Acceptance criteria coverage (from issue #90)

| Criterion | Where verified |
|---|---|
| Contributor-facing docs describe the terminology rule | New "Product terminology" section in AGENTS.md |
| User-facing docs for scenario generation avoid optimizer language | Audit + ongoing guardrail test |
| Deterministic report templates avoid banned terms | `test_no_banned_phrases_in_jinja_templates` |
| At least one test guards against accidental "optimized budget" phrasing | Yes — 11 parameterised checks across templates + helpers |

## Validation

- **22 new tests pass** in `test_terminology_guardrails.py`
- **Full unit suite:** 705 passed (was 686 + 19 new)
- **`mkdocs build --strict`** passes
- **Lint clean** on the new test file
- **Manual matcher verification:** `'"Wanamaker does not produce an optimized budget."'` correctly matches as a violation, demonstrating that the test enforces text-only and the doc carve-outs are by scope, not by clever exception-making

## Test plan

- [ ] Try introducing a banned phrase into one of the templates locally and confirm the test fails with an actionable message
- [ ] Confirm `AGENTS.md` reads as a coherent contributor north star (it sits next to the existing project-voice guidance)

## What's next

This unblocks the scenario-generation cluster. With the language rule pinned, the natural next pickup is **#88 (constraint schema for candidate scenario generation)** — the schema that the future `suggest-scenarios` command will read. Worth doing next regardless of who picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)