### PR TITLE
Polish compare-scenarios output for decision use (closes #86)

### DIFF
--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -1927,21 +1927,39 @@ def _format_forecast_markdown(result: Any, run_id: str, plan_path: Path) -> str:
 
 
 def _print_scenario_comparison_table(results: list[Any]) -> None:
-    """Print the ranked scenario comparison as a human-readable table."""
+    """Print the ranked scenario comparison as a human-readable table.
+
+    Lead columns are decision-grade: rank, plan, expected outcome, delta
+    vs baseline, P(beats baseline), P(material loss). The full 95% HDI
+    is preserved in the saved Markdown report rather than the terminal
+    summary so the line stays scannable.
+    """
     typer.echo("\nScenario comparison (ranked by expected outcome)")
     typer.echo("")
     typer.echo(
-        f"  {'Rank':<5} {'Plan':<24} {'Expected outcome':>18} {'95% HDI':>30}"
+        f"  {'Rank':<5} {'Plan':<24} {'Expected outcome':>18} "
+        f"{'Delta vs baseline':>16} {'P(beats)':>10} {'P(loss)':>9}"
     )
     for rank, result in enumerate(results, start=1):
-        hdi_label = (
-            f"{result.expected_outcome_hdi_low:,.0f}–"
-            f"{result.expected_outcome_hdi_high:,.0f}"
-        )
+        if result.is_baseline:
+            delta_label = "—"
+            p_beats_label = "—"
+            p_loss_label = "—"
+        else:
+            delta_label = f"{result.delta_vs_baseline_mean:+,.0f}"
+            p_beats_label = f"{result.probability_beats_baseline:.0%}"
+            p_loss_label = f"{result.probability_material_loss:.0%}"
+        marker = " (baseline)" if result.is_baseline else ""
+        plan_label = (result.plan_name + marker)[:24]
         typer.echo(
-            f"  {rank:<5} {result.plan_name:<24} "
-            f"{result.expected_outcome_mean:>18,.2f} {hdi_label:>30}"
+            f"  {rank:<5} {plan_label:<24} "
+            f"{result.expected_outcome_mean:>18,.0f} "
+            f"{delta_label:>16} {p_beats_label:>10} {p_loss_label:>9}"
         )
+
+    typer.echo("")
+    for result in results:
+        typer.echo(f"  {result.plan_name}: {result.interpretation}")
     for result in results:
         if result.spend_invariant_channels:
             typer.echo(
@@ -1963,24 +1981,73 @@ def _print_scenario_comparison_table(results: list[Any]) -> None:
 
 
 def _format_scenario_comparison_markdown(results: list[Any], run_id: str) -> str:
-    """Produce the saved Markdown report for a scenario comparison."""
+    """Produce the saved Markdown report for a scenario comparison.
+
+    Leads with a decision-grade ranking table (delta vs baseline,
+    probability metrics) and a per-plan plain-English interpretation
+    block. Raw outcome HDI columns and total-spend-by-channel are
+    preserved as analyst detail below.
+    """
     lines: list[str] = []
     lines.append("# Scenario comparison")
     lines.append("")
     lines.append(f"- Run ID: `{run_id}`")
     lines.append(f"- Plans compared: {len(results)}")
+    baseline_row = next((r for r in results if r.is_baseline), None)
+    if baseline_row is not None:
+        lines.append(f"- Baseline plan: `{baseline_row.plan_name}`")
     lines.append("")
 
-    lines.append("## Ranking")
+    lines.append("## Decision ranking")
     lines.append("")
-    lines.append("| Rank | Plan | Expected outcome | 95% HDI low | 95% HDI high |")
-    lines.append("|---|---|---|---|---|")
+    lines.append(
+        "| Rank | Plan | Expected outcome | Delta vs baseline | "
+        "P(beats baseline) | P(material loss) |"
+    )
+    lines.append("|---|---|---:|---:|---:|---:|")
     for rank, result in enumerate(results, start=1):
+        if result.is_baseline:
+            plan_cell = f"`{result.plan_name}` (baseline)"
+            delta_cell = "—"
+            p_beats_cell = "—"
+            p_loss_cell = "—"
+        else:
+            plan_cell = f"`{result.plan_name}`"
+            delta_cell = f"{result.delta_vs_baseline_mean:+,.0f}"
+            p_beats_cell = f"{result.probability_beats_baseline:.0%}"
+            p_loss_cell = f"{result.probability_material_loss:.0%}"
         lines.append(
-            f"| {rank} | `{result.plan_name}` | "
-            f"{result.expected_outcome_mean:,.2f} | "
-            f"{result.expected_outcome_hdi_low:,.2f} | "
-            f"{result.expected_outcome_hdi_high:,.2f} |"
+            f"| {rank} | {plan_cell} | "
+            f"{result.expected_outcome_mean:,.0f} | "
+            f"{delta_cell} | {p_beats_cell} | {p_loss_cell} |"
+        )
+    lines.append("")
+
+    lines.append("## How to read each scenario")
+    lines.append("")
+    for result in results:
+        lines.append(f"- **`{result.plan_name}`** — {result.interpretation}")
+    lines.append("")
+
+    lines.append("## Outcome and delta detail")
+    lines.append("")
+    lines.append(
+        "| Plan | 95% HDI low | 95% HDI high | "
+        "Delta HDI low | Delta HDI high |"
+    )
+    lines.append("|---|---:|---:|---:|---:|")
+    for result in results:
+        if result.is_baseline:
+            delta_low_cell = "—"
+            delta_high_cell = "—"
+        else:
+            delta_low_cell = f"{result.delta_vs_baseline_hdi_low:+,.0f}"
+            delta_high_cell = f"{result.delta_vs_baseline_hdi_high:+,.0f}"
+        lines.append(
+            f"| `{result.plan_name}` | "
+            f"{result.expected_outcome_hdi_low:,.0f} | "
+            f"{result.expected_outcome_hdi_high:,.0f} | "
+            f"{delta_low_cell} | {delta_high_cell} |"
         )
     lines.append("")
 

--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -754,7 +754,7 @@ def export(
     formatted strings) so analysts can pivot and compute on them
     directly.
     """
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
     from wanamaker import __version__
     from wanamaker.artifacts import (
@@ -839,7 +839,7 @@ def export(
         period_start=period_start,
         period_end=period_end,
         n_periods=n_periods,
-        generated_at=datetime.now(timezone.utc),
+        generated_at=datetime.now(UTC),
         package_version=__version__,
         runtime_mode=runtime_mode,
         engine_label=engine_label,

--- a/src/wanamaker/forecast/posterior_predictive.py
+++ b/src/wanamaker/forecast/posterior_predictive.py
@@ -139,6 +139,7 @@ def forecast(
         hdi_low=list(predictive.hdi_low),
         hdi_high=list(predictive.hdi_high),
         interval_mass=predictive.interval_mass,
+        draws=predictive.draws,
         extrapolation_flags=flags,
         spend_invariant_channels=spend_invariant_channels,
     )

--- a/src/wanamaker/forecast/scenarios.py
+++ b/src/wanamaker/forecast/scenarios.py
@@ -1,14 +1,18 @@
 """Scenario comparison (FR-5.2).
 
-User supplies 2–3 budget plans; we rank them with uncertainty and flag any
-plan that extrapolates beyond the historical observed spend range.
-Per FR-3.2, plans involving spend-invariant channels do not get
-reallocation recommendations.
+User supplies 2–3 budget plans; we rank them with uncertainty, flag any
+plan that extrapolates beyond the historical observed spend range, and
+report decision-grade summary metrics (probability of beating baseline,
+downside risk, plain-English interpretation). Per FR-3.2, plans involving
+spend-invariant channels do not get reallocation recommendations.
+
+Per AGENTS.md "Product terminology" the output uses cautious decision
+language ("ranks first", "directional", "not meaningfully distinguishable")
+and avoids optimizer-grade promises ("best budget", "guaranteed lift").
 
 This module is engine-neutral: it accepts a ``PosteriorPredictiveEngine``
 (the same Protocol consumed by ``forecast()``) and never imports any
-specific Bayesian backend. The forecast layer's no-engine-imports
-invariant from ``posterior_predictive`` carries through here.
+specific Bayesian backend.
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from wanamaker.engine.summary import PosteriorSummary
@@ -26,10 +31,22 @@ from wanamaker.forecast.posterior_predictive import (
     load_plan,
 )
 
+# Material loss threshold for the downside-probability metric:
+# probability that the plan underperforms baseline by more than this
+# fraction of the baseline outcome. Mirrors the ramp module's default
+# ``RiskTolerance.min_relative_loss`` so the two surfaces use the same
+# downside definition.
+_MATERIAL_LOSS_THRESHOLD = 0.05
+
 
 @dataclass(frozen=True)
 class ScenarioComparisonResult:
     """Outcome of forecasting a single scenario.
+
+    The first plan in the input list is treated as the baseline; the
+    delta and probability fields below are computed vs. that baseline.
+    For the baseline row itself, all delta and probability fields are
+    zero / 1.0 / informational (see ``is_baseline``).
 
     Attributes:
         plan_name: Either the CSV file's stem or ``"Plan {i}"`` for
@@ -48,6 +65,25 @@ class ScenarioComparisonResult:
         spend_invariant_channels: Channels whose saturation could not be
             estimated from training data (FR-3.2). These are excluded from
             reallocation recommendations.
+        is_baseline: True for the first plan in the input list. Delta /
+            probability fields are not meaningful on the baseline row;
+            consumers should display them as ``—`` or skip them.
+        delta_vs_baseline_mean: Posterior mean of (this plan − baseline).
+            Computed paired-by-draw using the same seed across forecasts,
+            so this captures correlations the per-plan HDIs cannot.
+        delta_vs_baseline_hdi_low: 95% HDI lower bound for the delta.
+        delta_vs_baseline_hdi_high: 95% HDI upper bound for the delta.
+        probability_beats_baseline: Posterior probability that this
+            plan's outcome exceeds the baseline's, computed paired by
+            draw. ``1.0`` for the baseline row by definition.
+        probability_material_loss: Posterior probability that this plan
+            underperforms the baseline by more than 5% of the baseline
+            mean. ``0.0`` for the baseline row.
+        interpretation: One-sentence plain-English summary of how to
+            read this scenario relative to baseline. Generated from a
+            deterministic decision tree over the metrics above; never
+            uses optimizer-grade language (no "best budget", no
+            "guaranteed lift").
     """
 
     plan_name: str
@@ -57,6 +93,13 @@ class ScenarioComparisonResult:
     total_spend_by_channel: dict[str, float]
     extrapolation_flags: list[ExtrapolationFlag] = field(default_factory=list)
     spend_invariant_channels: list[str] = field(default_factory=list)
+    is_baseline: bool = False
+    delta_vs_baseline_mean: float = 0.0
+    delta_vs_baseline_hdi_low: float = 0.0
+    delta_vs_baseline_hdi_high: float = 0.0
+    probability_beats_baseline: float = 1.0
+    probability_material_loss: float = 0.0
+    interpretation: str = ""
 
 
 def compare_scenarios(
@@ -68,9 +111,15 @@ def compare_scenarios(
     """Rank multiple budget plans with uncertainty (FR-5.2).
 
     Each plan is normalised, forecast via the supplied engine, and summarised
-    into a ``ScenarioComparisonResult``. Results are returned ranked by
-    descending ``expected_outcome_mean``; ties break on ``plan_name`` so
-    ordering is deterministic.
+    into a ``ScenarioComparisonResult``. The first plan in ``plans`` is
+    treated as the baseline; delta and probability fields on every other
+    result are computed paired-by-draw against it (so correlations between
+    plans are preserved).
+
+    Results are returned ranked by descending ``expected_outcome_mean``;
+    ties break on ``plan_name`` so ordering is deterministic. The
+    baseline plan is always present in the output but its position
+    depends on its expected outcome.
 
     Args:
         posterior_summary: Engine-neutral summary from a completed fit.
@@ -78,13 +127,16 @@ def compare_scenarios(
             available for extrapolation flagging.
         plans: 1+ future spend plans, each as a CSV path or a DataFrame in
             wide / long / transposed-wide format. See ``load_plan`` for the
-            accepted shapes.
-        seed: Posterior-predictive sampling seed.
+            accepted shapes. The first entry is the baseline.
+        seed: Posterior-predictive sampling seed. The same seed is passed
+            to every per-plan forecast so draws are aligned across plans
+            (paired comparison).
         engine: Implementation of ``PosteriorPredictiveEngine``. The same
             engine is reused across all plans to keep results comparable.
 
     Returns:
-        List of ``ScenarioComparisonResult``, ranked best-first.
+        List of ``ScenarioComparisonResult``, ranked best-first by
+        expected outcome.
 
     Raises:
         ValueError: If ``plans`` is empty.
@@ -96,7 +148,10 @@ def compare_scenarios(
 
     required_channels = [c.channel for c in posterior_summary.channel_contributions]
 
-    results: list[ScenarioComparisonResult] = []
+    # Forecast every plan first (in input order) so we can compute
+    # paired deltas vs the baseline (plans[0]).
+    raw_results: list[tuple[str, dict[str, float], object]] = []
+    per_draw_totals: list[np.ndarray | None] = []
     for index, plan in enumerate(plans):
         plan_name = _plan_name(plan, index)
         normalized = load_plan(plan, required_channels)
@@ -106,6 +161,41 @@ def compare_scenarios(
             channel: float(normalized.data[channel].sum())
             for channel in required_channels
         }
+        raw_results.append((plan_name, total_spend, forecast_result))
+        per_draw_totals.append(_per_draw_totals(forecast_result))
+
+    baseline_totals = per_draw_totals[0]
+    baseline_mean = float(sum(raw_results[0][2].mean))
+
+    results: list[ScenarioComparisonResult] = []
+    for index, (plan_name, total_spend, forecast_result) in enumerate(raw_results):
+        is_baseline = index == 0
+        scenario_totals = per_draw_totals[index]
+
+        if is_baseline or scenario_totals is None or baseline_totals is None:
+            delta_mean = 0.0
+            delta_hdi_low = 0.0
+            delta_hdi_high = 0.0
+            p_beats = 1.0 if is_baseline else 0.5
+            p_material_loss = 0.0
+        else:
+            delta = scenario_totals - baseline_totals
+            delta_mean = float(delta.mean())
+            delta_hdi_low, delta_hdi_high = _hdi(delta, mass=0.95)
+            p_beats = float((delta > 0).mean())
+            loss_threshold = _MATERIAL_LOSS_THRESHOLD * abs(baseline_mean)
+            p_material_loss = float((delta < -loss_threshold).mean())
+
+        interpretation = _interpretation_sentence(
+            is_baseline=is_baseline,
+            plan_name=plan_name,
+            extrapolation_flags=list(forecast_result.extrapolation_flags),
+            spend_invariant_channels=list(forecast_result.spend_invariant_channels),
+            probability_beats_baseline=p_beats,
+            probability_material_loss=p_material_loss,
+            delta_hdi_low=delta_hdi_low,
+            delta_hdi_high=delta_hdi_high,
+        )
 
         results.append(
             ScenarioComparisonResult(
@@ -116,12 +206,122 @@ def compare_scenarios(
                 total_spend_by_channel=total_spend,
                 extrapolation_flags=list(forecast_result.extrapolation_flags),
                 spend_invariant_channels=list(forecast_result.spend_invariant_channels),
+                is_baseline=is_baseline,
+                delta_vs_baseline_mean=delta_mean,
+                delta_vs_baseline_hdi_low=delta_hdi_low,
+                delta_vs_baseline_hdi_high=delta_hdi_high,
+                probability_beats_baseline=p_beats,
+                probability_material_loss=p_material_loss,
+                interpretation=interpretation,
             )
         )
 
     return sorted(
         results,
         key=lambda r: (-r.expected_outcome_mean, r.plan_name),
+    )
+
+
+def _per_draw_totals(forecast_result: object) -> np.ndarray | None:
+    """Total outcome per posterior-predictive draw, summed across periods.
+
+    Returns ``None`` when the forecast has no per-draw matrix (e.g., a
+    summary-only adapter). In that case downstream code falls back to
+    point estimates and the probability fields are reported as ``0.5``
+    / ``0.0``.
+    """
+    draws = getattr(forecast_result, "draws", None)
+    if not draws:
+        return None
+    arr = np.asarray(draws, dtype=float)
+    if arr.ndim != 2:
+        return None
+    return arr.sum(axis=1)
+
+
+def _hdi(values: np.ndarray, mass: float = 0.95) -> tuple[float, float]:
+    """Highest-density interval bounds via the central-mass shortcut.
+
+    For roughly unimodal posterior deltas this returns the same bounds
+    as a proper HDI; for multimodal cases it slightly under-covers but
+    stays well-defined. Same approximation the engine summary uses.
+    """
+    if values.size == 0:
+        return 0.0, 0.0
+    alpha = (1.0 - mass) / 2.0
+    low = float(np.quantile(values, alpha))
+    high = float(np.quantile(values, 1.0 - alpha))
+    return low, high
+
+
+def _interpretation_sentence(
+    *,
+    is_baseline: bool,
+    plan_name: str,
+    extrapolation_flags: list[ExtrapolationFlag],
+    spend_invariant_channels: list[str],
+    probability_beats_baseline: float,
+    probability_material_loss: float,
+    delta_hdi_low: float,
+    delta_hdi_high: float,
+) -> str:
+    """Deterministic plain-English read of a scenario vs. the baseline.
+
+    Decision tree, in order:
+
+    1. Baseline row → short identifying sentence.
+    2. Spend-invariant channels involved → recommend caveats; FR-3.2.
+    3. Plan extrapolates → flag and ask for a controlled test.
+    4. Probability of beating baseline ≥ 0.7 with low downside →
+       directional positive.
+    5. Probability of beating baseline ≤ 0.3 → directional negative.
+    6. Delta credible interval straddles zero → not meaningfully
+       distinguishable.
+    7. Otherwise → mixed signal sentence.
+
+    All sentences avoid optimizer language per AGENTS.md → "Product
+    terminology". The terminology guardrail test enforces that.
+    """
+    if is_baseline:
+        return (
+            f"`{plan_name}` is the baseline plan; other scenarios are "
+            "compared against it."
+        )
+    if spend_invariant_channels:
+        joined = ", ".join(f"`{c}`" for c in spend_invariant_channels)
+        return (
+            "Reallocation involves spend-invariant channel(s) "
+            f"({joined}); FR-3.2 excludes these from reallocation guidance."
+        )
+    if extrapolation_flags:
+        channels = sorted({flag.channel for flag in extrapolation_flags})
+        joined = ", ".join(f"`{c}`" for c in channels)
+        return (
+            f"Plan exceeds historical spend ranges for {joined}; treat as "
+            "a controlled-test candidate, not as supported headroom."
+        )
+    straddles_zero = delta_hdi_low <= 0 <= delta_hdi_high
+    if probability_beats_baseline >= 0.7 and probability_material_loss <= 0.10:
+        return (
+            "Higher expected outcome than baseline "
+            f"(P(beats baseline) = {probability_beats_baseline:.0%}) with "
+            "limited downside; treat as directional, not as a guaranteed move."
+        )
+    if probability_beats_baseline <= 0.3:
+        return (
+            "Lower expected outcome than baseline "
+            f"(P(beats baseline) = {probability_beats_baseline:.0%}); the "
+            "model does not support this reallocation."
+        )
+    if straddles_zero:
+        return (
+            "Delta credible interval straddles zero; not meaningfully "
+            "distinguishable from baseline."
+        )
+    return (
+        "Mixed signal: expected outcome differs from baseline but "
+        f"P(beats baseline) is {probability_beats_baseline:.0%}; treat as "
+        "directional and revisit after more data arrives."
     )
 
 

--- a/src/wanamaker/forecast/scenarios.py
+++ b/src/wanamaker/forecast/scenarios.py
@@ -231,27 +231,29 @@ def _per_draw_totals(forecast_result: object) -> np.ndarray | None:
     / ``0.0``.
     """
     draws = getattr(forecast_result, "draws", None)
-    if not draws:
+    if draws is None:
         return None
     arr = np.asarray(draws, dtype=float)
-    if arr.ndim != 2:
+    if arr.ndim != 2 or arr.size == 0:
         return None
     return arr.sum(axis=1)
 
 
 def _hdi(values: np.ndarray, mass: float = 0.95) -> tuple[float, float]:
-    """Highest-density interval bounds via the central-mass shortcut.
-
-    For roughly unimodal posterior deltas this returns the same bounds
-    as a proper HDI; for multimodal cases it slightly under-covers but
-    stays well-defined. Same approximation the engine summary uses.
-    """
+    """Return shortest interval containing ``mass`` of the sample draws."""
     if values.size == 0:
         return 0.0, 0.0
-    alpha = (1.0 - mass) / 2.0
-    low = float(np.quantile(values, alpha))
-    high = float(np.quantile(values, 1.0 - alpha))
-    return low, high
+    if not 0 < mass <= 1:
+        raise ValueError(f"mass must be in (0, 1]; got {mass!r}")
+    sorted_values = np.sort(np.asarray(values, dtype=float).reshape(-1))
+    interval_size = max(1, int(np.ceil(mass * sorted_values.size)))
+    if interval_size >= sorted_values.size:
+        return float(sorted_values[0]), float(sorted_values[-1])
+    lows = sorted_values[: sorted_values.size - interval_size + 1]
+    highs = sorted_values[interval_size - 1 :]
+    widths = highs - lows
+    best = int(np.argmin(widths))
+    return float(lows[best]), float(highs[best])
 
 
 def _interpretation_sentence(

--- a/tests/unit/test_cli_forecast.py
+++ b/tests/unit/test_cli_forecast.py
@@ -399,11 +399,21 @@ class TestCompareScenariosHappyPath:
         assert report.exists()
         body = report.read_text()
         assert "# Scenario comparison" in body
-        assert "## Ranking" in body
+        # Decision-grade ranking is the lead table.
+        assert "## Decision ranking" in body
+        # Plain-English interpretation block exists.
+        assert "## How to read each scenario" in body
+        # Outcome and delta detail preserves analyst-facing HDI columns.
+        assert "## Outcome and delta detail" in body
         assert "aggressive" in body
         assert "conservative" in body
-        # Higher-mean plan listed before lower-mean plan in the ranking section.
-        assert body.index("aggressive") < body.index("conservative")
+        # Higher-mean plan listed before lower-mean plan inside the ranking
+        # section. Scope the index check to the ranking block since the
+        # baseline-plan header above mentions `conservative` by name.
+        ranking_start = body.index("## Decision ranking")
+        ranking_end = body.index("## How to read each scenario")
+        ranking_block = body[ranking_start:ranking_end]
+        assert ranking_block.index("aggressive") < ranking_block.index("conservative")
         # Total spend section lists both channels.
         assert "## Total spend by channel" in body
         assert "`search`" in body and "`tv`" in body

--- a/tests/unit/test_compare_scenarios.py
+++ b/tests/unit/test_compare_scenarios.py
@@ -341,3 +341,294 @@ class TestResultDataclass:
         plan = _wide_plan([20.0], [100.0])
         results = compare_scenarios(_summary(), [plan], seed=0, engine=StubEngine())
         assert all(isinstance(r, ScenarioComparisonResult) for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Decision-grade metrics (issue #86)
+#
+# Probability and delta fields are computed from a per-draw outcome matrix
+# (PredictiveSummary.draws). DrawsStubEngine returns deterministic draws so
+# the tests can assert exact numbers without invoking PyMC.
+# ---------------------------------------------------------------------------
+
+
+class DrawsStubEngine:
+    """Deterministic engine that returns fixed per-draw outcomes.
+
+    The same seed produces the same draws across every plan, so paired
+    deltas have no within-engine noise — the engine simply maps the
+    plan's spend through fixed coefficients with a small fixed offset
+    per draw, then sums per period to get a total per draw.
+    """
+
+    def __init__(
+        self,
+        search_coef: float = 2.0,
+        tv_coef: float = 0.5,
+        draw_offsets: list[float] | None = None,
+    ) -> None:
+        self.search_coef = search_coef
+        self.tv_coef = tv_coef
+        # Default offsets create a small spread so the HDI is non-degenerate.
+        self.draw_offsets = draw_offsets or [-5.0, -2.0, 0.0, 2.0, 5.0]
+
+    def posterior_predictive(
+        self,
+        posterior_summary: PosteriorSummary,  # noqa: ARG002
+        new_data: pd.DataFrame,
+        seed: int,  # noqa: ARG002
+    ) -> PredictiveSummary:
+        period_means = (
+            new_data["search"].astype(float) * self.search_coef
+            + new_data["tv"].astype(float) * self.tv_coef
+        ).tolist()
+        # draws shape = (n_draws, n_periods).
+        draws = [
+            [m + offset for m in period_means]
+            for offset in self.draw_offsets
+        ]
+        # Use the per-draw matrix's own min/max as conservative HDI bounds.
+        column_lows = [min(d[i] for d in draws) for i in range(len(period_means))]
+        column_highs = [max(d[i] for d in draws) for i in range(len(period_means))]
+        return PredictiveSummary(
+            periods=new_data["period"].astype(str).tolist(),
+            mean=period_means,
+            hdi_low=column_lows,
+            hdi_high=column_highs,
+            draws=draws,
+        )
+
+
+class TestBaselineMarker:
+    def test_first_input_plan_is_baseline(self) -> None:
+        plans = [
+            _wide_plan([20.0], [100.0]),  # baseline
+            _wide_plan([40.0], [100.0]),
+        ]
+        results = compare_scenarios(
+            _summary(), plans, seed=0, engine=DrawsStubEngine(),
+        )
+        baseline = next(r for r in results if r.is_baseline)
+        assert baseline.plan_name == "Plan 1"
+        # And only one row is the baseline.
+        assert sum(r.is_baseline for r in results) == 1
+
+    def test_baseline_row_has_zero_delta_and_full_p_beats(self) -> None:
+        plans = [
+            _wide_plan([20.0], [100.0]),
+            _wide_plan([40.0], [100.0]),
+        ]
+        results = compare_scenarios(
+            _summary(), plans, seed=0, engine=DrawsStubEngine(),
+        )
+        baseline = next(r for r in results if r.is_baseline)
+        assert baseline.delta_vs_baseline_mean == 0.0
+        assert baseline.delta_vs_baseline_hdi_low == 0.0
+        assert baseline.delta_vs_baseline_hdi_high == 0.0
+        assert baseline.probability_beats_baseline == 1.0
+        assert baseline.probability_material_loss == 0.0
+
+
+class TestDeltaAndProbability:
+    def test_higher_mean_plan_has_positive_delta_and_high_p_beats(self) -> None:
+        plans = [
+            _wide_plan([20.0], [100.0]),  # mean = 90
+            _wide_plan([40.0], [100.0]),  # mean = 130
+        ]
+        results = compare_scenarios(
+            _summary(), plans, seed=0, engine=DrawsStubEngine(),
+        )
+        non_baseline = next(r for r in results if not r.is_baseline)
+        assert non_baseline.delta_vs_baseline_mean == pytest.approx(40.0)
+        # Every paired draw improves by exactly +40, so P(beats) = 100%.
+        assert non_baseline.probability_beats_baseline == 1.0
+        assert non_baseline.probability_material_loss == 0.0
+
+    def test_lower_mean_plan_has_negative_delta_and_low_p_beats(self) -> None:
+        plans = [
+            _wide_plan([40.0], [100.0]),  # baseline = 130
+            _wide_plan([20.0], [100.0]),  # mean = 90
+        ]
+        results = compare_scenarios(
+            _summary(), plans, seed=0, engine=DrawsStubEngine(),
+        )
+        non_baseline = next(r for r in results if not r.is_baseline)
+        assert non_baseline.delta_vs_baseline_mean == pytest.approx(-40.0)
+        assert non_baseline.probability_beats_baseline == 0.0
+        # 5% material-loss threshold of 130 = 6.5; -40 is far past that.
+        assert non_baseline.probability_material_loss == 1.0
+
+    def test_paired_delta_collapses_zero_when_plans_are_identical(self) -> None:
+        plan = _wide_plan([20.0], [100.0])
+        results = compare_scenarios(
+            _summary(), [plan, plan], seed=0, engine=DrawsStubEngine(),
+        )
+        # The non-baseline duplicate has zero paired delta on every draw.
+        non_baseline = next(r for r in results if not r.is_baseline)
+        assert non_baseline.delta_vs_baseline_mean == 0.0
+        # All draws are exactly equal -> P(strict beat) is 0%.
+        assert non_baseline.probability_beats_baseline == 0.0
+        assert non_baseline.probability_material_loss == 0.0
+
+
+class TestInterpretationSentences:
+    """Each interpretation bucket should produce a sentence the deterministic
+    template can render. The terminology guardrail enforces that none of
+    these sentences leaks optimizer language."""
+
+    def test_baseline_sentence_identifies_as_reference(self) -> None:
+        plans = [_wide_plan([20.0], [100.0]), _wide_plan([40.0], [100.0])]
+        results = compare_scenarios(
+            _summary(), plans, seed=0, engine=DrawsStubEngine(),
+        )
+        baseline = next(r for r in results if r.is_baseline)
+        assert "baseline" in baseline.interpretation.lower()
+
+    def test_directional_positive_sentence_for_high_p_beats(self) -> None:
+        plans = [
+            _wide_plan([20.0], [100.0]),  # baseline
+            _wide_plan([40.0], [100.0]),  # P(beats) = 100%
+        ]
+        # Use a TV-channel summary that's NOT spend-invariant so we hit
+        # the "no caveats" branch of the decision tree.
+        results = compare_scenarios(
+            _summary(spend_invariant_tv=False),
+            plans, seed=0, engine=DrawsStubEngine(),
+        )
+        non_baseline = next(r for r in results if not r.is_baseline)
+        assert "P(beats baseline) = 100%" in non_baseline.interpretation
+        assert "directional" in non_baseline.interpretation.lower()
+
+    def test_directional_negative_sentence_for_low_p_beats(self) -> None:
+        plans = [
+            _wide_plan([40.0], [100.0]),  # baseline
+            _wide_plan([20.0], [100.0]),  # P(beats) = 0%
+        ]
+        results = compare_scenarios(
+            _summary(spend_invariant_tv=False),
+            plans, seed=0, engine=DrawsStubEngine(),
+        )
+        non_baseline = next(r for r in results if not r.is_baseline)
+        assert "Lower expected outcome" in non_baseline.interpretation
+        assert "does not support" in non_baseline.interpretation
+
+    def test_extrapolation_sentence_when_plan_exceeds_observed_range(self) -> None:
+        plans = [
+            _wide_plan([20.0], [100.0]),  # baseline
+            _wide_plan([60.0], [100.0]),  # search=60 exceeds observed_max=50
+        ]
+        results = compare_scenarios(
+            _summary(spend_invariant_tv=False),
+            plans, seed=0, engine=DrawsStubEngine(),
+        )
+        non_baseline = next(r for r in results if not r.is_baseline)
+        assert "exceeds historical spend ranges" in non_baseline.interpretation
+        assert "controlled-test candidate" in non_baseline.interpretation
+
+    def test_spend_invariant_sentence_takes_precedence(self) -> None:
+        """Spend-invariant caveats should win the interpretation
+        regardless of probability metrics — FR-3.2 is the higher rule."""
+        plans = [_wide_plan([20.0], [100.0]), _wide_plan([20.0], [100.0])]
+        # tv is spend-invariant in this summary fixture.
+        results = compare_scenarios(
+            _summary(spend_invariant_tv=True),
+            plans, seed=0, engine=DrawsStubEngine(),
+        )
+        non_baseline = next(r for r in results if not r.is_baseline)
+        assert "spend-invariant" in non_baseline.interpretation
+        assert "FR-3.2" in non_baseline.interpretation
+
+    def test_indistinguishable_sentence_for_zero_straddling_delta(self) -> None:
+        """Direct test of the interpretation helper for the
+        ``delta credible interval straddles zero`` bucket.
+
+        Going through ``compare_scenarios`` here would be misleading: a
+        deterministic engine with paired draws produces a fully resolved
+        delta (paired noise cancels), so it can't naturally hit the
+        ``straddles zero`` decision branch. The helper itself is the
+        decision tree, so testing it directly is the correct level.
+        """
+        from wanamaker.forecast.scenarios import _interpretation_sentence
+
+        sentence = _interpretation_sentence(
+            is_baseline=False,
+            plan_name="alt",
+            extrapolation_flags=[],
+            spend_invariant_channels=[],
+            probability_beats_baseline=0.55,
+            probability_material_loss=0.05,
+            delta_hdi_low=-100.0,
+            delta_hdi_high=200.0,
+        )
+        assert "not meaningfully distinguishable" in sentence
+
+    def test_mixed_signal_sentence_for_middle_p_beats_with_one_sided_delta(
+        self,
+    ) -> None:
+        """Direct test: P(beats) in the middle band but delta CI fully
+        positive routes to the 'mixed signal' bucket."""
+        from wanamaker.forecast.scenarios import _interpretation_sentence
+
+        sentence = _interpretation_sentence(
+            is_baseline=False,
+            plan_name="alt",
+            extrapolation_flags=[],
+            spend_invariant_channels=[],
+            probability_beats_baseline=0.55,
+            probability_material_loss=0.05,
+            delta_hdi_low=10.0,  # entirely above zero — but P(beats) is mid
+            delta_hdi_high=200.0,
+        )
+        assert "mixed signal" in sentence.lower()
+
+
+class TestGracefulFallbackWithoutDraws:
+    """When the stub engine returns no per-draw matrix, the new fields
+    fall back to neutral defaults instead of crashing. The original
+    StubEngine in this file does not produce draws, so this is the
+    backward-compat path."""
+
+    def test_probabilities_fall_back_to_neutral_without_draws(self) -> None:
+        plans = [_wide_plan([20.0], [100.0]), _wide_plan([40.0], [100.0])]
+        results = compare_scenarios(_summary(), plans, seed=0, engine=StubEngine())
+        non_baseline = next(r for r in results if not r.is_baseline)
+        assert non_baseline.probability_beats_baseline == 0.5
+        assert non_baseline.probability_material_loss == 0.0
+        # Delta fields are zero (the function can't compute paired
+        # comparison without draws).
+        assert non_baseline.delta_vs_baseline_mean == 0.0
+
+
+class TestNoBannedTerminology:
+    """The interpretation sentences must not leak optimizer language."""
+
+    def test_no_banned_phrases_in_any_interpretation(self) -> None:
+        # Mirrors AGENTS.md → "Product terminology" and the canonical
+        # list in tests/unit/test_terminology_guardrails.py. Defined
+        # locally because tests/ is not a package.
+        banned_phrases = (
+            "optimized budget",
+            "optimal allocation",
+            "best budget",
+            "guaranteed lift",
+            "maximize roi",
+        )
+
+        plans = [
+            _wide_plan([20.0], [100.0]),
+            _wide_plan([40.0], [100.0]),
+            _wide_plan([60.0], [100.0]),  # extrapolation
+        ]
+        # Cover the spend-invariant branch too.
+        for spend_invariant in (True, False):
+            results = compare_scenarios(
+                _summary(spend_invariant_tv=spend_invariant),
+                plans, seed=0, engine=DrawsStubEngine(),
+            )
+            for r in results:
+                lowered = r.interpretation.lower()
+                for phrase in banned_phrases:
+                    assert phrase not in lowered, (
+                        f"interpretation for {r.plan_name!r} contains "
+                        f"banned phrase {phrase!r}: {r.interpretation!r}"
+                    )

--- a/tests/unit/test_compare_scenarios.py
+++ b/tests/unit/test_compare_scenarios.py
@@ -599,6 +599,33 @@ class TestGracefulFallbackWithoutDraws:
         assert non_baseline.delta_vs_baseline_mean == 0.0
 
 
+class TestPerDrawHelpers:
+    def test_per_draw_totals_accepts_array_like_draws(self) -> None:
+        from wanamaker.forecast.scenarios import _per_draw_totals
+
+        result = PredictiveSummary(
+            periods=["p1", "p2"],
+            mean=[1.0, 2.0],
+            hdi_low=[0.0, 1.0],
+            hdi_high=[2.0, 3.0],
+            draws=[[1.0, 2.0], [3.0, 4.0]],
+        )
+
+        assert _per_draw_totals(result).tolist() == [3.0, 7.0]
+
+    def test_hdi_uses_shortest_interval_not_equal_tailed_quantiles(self) -> None:
+        from wanamaker.forecast.scenarios import _hdi
+
+        low, high = _hdi(
+            # Shortest 80% interval is [0, 3], not an interpolated
+            # equal-tailed interval that would include part of the outlier gap.
+            values=pd.Series([0.0, 1.0, 2.0, 3.0, 100.0]).to_numpy(),
+            mass=0.8,
+        )
+
+        assert (low, high) == (0.0, 3.0)
+
+
 class TestNoBannedTerminology:
     """The interpretation sentences must not leak optimizer language."""
 


### PR DESCRIPTION
## Summary

Closes #86. The `compare-scenarios` command now leads with a decision-grade ranking that names what stakeholders care about — expected lift, **probability of beating baseline**, **downside risk** — rather than the previous mean+HDI table that read like an analyst dump. Each scenario also gets a plain-English interpretation generated from a deterministic decision tree, so the report can be forwarded without hand-translating the metrics.

This builds on the terminology guardrails landed in #97: every interpretation sentence respects the cautious-language rule (no "best plan", no "guaranteed lift") and a guardrail-style test sweeps every fixture-generated interpretation to keep that contract live.

## Sample of the new lead table (Markdown)

```
## Decision ranking

| Rank | Plan | Expected outcome | Δ vs baseline | P(beats baseline) | P(material loss) |
|---|---|---:|---:|---:|---:|
| 1 | `aggressive` | 1,250,000 | +85,000 | 92% | 3% |
| 2 | `conservative` (baseline) | 1,165,000 | — | — | — |

## How to read each scenario

- **`aggressive`** — Higher expected outcome than baseline (P(beats baseline) = 92%) with limited downside; treat as directional, not as a guaranteed move.
- **`conservative`** — `conservative` is the baseline plan; other scenarios are compared against it.
```

## Changes

- **Math layer.** `ScenarioComparisonResult` gains `is_baseline`, `delta_vs_baseline_mean`, `delta_vs_baseline_hdi_low/_high`, `probability_beats_baseline`, `probability_material_loss`, and a deterministic `interpretation` string. Probability fields are computed paired-by-draw against the first plan (the implicit baseline) using the engine's per-draw outcome matrix, so correlations between plans are preserved.
- **`forecast()` passthrough.** The forecast wrapper now includes `draws` in the returned `ForecastResult`. Without that, `compare-scenarios` couldn't reach the per-draw matrix it needs for paired comparisons. Same data the ramp module already reads via the engine directly.
- **Interpretation buckets** (`_interpretation_sentence`): baseline, spend-invariant caveat (FR-3.2), extrapolation, directional positive, directional negative, indistinguishable, mixed signal. Six exclusive paths through a clear decision tree.
- **CLI table.** Adds P(beats baseline) and P(material loss) columns plus a per-plan interpretation block beneath. Greek delta spelled "Delta" so the file reads cleanly under cp1252 on Windows runners.
- **Saved Markdown report** leads with `## Decision ranking` and `## How to read each scenario`. Analyst-facing HDI and Delta-HDI columns preserved under `## Outcome and delta detail` at the bottom.

## Tests

**[test_compare_scenarios.py](tests/unit/test_compare_scenarios.py)** — new sections:

- `TestBaselineMarker` — first input plan is flagged `is_baseline=True`; baseline row has zero delta + 1.0 P(beats).
- `TestDeltaAndProbability` — positive/negative/zero delta correctness using a `DrawsStubEngine` that returns deterministic per-draw outcomes; identical plans collapse to zero paired delta.
- `TestInterpretationSentences` — four buckets exercised through `compare_scenarios` (baseline, directional positive, directional negative, extrapolation, spend-invariant); the indistinguishable + mixed-signal buckets are exercised via direct calls to `_interpretation_sentence` because deterministic paired-draw stubs can't naturally produce a zero-straddling delta.
- `TestGracefulFallbackWithoutDraws` — engines that don't return per-draw matrices fall back to neutral defaults (P=0.5, delta=0) rather than crashing.
- `TestNoBannedTerminology` — every interpretation produced by the fixtures is swept for the AGENTS.md banned phrases.

**[test_cli_forecast.py](tests/unit/test_cli_forecast.py)** — updated assertions for the new section headings; the ranking-section index check is now scoped to the ranking block since the baseline plan name appears in the report header above it.

## Validation

- **Full unit suite:** 719 passed (was 705 + 14 new)
- **Lint clean** on all touched files
- **`mkdocs build --strict`** passes
- **Coordination:** zero file overlap with Jules's PR #96 (which is back in revision after my review). Both PRs sit on master cleanly.

## Test plan

- [ ] `wanamaker compare-scenarios --run-id <id> --plans base.csv alt.csv` produces a Markdown report whose `## Decision ranking` table includes the new probability columns
- [ ] The "How to read each scenario" block reads as plain English a CMO would understand
- [ ] Confirm the analyst-facing `## Outcome and delta detail` table preserves the raw HDI bounds
- [ ] Run with the public_benchmark and a tight uncertainty fixture to see the directional-positive interpretation in action

🤖 Generated with [Claude Code](https://claude.com/claude-code)