### PR TITLE
Productize lift-test calibration config

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -190,6 +190,7 @@ Unknown fields are rejected.
 | `channels` | list of `ChannelConfig` | `[]` | Per-channel category and adstock settings. |
 | `refresh` | `RefreshConfig` | `{anchor_strength: medium}` | Refresh accountability settings. |
 | `run` | `RunConfig` | `{seed: 0, runtime_mode: standard, artifact_dir: .wanamaker}` | Reproducibility and artifact settings. |
+| `calibration` | `CalibrationConfig` | `null` | External evidence and priors. |
 
 ### `data`
 
@@ -200,12 +201,19 @@ Unknown fields are rejected.
 | `target_column` | string | required | Target metric column, such as revenue or conversions. |
 | `spend_columns` | list of strings | `[]` | Paid media spend columns. |
 | `control_columns` | list of strings | `[]` | Non-media controls such as price, promotions, holidays, or macro indicators. |
-| `lift_test_csv` | path or null | `null` | Optional lift-test calibration CSV. |
+| `lift_test_csv` | path or null | `null` | **Deprecated.** Optional lift-test calibration CSV. Use `calibration.lift_tests.path` instead. |
 
-For `lift_test_csv`, Wanamaker supports three CSV schemas (all require `channel`, `test_start`, and `test_end` columns):
+For `calibration.lift_tests.path` (or legacy `lift_test_csv`), Wanamaker supports three CSV schemas (all require `channel`, `test_start`, and `test_end` columns):
 - **ROI Schema (Canonical):** Explicit ROI fields using `roi_estimate`, `roi_ci_lower`, and `roi_ci_upper`.
 - **Outcome Schema:** `incremental_outcome`, `incremental_spend`, `ci_lower_outcome`, and `ci_upper_outcome`. Wanamaker calculates ROI internally as outcome / spend.
 - **Legacy Schema:** Legacy lift fields `lift_estimate`, `ci_lower`, and `ci_upper`. Supported with a deprecation warning.
+
+### `calibration`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `lift_tests.path` | path | required if `lift_tests` set | CSV containing experiment/lift-test evidence. |
+| `lift_tests.mode` | `roi_prior` | `roi_prior` | How to use the lift test data (currently only `roi_prior` is supported). |
 
 ### `channels`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,8 +99,9 @@ All user-facing configuration is validated here via pydantic before any other mo
 ```
 WanamakerConfig
 +-- DataConfig          csv_path, date_column, target_column,
-|                       spend_columns, control_columns, lift_test_csv
+|                       spend_columns, control_columns
 +-- ChannelConfig[]     name, category, adstock_family per channel
++-- CalibrationConfig   lift_tests (path, mode)
 +-- RefreshConfig       anchor_strength (preset or float)
 +-- RunConfig           seed, runtime_mode, artifact_dir
 ```

--- a/docs/examples/lift_test_changes_verdict.md
+++ b/docs/examples/lift_test_changes_verdict.md
@@ -112,7 +112,6 @@ data:
   csv_path: tutorial_data/data.csv
   date_column: week
   target_column: revenue
-  lift_test_csv: tutorial_data/lift_tests.csv
   spend_columns:
     - paid_search
     - paid_social
@@ -145,6 +144,10 @@ channels:
     category: affiliate
   - name: email
     category: email_crm
+
+calibration:
+  lift_tests:
+    path: tutorial_data/lift_tests.csv
 
 run:
   seed: 20260430

--- a/docs/examples/lift_test_changes_verdict.md
+++ b/docs/examples/lift_test_changes_verdict.md
@@ -103,8 +103,8 @@ weight on the experiment.
 ## Step 3 — Refit with calibration
 
 Write a calibrated config that points at the lift-test CSV. Use the
-same fields as the uncalibrated config plus a `lift_test_csv` entry
-under `data:`:
+same fields as the uncalibrated config plus a `calibration.lift_tests`
+section:
 
 ```bash
 cat > tutorial_data/config_calibrated.yaml <<'EOF'

--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -2163,7 +2163,10 @@ def _load_lift_priors_if_any(cfg: Any) -> Any:
     """
     from wanamaker.model.builder import build_model_spec
 
-    if cfg.data.lift_test_csv is None:
+    calibration = getattr(cfg, "calibration", None)
+    lift_tests = getattr(calibration, "lift_tests", None)
+    legacy_path = getattr(cfg.data, "lift_test_csv", None)
+    if lift_tests is None and legacy_path is None:
         return None
     spec = build_model_spec(cfg)
     return spec.lift_test_priors or None

--- a/src/wanamaker/config.py
+++ b/src/wanamaker/config.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 RuntimeMode = Literal["quick", "standard", "full"]
 AnchorStrength = Literal["none", "light", "medium", "heavy"]
@@ -64,6 +64,23 @@ class RunConfig(BaseModel):
     artifact_dir: Path = Path(".wanamaker")
 
 
+class LiftTestCalibrationConfig(BaseModel):
+    """Configuration for lift-test / experiment calibration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: Path
+    mode: Literal["roi_prior"] = "roi_prior"
+
+
+class CalibrationConfig(BaseModel):
+    """Evidence and priors to calibrate the model."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    lift_tests: LiftTestCalibrationConfig | None = None
+
+
 class WanamakerConfig(BaseModel):
     """The full validated configuration for a Wanamaker run."""
 
@@ -73,6 +90,22 @@ class WanamakerConfig(BaseModel):
     channels: list[ChannelConfig] = Field(default_factory=list)
     refresh: RefreshConfig = Field(default_factory=RefreshConfig)
     run: RunConfig = Field(default_factory=RunConfig)
+    calibration: CalibrationConfig | None = None
+
+    @model_validator(mode="after")
+    def _check_lift_test_conflict(self) -> WanamakerConfig:
+        has_legacy = self.data.lift_test_csv is not None
+        has_new = (
+            self.calibration is not None
+            and self.calibration.lift_tests is not None
+            and self.calibration.lift_tests.path is not None
+        )
+        if has_legacy and has_new:
+            raise ValueError(
+                "Cannot specify both data.lift_test_csv and calibration.lift_tests.path. "
+                "Use calibration.lift_tests.path."
+            )
+        return self
 
 
 def load_config(path: Path) -> WanamakerConfig:

--- a/src/wanamaker/model/builder.py
+++ b/src/wanamaker/model/builder.py
@@ -89,11 +89,17 @@ def build_model_spec(cfg: WanamakerConfig) -> ModelSpec:
 
 
 def _load_lift_test_priors(cfg: WanamakerConfig) -> dict[str, LiftPrior]:
-    if cfg.data.lift_test_csv is None:
+    path = None
+    if cfg.calibration is not None and cfg.calibration.lift_tests is not None:
+        path = cfg.calibration.lift_tests.path
+    elif cfg.data.lift_test_csv is not None:
+        path = cfg.data.lift_test_csv
+
+    if path is None:
         return {}
 
     channel_names = {channel.name for channel in cfg.channels}
-    lift_tests = load_lift_test_csv(cfg.data.lift_test_csv)
+    lift_tests = load_lift_test_csv(path)
     unknown = sorted(set(lift_tests["channel"]) - channel_names)
     if unknown:
         raise ValueError(

--- a/tests/unit/test_lift_test_calibration.py
+++ b/tests/unit/test_lift_test_calibration.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from wanamaker.cli import _load_lift_priors_if_any
 from wanamaker.config import (
     CalibrationConfig,
     ChannelConfig,
@@ -178,7 +179,7 @@ def test_build_model_spec_uses_calibration_config_priors(tmp_path: Path) -> None
         "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
         "search,2024-01-01,2024-01-14,2.0,1.216014,2.783986\n",
     )
-    
+
     cfg = WanamakerConfig(
         data=DataConfig(
             csv_path=data_csv,
@@ -191,11 +192,40 @@ def test_build_model_spec_uses_calibration_config_priors(tmp_path: Path) -> None
             lift_tests=LiftTestCalibrationConfig(path=lift_csv)
         ),
     )
-    
+
     spec = build_model_spec(cfg)
     assert set(spec.lift_test_priors) == {"search"}
     prior = spec.lift_test_priors["search"]
     assert prior.mean_roi == pytest.approx(2.0)
+
+
+def test_cli_lift_prior_helper_uses_calibration_config(tmp_path: Path) -> None:
+    data_csv = tmp_path / "data.csv"
+    data_csv.write_text("week,revenue,search\n2024-01-01,100,10\n", encoding="utf-8")
+    lift_csv = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.216014,2.783986\n",
+    )
+
+    cfg = WanamakerConfig(
+        data=DataConfig(
+            csv_path=data_csv,
+            date_column="week",
+            target_column="revenue",
+            spend_columns=["search"],
+        ),
+        channels=[ChannelConfig(name="search", category="paid_search")],
+        calibration=CalibrationConfig(
+            lift_tests=LiftTestCalibrationConfig(path=lift_csv)
+        ),
+    )
+
+    priors = _load_lift_priors_if_any(cfg)
+
+    assert priors is not None
+    assert set(priors) == {"search"}
+    assert priors["search"].mean_roi == pytest.approx(2.0)
 
 
 def test_config_rejects_conflicting_lift_test_paths(tmp_path: Path) -> None:
@@ -207,7 +237,7 @@ def test_config_rejects_conflicting_lift_test_paths(tmp_path: Path) -> None:
         "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
         encoding="utf-8",
     )
-    
+
     with pytest.raises(ValueError, match="Cannot specify both"):
         WanamakerConfig(
             data=DataConfig(

--- a/tests/unit/test_lift_test_calibration.py
+++ b/tests/unit/test_lift_test_calibration.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from wanamaker.config import ChannelConfig, DataConfig, WanamakerConfig
+from wanamaker.config import (
+    CalibrationConfig,
+    ChannelConfig,
+    DataConfig,
+    LiftTestCalibrationConfig,
+    WanamakerConfig,
+)
 from wanamaker.data.io import load_lift_test_csv
 from wanamaker.engine.pymc import _coefficient_prior
 from wanamaker.model.builder import build_model_spec
@@ -162,6 +168,60 @@ def test_build_model_spec_converts_lift_tests_to_priors(tmp_path: Path) -> None:
     assert prior.mean_roi == pytest.approx(2.0)
     assert prior.sd_roi == pytest.approx(0.4, rel=1e-6)
     assert prior.confidence == pytest.approx(0.95)
+
+
+def test_build_model_spec_uses_calibration_config_priors(tmp_path: Path) -> None:
+    data_csv = tmp_path / "data.csv"
+    data_csv.write_text("week,revenue,search\n2024-01-01,100,10\n", encoding="utf-8")
+    lift_csv = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.216014,2.783986\n",
+    )
+    
+    cfg = WanamakerConfig(
+        data=DataConfig(
+            csv_path=data_csv,
+            date_column="week",
+            target_column="revenue",
+            spend_columns=["search"],
+        ),
+        channels=[ChannelConfig(name="search", category="paid_search")],
+        calibration=CalibrationConfig(
+            lift_tests=LiftTestCalibrationConfig(path=lift_csv)
+        ),
+    )
+    
+    spec = build_model_spec(cfg)
+    assert set(spec.lift_test_priors) == {"search"}
+    prior = spec.lift_test_priors["search"]
+    assert prior.mean_roi == pytest.approx(2.0)
+
+
+def test_config_rejects_conflicting_lift_test_paths(tmp_path: Path) -> None:
+    data_csv = tmp_path / "data.csv"
+    data_csv.write_text("week,revenue,search\n2024-01-01,100,10\n", encoding="utf-8")
+    lift_csv = tmp_path / "lift_tests.csv"
+    lift_csv.write_text(
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n",
+        encoding="utf-8",
+    )
+    
+    with pytest.raises(ValueError, match="Cannot specify both"):
+        WanamakerConfig(
+            data=DataConfig(
+                csv_path=data_csv,
+                date_column="week",
+                target_column="revenue",
+                spend_columns=["search"],
+                lift_test_csv=lift_csv,
+            ),
+            channels=[ChannelConfig(name="search", category="paid_search")],
+            calibration=CalibrationConfig(
+                lift_tests=LiftTestCalibrationConfig(path=lift_csv)
+            ),
+        )
 
 
 def test_build_model_spec_rejects_lift_test_for_unknown_channel(tmp_path: Path) -> None:


### PR DESCRIPTION
Resolves #76.

Introduces a first-class \calibration\ section in the \WanamakerConfig\ to make lift-test functionality more discoverable for users, while maintaining backward compatibility with the legacy \data.lift_test_csv\ configuration.