### PR TITLE
Add explicit scenario generation constraints

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -191,6 +191,7 @@ Unknown fields are rejected.
 | `refresh` | `RefreshConfig` | `{anchor_strength: medium}` | Refresh accountability settings. |
 | `run` | `RunConfig` | `{seed: 0, runtime_mode: standard, artifact_dir: .wanamaker}` | Reproducibility and artifact settings. |
 | `calibration` | `CalibrationConfig` | `null` | External evidence and priors. |
+| `scenario_generation` | `ScenarioGenerationConfig` | `null` | Auditable constraints for future generated candidate scenarios. |
 
 ### `data`
 
@@ -224,6 +225,44 @@ The pooled `σ` is always less than the smallest individual `σ`. The Trust Card
 |---|---|---|---|
 | `lift_tests.path` | path | required if `lift_tests` set | CSV containing experiment/lift-test evidence. |
 | `lift_tests.mode` | `roi_prior` | `roi_prior` | How to use the lift test data (currently only `roi_prior` is supported). |
+
+### `scenario_generation`
+
+This section defines constraints for future bounded candidate scenario generation. It does not
+turn Wanamaker into an optimizer; it makes any mechanically generated candidates auditable.
+Unknown fields are rejected and invalid constraints fail before candidates are generated.
+
+```yaml
+scenario_generation:
+  budget_mode: hold_total
+  top_n: 5
+  max_channel_change: 0.15
+  max_total_moved_budget: 0.20
+  locked_channels:
+    - brand_tv
+  excluded_channels:
+    - affiliate
+  min_spend:
+    paid_search: 5000
+  max_spend:
+    paid_search: 20000
+  require_historical_support: true
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `budget_mode` | `hold_total`, `allow_increase`, `allow_decrease`, or `allow_change` | `hold_total` | Total budget behavior relative to the baseline plan. |
+| `top_n` | integer in `[1, 20]` | `5` | Maximum number of candidate scenarios to report. |
+| `max_channel_change` | float in `[0, 1]` | `0.15` | Maximum relative spend change for any one channel. |
+| `max_total_moved_budget` | float in `[0, 1]` | `0.20` | Maximum shifted budget as a share of baseline total spend. |
+| `locked_channels` | list of channel names | `[]` | Channels that generated candidates must leave unchanged. |
+| `excluded_channels` | list of channel names | `[]` | Channels excluded from generated reallocations. |
+| `min_spend` | map of channel name to spend | `{}` | Per-channel lower bounds for generated candidates. |
+| `max_spend` | map of channel name to spend | `{}` | Per-channel upper bounds for generated candidates. |
+| `require_historical_support` | boolean | `true` | Whether generated candidates must stay inside historically observed spend ranges. |
+
+Resolved constraints are immutable and should be written into generated reports under
+`## Constraints used` so CMO and Finance readers can see what shaped the candidates.
 
 ### `channels`
 

--- a/src/wanamaker/config.py
+++ b/src/wanamaker/config.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 RuntimeMode = Literal["quick", "standard", "full"]
 AnchorStrength = Literal["none", "light", "medium", "heavy"]
+BudgetMode = Literal["hold_total", "allow_increase", "allow_decrease", "allow_change"]
 
 
 class DataConfig(BaseModel):
@@ -81,6 +82,63 @@ class CalibrationConfig(BaseModel):
     lift_tests: LiftTestCalibrationConfig | None = None
 
 
+class ScenarioGenerationConfig(BaseModel):
+    """Explicit constraints for future bounded candidate scenario generation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    budget_mode: BudgetMode = "hold_total"
+    top_n: int = Field(default=5, ge=1, le=20)
+    max_channel_change: float = Field(default=0.15, ge=0.0, le=1.0)
+    max_total_moved_budget: float = Field(default=0.20, ge=0.0, le=1.0)
+    locked_channels: list[str] = Field(default_factory=list)
+    excluded_channels: list[str] = Field(default_factory=list)
+    min_spend: dict[str, float] = Field(default_factory=dict)
+    max_spend: dict[str, float] = Field(default_factory=dict)
+    require_historical_support: bool = True
+
+    @model_validator(mode="after")
+    def _check_channel_constraints(self) -> ScenarioGenerationConfig:
+        locked = set(self.locked_channels)
+        excluded = set(self.excluded_channels)
+        overlap = sorted(locked & excluded)
+        if overlap:
+            raise ValueError(
+                "scenario_generation channels cannot be both locked and excluded: "
+                f"{overlap}"
+            )
+
+        for field_name, values in (
+            ("locked_channels", self.locked_channels),
+            ("excluded_channels", self.excluded_channels),
+        ):
+            blanks = [value for value in values if not value.strip()]
+            if blanks:
+                raise ValueError(f"scenario_generation.{field_name} cannot contain blanks")
+
+        for field_name, bounds in (("min_spend", self.min_spend), ("max_spend", self.max_spend)):
+            blank_keys = [channel for channel in bounds if not channel.strip()]
+            if blank_keys:
+                raise ValueError(f"scenario_generation.{field_name} cannot contain blank channels")
+            negative = {channel: value for channel, value in bounds.items() if value < 0}
+            if negative:
+                raise ValueError(
+                    f"scenario_generation.{field_name} values must be non-negative: {negative}"
+                )
+
+        inverted = sorted(
+            channel
+            for channel, min_value in self.min_spend.items()
+            if channel in self.max_spend and min_value > self.max_spend[channel]
+        )
+        if inverted:
+            raise ValueError(
+                "scenario_generation min_spend cannot exceed max_spend for channels: "
+                f"{inverted}"
+            )
+        return self
+
+
 class WanamakerConfig(BaseModel):
     """The full validated configuration for a Wanamaker run."""
 
@@ -91,6 +149,7 @@ class WanamakerConfig(BaseModel):
     refresh: RefreshConfig = Field(default_factory=RefreshConfig)
     run: RunConfig = Field(default_factory=RunConfig)
     calibration: CalibrationConfig | None = None
+    scenario_generation: ScenarioGenerationConfig | None = None
 
     @model_validator(mode="after")
     def _check_lift_test_conflict(self) -> WanamakerConfig:

--- a/src/wanamaker/forecast/__init__.py
+++ b/src/wanamaker/forecast/__init__.py
@@ -13,6 +13,12 @@ optimization (deferred to v1.1, BRD/PRD §4.2). User-driven scenarios keep
 the human in control of strategic decisions.
 """
 
+from wanamaker.forecast.constraints import (
+    ScenarioGenerationConstraints,
+    format_constraints_markdown,
+    resolve_scenario_generation_constraints,
+    validate_candidate_spend,
+)
 from wanamaker.forecast.posterior_predictive import (
     ExtrapolationFlag,
     ForecastResult,
@@ -24,5 +30,9 @@ __all__ = [
     "ExtrapolationFlag",
     "ForecastResult",
     "PosteriorPredictiveEngine",
+    "ScenarioGenerationConstraints",
+    "format_constraints_markdown",
     "forecast",
+    "resolve_scenario_generation_constraints",
+    "validate_candidate_spend",
 ]

--- a/src/wanamaker/forecast/constraints.py
+++ b/src/wanamaker/forecast/constraints.py
@@ -1,0 +1,224 @@
+"""Candidate scenario-generation constraints.
+
+This module defines the explicit, auditable constraint contract for future
+bounded candidate generation. It does not generate scenarios; it validates
+and resolves user configuration into immutable objects that a generator can
+consume before any mechanical allocation search starts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+from wanamaker.config import ScenarioGenerationConfig, WanamakerConfig
+
+BudgetMode = Literal["hold_total", "allow_increase", "allow_decrease", "allow_change"]
+
+
+@dataclass(frozen=True)
+class ScenarioGenerationConstraints:
+    """Resolved immutable constraints for bounded scenario generation.
+
+    Attributes:
+        budget_mode: How total budget may change relative to the baseline.
+        top_n: Maximum number of candidate scenarios to return.
+        max_channel_change: Maximum relative change for any channel.
+        max_total_moved_budget: Maximum moved budget as a share of baseline total.
+        locked_channels: Channels that must remain unchanged.
+        excluded_channels: Channels excluded from generated reallocations.
+        min_spend: Per-channel lower spend bounds, sorted by channel.
+        max_spend: Per-channel upper spend bounds, sorted by channel.
+        require_historical_support: Whether candidates must stay inside observed
+            historical spend ranges.
+    """
+
+    budget_mode: BudgetMode
+    top_n: int
+    max_channel_change: float
+    max_total_moved_budget: float
+    locked_channels: tuple[str, ...]
+    excluded_channels: tuple[str, ...]
+    min_spend: tuple[tuple[str, float], ...]
+    max_spend: tuple[tuple[str, float], ...]
+    require_historical_support: bool
+
+
+def resolve_scenario_generation_constraints(
+    cfg: WanamakerConfig,
+) -> ScenarioGenerationConstraints:
+    """Resolve YAML scenario-generation config into immutable constraints.
+
+    Args:
+        cfg: Validated Wanamaker configuration.
+
+    Returns:
+        Immutable constraints with sorted channel lists and spend bounds.
+
+    Raises:
+        ValueError: If constraints refer to channels not declared in
+            ``cfg.channels``.
+
+    Examples:
+        >>> from wanamaker.config import ChannelConfig, DataConfig, WanamakerConfig
+        >>> cfg = WanamakerConfig(
+        ...     data=DataConfig(csv_path="data.csv", date_column="week", target_column="sales"),
+        ...     channels=[ChannelConfig(name="search", category="paid_search")],
+        ... )
+        >>> resolve_scenario_generation_constraints(cfg).budget_mode
+        'hold_total'
+    """
+    raw = cfg.scenario_generation or ScenarioGenerationConfig()
+    configured_channels = {channel.name for channel in cfg.channels}
+    referenced = set(raw.locked_channels)
+    referenced.update(raw.excluded_channels)
+    referenced.update(raw.min_spend)
+    referenced.update(raw.max_spend)
+    unknown = sorted(referenced - configured_channels)
+    if unknown:
+        raise ValueError(
+            "scenario_generation references channels that are not configured: "
+            f"{unknown}"
+        )
+
+    return ScenarioGenerationConstraints(
+        budget_mode=raw.budget_mode,
+        top_n=raw.top_n,
+        max_channel_change=raw.max_channel_change,
+        max_total_moved_budget=raw.max_total_moved_budget,
+        locked_channels=tuple(sorted(raw.locked_channels)),
+        excluded_channels=tuple(sorted(raw.excluded_channels)),
+        min_spend=tuple(sorted((k, float(v)) for k, v in raw.min_spend.items())),
+        max_spend=tuple(sorted((k, float(v)) for k, v in raw.max_spend.items())),
+        require_historical_support=raw.require_historical_support,
+    )
+
+
+def validate_candidate_spend(
+    baseline_spend: Mapping[str, float],
+    candidate_spend: Mapping[str, float],
+    constraints: ScenarioGenerationConstraints,
+) -> None:
+    """Validate a generated candidate against resolved constraints.
+
+    This is the fail-closed gate a future candidate generator can call before
+    scoring or reporting a scenario.
+
+    Args:
+        baseline_spend: Baseline total spend by channel.
+        candidate_spend: Candidate total spend by channel.
+        constraints: Resolved scenario generation constraints.
+
+    Raises:
+        ValueError: If the candidate violates budget mode, movement, locked
+            channels, excluded channels, or spend bounds.
+    """
+    baseline = {k: float(v) for k, v in baseline_spend.items()}
+    candidate = {k: float(v) for k, v in candidate_spend.items()}
+    if set(baseline) != set(candidate):
+        missing = sorted(set(baseline) - set(candidate))
+        extra = sorted(set(candidate) - set(baseline))
+        raise ValueError(
+            "candidate spend channels must match baseline channels; "
+            f"missing={missing}, extra={extra}"
+        )
+
+    baseline_total = sum(baseline.values())
+    candidate_total = sum(candidate.values())
+    tolerance = max(1e-9, abs(baseline_total) * 1e-9)
+    total_changed = abs(candidate_total - baseline_total) > tolerance
+    if constraints.budget_mode == "hold_total" and total_changed:
+        raise ValueError(
+            "candidate violates scenario_generation.budget_mode=hold_total: "
+            f"baseline total {baseline_total:.6g}, candidate total {candidate_total:.6g}"
+        )
+    if constraints.budget_mode == "allow_increase" and candidate_total + tolerance < baseline_total:
+        raise ValueError("candidate total decreased but budget_mode=allow_increase")
+    if constraints.budget_mode == "allow_decrease" and candidate_total > baseline_total + tolerance:
+        raise ValueError("candidate total increased but budget_mode=allow_decrease")
+
+    locked = set(constraints.locked_channels)
+    excluded = set(constraints.excluded_channels)
+    for channel in sorted(locked | excluded):
+        if abs(candidate[channel] - baseline[channel]) > tolerance:
+            status = "locked" if channel in locked else "excluded"
+            raise ValueError(
+                f"candidate changes {status} channel {channel!r}: "
+                f"baseline {baseline[channel]:.6g}, candidate {candidate[channel]:.6g}"
+            )
+
+    for channel, base_value in baseline.items():
+        candidate_value = candidate[channel]
+        delta = abs(candidate_value - base_value)
+        if base_value == 0:
+            if delta > tolerance:
+                raise ValueError(
+                    f"candidate changes zero-baseline channel {channel!r}; "
+                    "max_channel_change is undefined from zero"
+                )
+            continue
+        relative_change = delta / abs(base_value)
+        if relative_change > constraints.max_channel_change + 1e-12:
+            raise ValueError(
+                f"candidate changes channel {channel!r} by {relative_change:.1%}, "
+                "above scenario_generation.max_channel_change"
+            )
+
+    if baseline_total > 0:
+        moved_budget = sum(max(candidate[ch] - baseline[ch], 0.0) for ch in baseline)
+        moved_share = moved_budget / baseline_total
+        if moved_share > constraints.max_total_moved_budget + 1e-12:
+            raise ValueError(
+                f"candidate moves {moved_share:.1%} of baseline budget, above "
+                "scenario_generation.max_total_moved_budget"
+            )
+
+    min_spend = dict(constraints.min_spend)
+    max_spend = dict(constraints.max_spend)
+    for channel, minimum in min_spend.items():
+        if candidate[channel] < minimum - tolerance:
+            raise ValueError(
+                f"candidate spend for {channel!r} is below scenario_generation.min_spend"
+            )
+    for channel, maximum in max_spend.items():
+        if candidate[channel] > maximum + tolerance:
+            raise ValueError(
+                f"candidate spend for {channel!r} is above scenario_generation.max_spend"
+            )
+
+
+def format_constraints_markdown(
+    constraints: ScenarioGenerationConstraints,
+    *,
+    heading: str = "## Constraints used",
+) -> str:
+    """Render a human-readable Markdown section for generated reports."""
+    lines = [
+        heading,
+        "",
+        f"- Budget mode: `{constraints.budget_mode}`",
+        f"- Top candidates requested: {constraints.top_n}",
+        f"- Maximum per-channel change: {constraints.max_channel_change:.0%}",
+        f"- Maximum total moved budget: {constraints.max_total_moved_budget:.0%}",
+        "- Historical support required: "
+        + ("yes" if constraints.require_historical_support else "no"),
+        "- Locked channels: " + _channel_list_label(constraints.locked_channels),
+        "- Excluded channels: " + _channel_list_label(constraints.excluded_channels),
+        "- Minimum spend bounds: " + _bounds_label(constraints.min_spend),
+        "- Maximum spend bounds: " + _bounds_label(constraints.max_spend),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _channel_list_label(channels: tuple[str, ...]) -> str:
+    if not channels:
+        return "none"
+    return ", ".join(f"`{channel}`" for channel in channels)
+
+
+def _bounds_label(bounds: tuple[tuple[str, float], ...]) -> str:
+    if not bounds:
+        return "none"
+    return ", ".join(f"`{channel}`={value:,.0f}" for channel, value in bounds)

--- a/tests/unit/test_scenario_constraints.py
+++ b/tests/unit/test_scenario_constraints.py
@@ -1,0 +1,265 @@
+"""Tests for explicit scenario-generation constraints (issue #88)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from wanamaker.config import (
+    ChannelConfig,
+    DataConfig,
+    ScenarioGenerationConfig,
+    WanamakerConfig,
+)
+from wanamaker.forecast.constraints import (
+    ScenarioGenerationConstraints,
+    format_constraints_markdown,
+    resolve_scenario_generation_constraints,
+    validate_candidate_spend,
+)
+
+
+def _config(
+    tmp_path: Path,
+    *,
+    scenario_generation: ScenarioGenerationConfig | None = None,
+) -> WanamakerConfig:
+    data_csv = tmp_path / "data.csv"
+    data_csv.write_text(
+        "week,revenue,search,tv,affiliate\n2024-01-01,100,10,20,5\n",
+        encoding="utf-8",
+    )
+    return WanamakerConfig(
+        data=DataConfig(
+            csv_path=data_csv,
+            date_column="week",
+            target_column="revenue",
+            spend_columns=["search", "tv", "affiliate"],
+        ),
+        channels=[
+            ChannelConfig(name="search", category="paid_search"),
+            ChannelConfig(name="tv", category="linear_tv"),
+            ChannelConfig(name="affiliate", category="affiliate"),
+        ],
+        scenario_generation=scenario_generation,
+    )
+
+
+def test_missing_scenario_generation_uses_conservative_defaults(tmp_path: Path) -> None:
+    constraints = resolve_scenario_generation_constraints(_config(tmp_path))
+
+    assert constraints == ScenarioGenerationConstraints(
+        budget_mode="hold_total",
+        top_n=5,
+        max_channel_change=0.15,
+        max_total_moved_budget=0.20,
+        locked_channels=(),
+        excluded_channels=(),
+        min_spend=(),
+        max_spend=(),
+        require_historical_support=True,
+    )
+
+
+def test_resolved_constraints_are_immutable_and_sorted(tmp_path: Path) -> None:
+    cfg = _config(
+        tmp_path,
+        scenario_generation=ScenarioGenerationConfig(
+            locked_channels=["tv"],
+            excluded_channels=["affiliate"],
+            min_spend={"search": 5000.0},
+            max_spend={"search": 20000.0},
+        ),
+    )
+
+    constraints = resolve_scenario_generation_constraints(cfg)
+
+    assert constraints.locked_channels == ("tv",)
+    assert constraints.excluded_channels == ("affiliate",)
+    assert constraints.min_spend == (("search", 5000.0),)
+    assert constraints.max_spend == (("search", 20000.0),)
+    with pytest.raises(FrozenInstanceError):
+        constraints.top_n = 10  # type: ignore[misc]
+
+
+def test_config_rejects_invalid_percentages_and_top_n() -> None:
+    with pytest.raises(ValidationError, match="max_channel_change"):
+        ScenarioGenerationConfig(max_channel_change=1.2)
+
+    with pytest.raises(ValidationError, match="top_n"):
+        ScenarioGenerationConfig(top_n=0)
+
+
+def test_config_rejects_locked_and_excluded_overlap() -> None:
+    with pytest.raises(ValidationError, match="both locked and excluded"):
+        ScenarioGenerationConfig(
+            locked_channels=["tv"],
+            excluded_channels=["tv"],
+        )
+
+
+def test_config_rejects_invalid_spend_bounds() -> None:
+    with pytest.raises(ValidationError, match="non-negative"):
+        ScenarioGenerationConfig(min_spend={"search": -1.0})
+
+    with pytest.raises(ValidationError, match="min_spend cannot exceed max_spend"):
+        ScenarioGenerationConfig(
+            min_spend={"search": 20000.0},
+            max_spend={"search": 5000.0},
+        )
+
+
+def test_resolver_rejects_unknown_constraint_channels(tmp_path: Path) -> None:
+    cfg = _config(
+        tmp_path,
+        scenario_generation=ScenarioGenerationConfig(
+            locked_channels=["ghost"],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="not configured"):
+        resolve_scenario_generation_constraints(cfg)
+
+
+def test_validate_candidate_preserves_total_budget_when_required(tmp_path: Path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                max_channel_change=1.0,
+                max_total_moved_budget=1.0,
+            ),
+        )
+    )
+
+    validate_candidate_spend(
+        {"search": 100.0, "tv": 100.0, "affiliate": 0.0},
+        {"search": 120.0, "tv": 80.0, "affiliate": 0.0},
+        constraints,
+    )
+
+    with pytest.raises(ValueError, match="hold_total"):
+        validate_candidate_spend(
+            {"search": 100.0, "tv": 100.0, "affiliate": 0.0},
+            {"search": 130.0, "tv": 100.0, "affiliate": 0.0},
+            constraints,
+        )
+
+
+def test_validate_candidate_enforces_locked_and_excluded_channels(tmp_path: Path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                max_channel_change=1.0,
+                max_total_moved_budget=1.0,
+                locked_channels=["tv"],
+                excluded_channels=["affiliate"],
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match="locked channel 'tv'"):
+        validate_candidate_spend(
+            {"search": 100.0, "tv": 100.0, "affiliate": 50.0},
+            {"search": 120.0, "tv": 80.0, "affiliate": 50.0},
+            constraints,
+        )
+
+    with pytest.raises(ValueError, match="excluded channel 'affiliate'"):
+        validate_candidate_spend(
+            {"search": 100.0, "tv": 100.0, "affiliate": 50.0},
+            {"search": 110.0, "tv": 100.0, "affiliate": 40.0},
+            constraints,
+        )
+
+
+def test_validate_candidate_enforces_movement_and_spend_bounds(tmp_path: Path) -> None:
+    change_constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                max_channel_change=0.10,
+                max_total_moved_budget=0.05,
+                min_spend={"search": 95.0},
+                max_spend={"tv": 105.0},
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match="max_channel_change"):
+        validate_candidate_spend(
+            {"search": 100.0, "tv": 100.0, "affiliate": 100.0},
+            {"search": 120.0, "tv": 90.0, "affiliate": 90.0},
+            change_constraints,
+        )
+
+    moved_constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                max_channel_change=1.0,
+                max_total_moved_budget=0.05,
+            ),
+        )
+    )
+    with pytest.raises(ValueError, match="max_total_moved_budget"):
+        validate_candidate_spend(
+            {"search": 100.0, "tv": 100.0, "affiliate": 100.0},
+            {"search": 110.0, "tv": 110.0, "affiliate": 80.0},
+            moved_constraints,
+        )
+
+    bound_constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                max_channel_change=1.0,
+                max_total_moved_budget=1.0,
+                min_spend={"search": 95.0},
+                max_spend={"tv": 105.0},
+            ),
+        )
+    )
+    with pytest.raises(ValueError, match="min_spend"):
+        validate_candidate_spend(
+            {"search": 100.0, "tv": 100.0, "affiliate": 100.0},
+            {"search": 94.0, "tv": 103.0, "affiliate": 103.0},
+            bound_constraints,
+        )
+
+    with pytest.raises(ValueError, match="max_spend"):
+        validate_candidate_spend(
+            {"search": 100.0, "tv": 100.0, "affiliate": 100.0},
+            {"search": 98.0, "tv": 106.0, "affiliate": 96.0},
+            bound_constraints,
+        )
+
+
+def test_constraints_markdown_is_report_ready(tmp_path: Path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                budget_mode="hold_total",
+                top_n=3,
+                locked_channels=["tv"],
+                excluded_channels=["affiliate"],
+                min_spend={"search": 5000.0},
+                max_spend={"search": 20000.0},
+                require_historical_support=True,
+            ),
+        )
+    )
+
+    markdown = format_constraints_markdown(constraints)
+
+    assert markdown.startswith("## Constraints used")
+    assert "- Budget mode: `hold_total`" in markdown
+    assert "- Locked channels: `tv`" in markdown
+    assert "- Excluded channels: `affiliate`" in markdown
+    assert "- Minimum spend bounds: `search`=5,000" in markdown
+    assert "- Maximum spend bounds: `search`=20,000" in markdown


### PR DESCRIPTION
## Summary

Closes #88.

Adds an explicit `scenario_generation` YAML schema and a resolved immutable constraints object for future bounded candidate scenario generation. The implementation is deliberately constraint-only: it does not generate scenarios or introduce optimizer behavior, but gives the future generator a fail-closed contract to consume.

## What changed

- Added `ScenarioGenerationConfig` to `WanamakerConfig` with:
  - `budget_mode`
  - `top_n`
  - `max_channel_change`
  - `max_total_moved_budget`
  - `locked_channels`
  - `excluded_channels`
  - `min_spend`
  - `max_spend`
  - `require_historical_support`
- Added `wanamaker.forecast.constraints` with:
  - immutable `ScenarioGenerationConstraints`
  - `resolve_scenario_generation_constraints(cfg)`
  - `validate_candidate_spend(...)`
  - `format_constraints_markdown(...)` for generated report sections
- Exported the constraint helpers from `wanamaker.forecast`.
- Documented the new YAML section in `docs/api_reference.md`.
- Added unit tests covering defaults, invalid values, unknown channels, locked/excluded channels, total-budget preservation, movement limits, spend bounds, immutability, and Markdown report text.

## Validation

- `pytest tests\unit\test_scenario_constraints.py -q` -> 10 passed
- `ruff check src\wanamaker\config.py src\wanamaker\forecast\constraints.py src\wanamaker\forecast\__init__.py tests\unit\test_scenario_constraints.py` -> clean
- `pytest tests\unit -q` -> 775 passed
- `mkdocs build --strict` -> passed

## Notes

This is intentionally the constraint foundation for `suggest-scenarios`; it does not yet generate or rank candidate plans.