### PR TITLE
Support multiple lift tests per channel via precision-weighted pooling (closes #78)

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -208,6 +208,16 @@ For `calibration.lift_tests.path` (or legacy `lift_test_csv`), Wanamaker support
 - **Outcome Schema:** `incremental_outcome`, `incremental_spend`, `ci_lower_outcome`, and `ci_upper_outcome`. Wanamaker calculates ROI internally as outcome / spend.
 - **Legacy Schema:** Legacy lift fields `lift_estimate`, `ci_lower`, and `ci_upper`. Supported with a deprecation warning.
 
+**Multiple tests per channel.** A channel may appear on more than one row. Wanamaker treats those rows as independent ROI estimates and combines them via precision-weighted (inverse-variance) pooling:
+
+- `precision_i = 1 / σ_i²` for each row's standard deviation `σ_i = (CI_upper − CI_lower) / (2 × 1.96)`.
+- `μ_pooled = Σ(μ_i × precision_i) / Σ precision_i`
+- `σ_pooled = √(1 / Σ precision_i)`
+
+The pooled `σ` is always less than the smallest individual `σ`. The Trust Card calibration line ("Calibrated with N lift tests…") reports the total number of underlying rows, not the number of channels.
+
+**Independence assumption.** The pooling formula assumes the rows are independent. When two rows for the same channel have overlapping `[test_start, test_end]` windows, Wanamaker emits a `UserWarning` because shared market/time/audience violates that assumption. Either combine the tests externally before supplying them, or widen one interval to absorb the correlation.
+
 ### `calibration`
 
 | Field | Type | Default | Description |

--- a/docs/examples/lift_test_changes_verdict.md
+++ b/docs/examples/lift_test_changes_verdict.md
@@ -100,6 +100,13 @@ The required columns are `channel`, `test_start`, `test_end`,
 into a Gaussian prior on the channel's effect; tighter bounds put more
 weight on the experiment.
 
+If you have multiple tests for the same channel (different geos or different
+time windows), put each on its own row. Wanamaker combines them via
+precision-weighted pooling and reports the total in the Trust Card. This
+assumes the tests are *independent* — overlapping market/time/audience
+windows trigger a warning, in which case combine the tests externally or
+widen one interval to absorb the correlation.
+
 ## Step 3 — Refit with calibration
 
 Write a calibrated config that points at the lift-test CSV. Use the

--- a/src/wanamaker/data/io.py
+++ b/src/wanamaker/data/io.py
@@ -79,23 +79,30 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
       ci_lower, ci_upper
 
     The returned frame converts any schema into the canonical ROI columns,
-    parses test dates, converts numeric fields to floats, and rejects
-    ambiguous duplicate channel rows or mixed schemas. Conversion from
-    confidence intervals to ``LiftPrior`` objects is handled by
-    ``wanamaker.model.builder``.
+    parses test dates, and converts numeric fields to floats. Conversion
+    from confidence intervals to ``LiftPrior`` objects (including
+    precision-weighted pooling when a channel has multiple tests) is
+    handled by ``wanamaker.model.builder``.
+
+    Multiple rows per channel are allowed and pooled downstream as
+    independent ROI estimates (#78). When two rows for the same channel
+    have overlapping ``[test_start, test_end]`` windows, a
+    ``UserWarning`` fires because the independence assumption the
+    pooling formula relies on is violated — the user should either
+    combine the tests externally or supply a wider interval.
 
     Args:
         path: Path to the lift-test CSV.
 
     Returns:
-        Validated lift-test results, one row per channel, with canonical
-        ROI columns (roi_estimate, roi_ci_lower, roi_ci_upper).
+        Validated lift-test results with canonical ROI columns
+        (``roi_estimate``, ``roi_ci_lower``, ``roi_ci_upper``).
+        Multiple rows per channel are preserved.
 
     Raises:
         FileNotFoundError: If ``path`` does not exist.
         ValueError: If required columns are missing, mixed schemas are used,
-            dates/numbers cannot be parsed, intervals are invalid, or a
-            channel appears more than once.
+            dates/numbers cannot be parsed, or intervals are invalid.
     """
     df = pd.read_csv(path)
     columns = set(df.columns)
@@ -160,12 +167,6 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
     if bool((out["channel"] == "").any()):
         raise ValueError(f"lift-test CSV {path} contains blank channel names")
 
-    duplicates = sorted(out.loc[out["channel"].duplicated(), "channel"].unique())
-    if duplicates:
-        raise ValueError(
-            f"lift-test CSV {path} contains duplicate channel rows: {duplicates}"
-        )
-
     for column in ("test_start", "test_end"):
         out[column] = pd.to_datetime(out[column], errors="raise")
 
@@ -186,4 +187,39 @@ def load_lift_test_csv(path: Path) -> pd.DataFrame:
             f"lift-test CSV {path} has roi_ci_upper <= roi_ci_lower for channels: {channels}"
         )
 
+    overlapping = _channels_with_overlapping_test_windows(out)
+    if overlapping:
+        warnings.warn(
+            f"lift-test CSV {path} has overlapping test windows for channels: "
+            f"{sorted(overlapping)}. The pooling formula assumes the rows are "
+            "independent; overlapping market/time/audience violates that. "
+            "Combine these tests externally or supply a wider interval.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     return out
+
+
+def _channels_with_overlapping_test_windows(df: pd.DataFrame) -> set[str]:
+    """Return channels whose multiple test rows have overlapping date windows.
+
+    Independence-violating overlap is the case the pooling formula in
+    ``wanamaker.model.builder`` cannot recover from cleanly. Two
+    closed intervals ``[a1, a2]`` and ``[b1, b2]`` overlap iff
+    ``a1 <= b2 and b1 <= a2``.
+    """
+    overlapping: set[str] = set()
+    for channel, group in df.groupby("channel"):
+        if len(group) < 2:
+            continue
+        starts = group["test_start"].tolist()
+        ends = group["test_end"].tolist()
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                if starts[i] <= ends[j] and starts[j] <= ends[i]:
+                    overlapping.add(str(channel))
+                    break
+            if channel in overlapping:
+                break
+    return overlapping

--- a/src/wanamaker/model/builder.py
+++ b/src/wanamaker/model/builder.py
@@ -107,18 +107,77 @@ def _load_lift_test_priors(cfg: WanamakerConfig) -> dict[str, LiftPrior]:
             f"{unknown}. Add them to channels or remove the lift-test rows."
         )
 
+    # Group rows by channel so multiple lift tests for the same channel
+    # can be pooled (#78). Single-test channels still produce a single
+    # ``LiftPrior`` with the same mean/sd as before.
     priors: dict[str, LiftPrior] = {}
-    for row in lift_tests.itertuples(index=False):
-        interval_width = float(row.roi_ci_upper) - float(row.roi_ci_lower)
-        sd_roi = interval_width / (2.0 * _NORMAL_95_Z)
-        if not math.isfinite(sd_roi) or sd_roi <= 0.0:
-            raise ValueError(
-                f"lift-test CSV produced a non-positive prior sd for channel {row.channel!r}"
+    for channel, group in lift_tests.groupby("channel"):
+        per_test_priors: list[LiftPrior] = []
+        for row in group.itertuples(index=False):
+            interval_width = float(row.roi_ci_upper) - float(row.roi_ci_lower)
+            sd_roi = interval_width / (2.0 * _NORMAL_95_Z)
+            if not math.isfinite(sd_roi) or sd_roi <= 0.0:
+                raise ValueError(
+                    f"lift-test CSV produced a non-positive prior sd for channel {channel!r}"
+                )
+            per_test_priors.append(
+                LiftPrior(
+                    mean_roi=float(row.roi_estimate),
+                    sd_roi=sd_roi,
+                    confidence=0.95,
+                )
             )
-        priors[str(row.channel)] = LiftPrior(
-            mean_roi=float(row.roi_estimate),
-            sd_roi=sd_roi,
-            confidence=0.95,
-        )
+        priors[str(channel)] = pool_lift_priors(per_test_priors)
 
     return priors
+
+
+def pool_lift_priors(priors: list[LiftPrior]) -> LiftPrior:
+    """Combine multiple ``LiftPrior``s for the same channel via precision weighting.
+
+    For independent ROI estimates ``μ_i`` with standard deviations ``σ_i``,
+    the precision-weighted pooled estimate is:
+
+        precision_i = 1 / σ_i²
+        μ_pooled    = Σ(μ_i × precision_i) / Σ precision_i
+        σ_pooled    = √(1 / Σ precision_i)
+
+    This is the inverse-variance estimator: tests with tighter intervals
+    contribute more weight, and the pooled standard error shrinks below
+    the smallest individual standard error. The formula assumes the
+    underlying tests are *independent* — overlapping market/time/audience
+    breaks that, which is why ``data.io.load_lift_test_csv`` warns when
+    test windows overlap.
+
+    Single-element pooling returns the input unchanged but with
+    ``n_tests=1`` made explicit. Empty input is a programmer error and
+    raises.
+    """
+    if not priors:
+        raise ValueError("pool_lift_priors requires at least one input prior")
+
+    if len(priors) == 1:
+        original = priors[0]
+        # Preserve the original n_tests if the caller already pooled once.
+        return LiftPrior(
+            mean_roi=original.mean_roi,
+            sd_roi=original.sd_roi,
+            confidence=original.confidence,
+            n_tests=max(original.n_tests, 1),
+        )
+
+    precisions = [1.0 / (p.sd_roi * p.sd_roi) for p in priors]
+    total_precision = sum(precisions)
+    pooled_mean = sum(p.mean_roi * w for p, w in zip(priors, precisions, strict=True))
+    pooled_mean /= total_precision
+    pooled_sd = math.sqrt(1.0 / total_precision)
+    # When tests share a confidence level (the common case), preserve it;
+    # otherwise default to 0.95 since that's the v1 contract for the CSV.
+    confidences = {p.confidence for p in priors}
+    confidence = next(iter(confidences)) if len(confidences) == 1 else 0.95
+    return LiftPrior(
+        mean_roi=pooled_mean,
+        sd_roi=pooled_sd,
+        confidence=confidence,
+        n_tests=sum(p.n_tests for p in priors),
+    )

--- a/src/wanamaker/model/spec.py
+++ b/src/wanamaker/model/spec.py
@@ -102,11 +102,17 @@ class LiftPrior:
         confidence: Nominal confidence level of the lift test interval
             (e.g. 0.95).  Stored for auditing; not used in the prior
             directly (the sd already encodes the uncertainty).
+        n_tests: Number of underlying lift-test rows that contributed to
+            this prior. ``1`` for a single-test prior. When multiple
+            tests for the same channel are pooled (#78), this records
+            how many rows the precision-weighted pool consumed so the
+            Trust Card calibration message can report the right total.
     """
 
     mean_roi: float
     sd_roi: float
     confidence: float = 0.95
+    n_tests: int = 1
 
     def __post_init__(self) -> None:
         """Validate lift-prior uncertainty."""
@@ -114,6 +120,8 @@ class LiftPrior:
             raise ValueError(f"sd_roi must be strictly positive; got {self.sd_roi!r}")
         if not 0.0 < self.confidence < 1.0:
             raise ValueError(f"confidence must be in (0, 1); got {self.confidence!r}")
+        if self.n_tests < 1:
+            raise ValueError(f"n_tests must be >= 1; got {self.n_tests!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/wanamaker/trust_card/compute.py
+++ b/src/wanamaker/trust_card/compute.py
@@ -328,7 +328,12 @@ def lift_test_consistency_dimension(
         else:
             consistent.append(channel)
 
-    num_tests = len(lift_test_priors)
+    # ``n_tests`` is the number of underlying lift-test rows that
+    # contributed to each prior — typically 1, but >1 when multiple
+    # tests for the same channel were pooled (#78). Summing across
+    # priors gives the right total for the "Calibrated with N lift tests"
+    # message regardless of how many channels were calibrated.
+    num_tests = sum(prior.n_tests for prior in lift_test_priors.values())
     coverage_str = ""
     if total_spend and total_spend > 0:
         coverage_pct = calibrated_spend / total_spend

--- a/tests/unit/test_lift_test_calibration.py
+++ b/tests/unit/test_lift_test_calibration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import pandas as pd
@@ -17,7 +18,8 @@ from wanamaker.config import (
 )
 from wanamaker.data.io import load_lift_test_csv
 from wanamaker.engine.pymc import _coefficient_prior
-from wanamaker.model.builder import build_model_spec
+from wanamaker.model.builder import build_model_spec, pool_lift_priors
+from wanamaker.model.spec import LiftPrior
 
 
 def _write_lift_csv(tmp_path: Path, content: str) -> Path:
@@ -80,7 +82,10 @@ def test_load_lift_test_csv_requires_all_columns(tmp_path: Path) -> None:
         load_lift_test_csv(path)
 
 
-def test_load_lift_test_csv_rejects_duplicate_channel_rows(tmp_path: Path) -> None:
+def test_load_lift_test_csv_allows_multiple_rows_per_channel(tmp_path: Path) -> None:
+    """Multiple rows for the same channel are now allowed (#78). They're
+    pooled in ``model.builder._load_lift_test_priors``; the loader just
+    preserves them."""
     path = _write_lift_csv(
         tmp_path,
         "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
@@ -88,8 +93,46 @@ def test_load_lift_test_csv_rejects_duplicate_channel_rows(tmp_path: Path) -> No
         "search,2024-02-01,2024-02-14,2.2,1.4,3.0\n",
     )
 
-    with pytest.raises(ValueError, match="duplicate channel"):
-        load_lift_test_csv(path)
+    df = load_lift_test_csv(path)
+    assert len(df) == 2
+    assert (df["channel"] == "search").all()
+
+
+def test_load_lift_test_csv_warns_on_overlapping_test_windows(tmp_path: Path) -> None:
+    """Two tests for the same channel with overlapping date windows
+    violate the independence assumption the pooling formula relies on
+    (#78). The loader still returns the rows; it just warns."""
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
+        "search,2024-01-01,2024-01-31,2.0,1.2,2.8\n"
+        # Overlaps with the first row (2024-01-01..31).
+        "search,2024-01-15,2024-02-14,2.2,1.4,3.0\n",
+    )
+
+    with pytest.warns(UserWarning, match="overlapping test windows"):
+        df = load_lift_test_csv(path)
+
+    assert len(df) == 2
+
+
+def test_load_lift_test_csv_does_not_warn_on_disjoint_windows(tmp_path: Path) -> None:
+    """Two tests for the same channel with disjoint date windows are the
+    intended use case for pooling and should not warn."""
+    import warnings as _warnings
+
+    path = _write_lift_csv(
+        tmp_path,
+        "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
+        "search,2024-01-01,2024-01-14,2.0,1.2,2.8\n"
+        "search,2024-02-01,2024-02-14,2.2,1.4,3.0\n",
+    )
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        df = load_lift_test_csv(path)
+
+    assert len(df) == 2
 
 
 def test_load_lift_test_csv_rejects_invalid_interval(tmp_path: Path) -> None:
@@ -333,3 +376,145 @@ def test_pymc_coefficient_prior_uses_default_without_lift_prior() -> None:
     assert fake_pm.calls == [
         ("HalfNormal", "channel__tv__coefficient", {"sigma": 10.0})
     ]
+
+
+# ---------------------------------------------------------------------------
+# Multi-test-per-channel pooling (#78)
+# ---------------------------------------------------------------------------
+
+
+class TestPoolLiftPriors:
+    """Worked-example tests for the precision-weighted pooling formula."""
+
+    def test_single_prior_passes_through_with_n_tests_one(self) -> None:
+        """A single-element pool should be the input itself, with
+        ``n_tests=1`` made explicit even if the input had a default."""
+        original = LiftPrior(mean_roi=2.0, sd_roi=0.5)
+        pooled = pool_lift_priors([original])
+        assert pooled.mean_roi == pytest.approx(2.0)
+        assert pooled.sd_roi == pytest.approx(0.5)
+        assert pooled.n_tests == 1
+
+    def test_two_equal_precision_priors_average_means_and_shrink_sd(self) -> None:
+        """Equal precisions → average mean; pooled sd = σ / √2."""
+        priors = [
+            LiftPrior(mean_roi=1.0, sd_roi=0.5),
+            LiftPrior(mean_roi=3.0, sd_roi=0.5),
+        ]
+        pooled = pool_lift_priors(priors)
+        assert pooled.mean_roi == pytest.approx(2.0)
+        # σ_pooled = √(1 / (1/0.25 + 1/0.25)) = √(1/8) = 0.3536...
+        assert pooled.sd_roi == pytest.approx(0.5 / math.sqrt(2))
+        assert pooled.n_tests == 2
+
+    def test_unequal_precision_pulls_toward_tighter_estimate(self) -> None:
+        """A tight test should dominate a wide test in the pooled mean."""
+        # σ1 = 0.1, σ2 = 1.0 → precisions 100, 1.
+        # μ_pooled = (1.0*100 + 3.0*1) / 101 ≈ 1.0198
+        priors = [
+            LiftPrior(mean_roi=1.0, sd_roi=0.1),
+            LiftPrior(mean_roi=3.0, sd_roi=1.0),
+        ]
+        pooled = pool_lift_priors(priors)
+        assert pooled.mean_roi == pytest.approx(1.0198, abs=1e-3)
+        # σ_pooled = √(1/101) ≈ 0.0995
+        assert pooled.sd_roi == pytest.approx(math.sqrt(1.0 / 101.0), rel=1e-6)
+        # And the pooled sd is below even the tighter input — that is the
+        # whole point of pooling additional information.
+        assert pooled.sd_roi < 0.1
+
+    def test_pooled_n_tests_sums_inputs(self) -> None:
+        """Pooling already-pooled priors keeps ``n_tests`` cumulative."""
+        a = pool_lift_priors([
+            LiftPrior(mean_roi=2.0, sd_roi=0.5),
+            LiftPrior(mean_roi=2.5, sd_roi=0.5),
+        ])
+        b = LiftPrior(mean_roi=1.5, sd_roi=0.3)
+        combined = pool_lift_priors([a, b])
+        assert a.n_tests == 2
+        assert combined.n_tests == 3
+
+    def test_pool_with_empty_list_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            pool_lift_priors([])
+
+
+class TestMultipleLiftTestsPerChannel:
+    """End-to-end tests through ``build_model_spec``."""
+
+    def test_pooled_prior_is_tighter_than_single_test_prior(self, tmp_path: Path) -> None:
+        # Write two distinct CSVs side by side; helper overwrites a single
+        # path so we use sub-directories to keep them apart.
+        single_dir = tmp_path / "single"
+        single_dir.mkdir()
+        double_dir = tmp_path / "double"
+        double_dir.mkdir()
+        single = _write_lift_csv(
+            single_dir,
+            "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
+            "search,2024-01-01,2024-01-14,2.0,1.6,2.4\n",
+        )
+        double = _write_lift_csv(
+            double_dir,
+            "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
+            "search,2024-01-01,2024-01-14,2.0,1.6,2.4\n"
+            "search,2024-02-01,2024-02-14,2.0,1.6,2.4\n",
+        )
+
+        single_spec = build_model_spec(_config(tmp_path, single))
+        double_spec = build_model_spec(_config(tmp_path, double))
+
+        single_prior = single_spec.lift_test_priors["search"]
+        double_prior = double_spec.lift_test_priors["search"]
+
+        # Same point estimate.
+        assert single_prior.mean_roi == pytest.approx(double_prior.mean_roi)
+        # Pooled sd is √2 times tighter (two equal-precision tests).
+        assert double_prior.sd_roi == pytest.approx(
+            single_prior.sd_roi / math.sqrt(2), rel=1e-6,
+        )
+        # n_tests reflects both rows.
+        assert single_prior.n_tests == 1
+        assert double_prior.n_tests == 2
+
+    def test_unknown_channel_still_fails(self, tmp_path: Path) -> None:
+        """Multi-row support doesn't relax the unknown-channel check."""
+        path = _write_lift_csv(
+            tmp_path,
+            "channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper\n"
+            "ghost,2024-01-01,2024-01-14,2.0,1.6,2.4\n"
+            "ghost,2024-02-01,2024-02-14,2.0,1.6,2.4\n",
+        )
+        with pytest.raises(ValueError, match="not configured"):
+            build_model_spec(_config(tmp_path, path))
+
+
+class TestTrustCardReportsPooledTestCount:
+    """The Trust Card calibration message should report the total number
+    of underlying lift-test rows, not the number of channels."""
+
+    def test_message_counts_tests_not_channels(self) -> None:
+        from wanamaker.engine.summary import ChannelContributionSummary
+        from wanamaker.trust_card.compute import lift_test_consistency_dimension
+
+        contributions = [
+            ChannelContributionSummary(
+                channel="search",
+                mean_contribution=100.0,
+                hdi_low=80.0,
+                hdi_high=120.0,
+                roi_mean=2.0,
+                roi_hdi_low=1.6,
+                roi_hdi_high=2.4,
+                observed_spend_min=10.0,
+                observed_spend_max=50.0,
+            ),
+        ]
+        # One channel, but the underlying prior pooled three rows.
+        priors = {
+            "search": LiftPrior(mean_roi=2.0, sd_roi=0.2, n_tests=3),
+        }
+
+        result = lift_test_consistency_dimension(contributions, priors)
+        # Must say "3 lift tests", not "1 lift test".
+        assert "3 lift tests" in result.explanation


### PR DESCRIPTION
## Summary

Closes #78. A channel may now appear on more than one row in the lift-test CSV. Wanamaker combines those rows as independent ROI estimates via inverse-variance pooling:

```
precision_i = 1 / σ_i²
μ_pooled    = Σ(μ_i × precision_i) / Σ precision_i
σ_pooled    = √(1 / Σ precision_i)
```

The pooled σ is always tighter than the smallest individual σ — that's the whole reason to pool. Tests with narrower CIs contribute more weight; combined precision exceeds either input.

This was sequenced after `#77` (schema clarity), `#76` (YAML productization), `#79` (Trust Card messaging), and `#81` (calibration benchmark tests) all landed, because pooling changes the "N lift tests" count threaded through every calibration message.

## Behavior

```csv
channel,test_start,test_end,roi_estimate,roi_ci_lower,roi_ci_upper
paid_social,2024-09-01,2024-10-15,0.38,0.30,0.46
paid_social,2025-03-01,2025-04-15,0.42,0.34,0.50
```

→ one pooled `LiftPrior` for `paid_social`, with `n_tests = 2`. Trust Card reads "Calibrated with 2 lift tests…" (not "1 lift test", which would be the channel-count answer).

If the two windows overlap (shared market/time/audience), `load_lift_test_csv` emits a `UserWarning` because the pooling formula assumes independence. The user can combine the tests externally or widen one interval to absorb the correlation.

## Changes

- **`LiftPrior` gains `n_tests: int = 1`** — preserves backward compat for any code that constructs `LiftPrior` directly. Validates `n_tests >= 1`.
- **New `pool_lift_priors(priors)` helper** in `model.builder` implements the precision-weighted formula. Single-element pooling passes through; empty pooling raises (programmer error). Pooling already-pooled priors keeps `n_tests` cumulative.
- **`load_lift_test_csv` no longer rejects duplicate channels.** Emits `UserWarning` when two rows for the same channel have overlapping `[test_start, test_end]` windows.
- **`_load_lift_test_priors` groups rows by channel** and routes each group through `pool_lift_priors`. Single-row channels produce identical output to the previous code — no behavioral change for the common case.
- **Trust Card calibration message** now totals `prior.n_tests` across priors instead of just counting channels.

## Tests

11 new tests in [`test_lift_test_calibration.py`](tests/unit/test_lift_test_calibration.py):

| Class | What it covers |
|---|---|
| `TestPoolLiftPriors` | Single pass-through, two-equal-precision averaging, unequal-precision pull toward tighter, cumulative `n_tests`, empty-pool error |
| `TestMultipleLiftTestsPerChannel` | End-to-end through `build_model_spec`: pooled prior is √2 tighter than single test for two equal-precision rows; unknown-channel error still fires |
| `TestTrustCardReportsPooledTestCount` | Trust Card message says "3 lift tests" when one channel has 3 pooled, not "1 lift test" (the channel count) |

The previous `test_load_lift_test_csv_rejects_duplicate_channel_rows` flips to `test_load_lift_test_csv_allows_multiple_rows_per_channel`. Two new loader tests cover the overlap warning and the disjoint-window quiet path.

## Validation

- **Full unit suite:** 742 passed (was 731 + 11 new)
- **Lint clean** on all touched files
- **`mkdocs build --strict`** green

## Docs

- New "Multiple tests per channel" subsection in [`docs/api_reference.md`](docs/api_reference.md) under the lift-test schema docs, showing the pooling formula and naming the independence assumption.
- Short paragraph in [`docs/examples/lift_test_changes_verdict.md`](docs/examples/lift_test_changes_verdict.md) pointing users at the multi-row pattern and the overlap warning.

## Test plan

- [ ] Try a real lift-test CSV with two disjoint-window rows for the same channel; confirm the Trust Card explanation says "Calibrated with 2 lift tests" rather than "1 lift test"
- [ ] Try a CSV with two overlapping-window rows; confirm the `UserWarning` fires
- [ ] Verify legacy single-row CSVs produce identical numeric output to before this PR

## What's next

Per #82's recommended sequencing, the calibration workstream's last item is **#80 (calibrated-vs-uncalibrated sensitivity comparison)** — a deterministic side-by-side report. With #76, #77, #78, #79, #81 all done, that's the right next pickup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)