### PR TITLE
Generate bounded candidate budget scenarios (closes #85)

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -146,6 +146,29 @@ wanamaker compare-scenarios --run-id <run_id> --plans path/to/base.csv --plans p
 | `--seed` | integer | run seed | Override posterior-predictive sampling seed. |
 | `--output` | path | `<run_dir>/scenario_comparison.md` | Markdown scenario report path. |
 
+### `wanamaker suggest-scenarios`
+
+Generate up to `top_n` bounded candidate budget plans from a baseline plan and rank them with uncertainty. The model evaluates the candidates it generated; it does not perform constrained optimization. Every candidate is gated through the explicit `scenario_generation` constraint contract before being forecast, and the surviving plans are ranked against the supplied baseline.
+
+Candidate CSVs are written to `<run_dir>/candidates/` and can be passed directly into `compare-scenarios` for further drill-down. The Markdown summary at `<run_dir>/scenario_suggestions.md` always includes a "Constraints used" section so the audit context is visible alongside the ranking.
+
+```bash
+wanamaker suggest-scenarios --run-id <run_id> --baseline path/to/base.csv
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `--run-id` | string | required | Existing fitted run ID. |
+| `--baseline` | path | required | Baseline future spend plan CSV. |
+| `--artifact-dir` | path | `.wanamaker` | Root artifact directory. |
+| `--top-n` | integer | config value | Override `scenario_generation.top_n`. |
+| `--max-channel-change` | float | config value | Override `scenario_generation.max_channel_change`. |
+| `--budget-mode` | `hold_total`, `allow_increase`, `allow_decrease`, `allow_change` | config value | Override `scenario_generation.budget_mode`. |
+| `--output-dir` | path | `<run_dir>/candidates/` | Directory for candidate CSVs. |
+| `--seed` | integer | run seed | Override posterior-predictive sampling seed. |
+
+The command exits non-zero when no candidate plans could be produced — for example when every channel is locked, excluded, spend-invariant, or has a zero baseline. The saved Markdown still records why so the failure is auditable.
+
 ### `wanamaker recommend-ramp`
 
 Recommend a risk-adjusted staged move from a baseline plan toward a target plan.

--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -1227,6 +1227,8 @@ def _resolved_scenario_constraints(
     users can re-run ``suggest-scenarios`` with different bounds without
     re-fitting the model.
     """
+    from pydantic import ValidationError
+
     from wanamaker.config import ScenarioGenerationConfig
     from wanamaker.forecast import resolve_scenario_generation_constraints
 
@@ -1239,11 +1241,19 @@ def _resolved_scenario_constraints(
     if budget_mode is not None:
         overrides["budget_mode"] = budget_mode
     if overrides:
+        # ``model_copy(update=...)`` skips validation, so bounds/literal
+        # checks on the overridden fields would silently slip through.
+        # Round-trip through ``model_validate`` to fail closed on invalid
+        # CLI values (e.g. ``--top-n 0``, ``--budget-mode nonsense``).
+        merged = {**base.model_dump(), **overrides}
         try:
-            base = base.model_copy(update=overrides)
-        except Exception as exc:  # pydantic ValidationError surfaces as Exception subtype
+            base = ScenarioGenerationConfig.model_validate(merged)
+        except ValidationError as exc:
             typer.echo(
-                typer.style(f"Error: invalid override: {exc}", fg=typer.colors.RED),
+                typer.style(
+                    f"Error: invalid scenario_generation override:\n{exc}",
+                    fg=typer.colors.RED,
+                ),
                 err=True,
             )
             raise typer.Exit(code=1) from exc

--- a/src/wanamaker/cli.py
+++ b/src/wanamaker/cli.py
@@ -11,6 +11,7 @@ Core commands per FR-6.3 plus the HTML showcase:
     wanamaker forecast --run-id <run_id> --plan <plan.csv>
     wanamaker compare-scenarios --run-id <run_id> --plans <p1.csv> <p2.csv> ...
     wanamaker compare-calibration --uncalibrated-run <id> --calibrated-run <id>
+    wanamaker suggest-scenarios --run-id <run_id> --baseline <base.csv>
     wanamaker recommend-ramp --run-id <run_id> --baseline <base.csv> --target <alt.csv>
     wanamaker refresh --config <config.yaml>
 
@@ -1110,6 +1111,149 @@ def compare_scenarios(
     output_path = output if output is not None else paths.root / "scenario_comparison.md"
     output_path.write_text(_format_scenario_comparison_markdown(results, run_id))
     typer.echo(typer.style(f"\nReport saved: {output_path}", fg=typer.colors.GREEN))
+
+
+@app.command(name="suggest-scenarios")
+def suggest_scenarios_cmd(
+    run_id: str = typer.Option(..., "--run-id"),
+    baseline: Path = typer.Option(..., "--baseline", exists=True),
+    artifact_dir: Path = typer.Option(
+        Path(".wanamaker"),
+        "--artifact-dir",
+        help="Root of the runs directory (default: .wanamaker).",
+    ),
+    top_n: int | None = typer.Option(
+        None,
+        "--top-n",
+        help="Override the run config's top_n (max candidate plans to return).",
+    ),
+    max_channel_change: float | None = typer.Option(
+        None,
+        "--max-channel-change",
+        help=(
+            "Override the run config's max_channel_change "
+            "(maximum relative change for any channel)."
+        ),
+    ),
+    budget_mode: str | None = typer.Option(
+        None,
+        "--budget-mode",
+        help=(
+            "Override the run config's budget_mode "
+            "(hold_total | allow_increase | allow_decrease | allow_change)."
+        ),
+    ),
+    output_dir: Path | None = typer.Option(
+        None,
+        "--output-dir",
+        help=(
+            "Directory to write candidate CSVs into. "
+            "Default: <run_dir>/candidates/"
+        ),
+    ),
+    seed: int | None = typer.Option(
+        None,
+        "--seed",
+        help="Override the run's stored seed for posterior-predictive sampling.",
+    ),
+) -> None:
+    """Generate bounded candidate budget plans, ranked with uncertainty.
+
+    The model evaluates the candidates it generated; it does not
+    perform constrained optimization. Candidates respect the explicit
+    ``scenario_generation`` constraint contract from the run config (or
+    the CLI overrides) and are ranked against the supplied baseline.
+    """
+    from wanamaker.config import load_config
+    from wanamaker.forecast import suggest_scenarios as run_suggest
+
+    plan_engine, _, summary, paths, run_seed = _load_run_for_forecast(
+        artifact_dir, run_id
+    )
+    seed_used = seed if seed is not None else run_seed
+    cfg = load_config(paths.config)
+    constraints = _resolved_scenario_constraints(
+        cfg,
+        top_n=top_n,
+        max_channel_change=max_channel_change,
+        budget_mode=budget_mode,
+    )
+
+    out_dir = output_dir if output_dir is not None else paths.root / "candidates"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    typer.echo(
+        f"Generating up to {constraints.top_n} candidate plan(s) for run "
+        f"{run_id} (seed={seed_used})…"
+    )
+    result = run_suggest(
+        summary,
+        baseline,
+        constraints,
+        seed=seed_used,
+        engine=plan_engine,
+        baseline_label=baseline.stem,
+    )
+
+    written: list[Path] = []
+    for candidate in result.candidates:
+        csv_path = out_dir / f"{candidate.label}.csv"
+        candidate.plan.to_csv(csv_path, index=False)
+        written.append(csv_path)
+
+    _print_suggest_scenarios(result, written)
+
+    report_path = paths.root / "scenario_suggestions.md"
+    report_path.write_text(
+        _format_suggest_scenarios_markdown(result, run_id, written),
+        encoding="utf-8",
+    )
+    typer.echo(typer.style(f"\nReport saved: {report_path}", fg=typer.colors.GREEN))
+
+    if not result.candidates:
+        raise typer.Exit(code=1)
+
+
+def _resolved_scenario_constraints(
+    cfg: Any,
+    *,
+    top_n: int | None,
+    max_channel_change: float | None,
+    budget_mode: str | None,
+) -> Any:
+    """Resolve scenario constraints from config, applying any CLI overrides.
+
+    CLI flags override individual fields without rewriting the YAML, so
+    users can re-run ``suggest-scenarios`` with different bounds without
+    re-fitting the model.
+    """
+    from wanamaker.config import ScenarioGenerationConfig
+    from wanamaker.forecast import resolve_scenario_generation_constraints
+
+    base = cfg.scenario_generation or ScenarioGenerationConfig()
+    overrides: dict[str, Any] = {}
+    if top_n is not None:
+        overrides["top_n"] = top_n
+    if max_channel_change is not None:
+        overrides["max_channel_change"] = max_channel_change
+    if budget_mode is not None:
+        overrides["budget_mode"] = budget_mode
+    if overrides:
+        try:
+            base = base.model_copy(update=overrides)
+        except Exception as exc:  # pydantic ValidationError surfaces as Exception subtype
+            typer.echo(
+                typer.style(f"Error: invalid override: {exc}", fg=typer.colors.RED),
+                err=True,
+            )
+            raise typer.Exit(code=1) from exc
+
+    overridden_cfg = cfg.model_copy(update={"scenario_generation": base})
+    try:
+        return resolve_scenario_generation_constraints(overridden_cfg)
+    except ValueError as exc:
+        typer.echo(typer.style(f"Error: {exc}", fg=typer.colors.RED), err=True)
+        raise typer.Exit(code=1) from exc
 
 
 @app.command(name="compare-calibration")
@@ -2248,6 +2392,206 @@ def _format_scenario_comparison_markdown(results: list[Any], run_id: str) -> str
                         f"{flag.observed_spend_max:,.0f})"
                     )
         lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+_BLOCKED_REASON_LABELS: dict[str, str] = {
+    "locked": "locked by config",
+    "excluded": "excluded by config",
+    "spend_invariant": "spend-invariant; excluded from reallocation guidance (FR-3.2)",
+    "zero_baseline": "zero baseline spend; percentage moves undefined from zero",
+}
+
+
+def _print_suggest_scenarios(result: Any, written: list[Path]) -> None:
+    """Print a compact summary of generated candidate scenarios.
+
+    Falls back to a clear "no candidates generated" message when the
+    safety gate refused every attempt; the saved Markdown still records
+    why so the user can audit.
+    """
+    typer.echo("")
+    typer.echo("Candidate scenarios (bounded; not optimized)")
+    typer.echo("")
+
+    constraints = result.constraints
+    typer.echo(
+        f"  Constraints: budget_mode={constraints.budget_mode}, "
+        f"top_n={constraints.top_n}, "
+        f"max_channel_change={constraints.max_channel_change:.0%}, "
+        f"max_total_moved_budget={constraints.max_total_moved_budget:.0%}"
+    )
+    if result.blocked_channels:
+        joined = ", ".join(
+            f"{channel} ({_BLOCKED_REASON_LABELS.get(reason, reason)})"
+            for channel, reason in sorted(result.blocked_channels.items())
+        )
+        typer.echo(typer.style(f"  Blocked channels: {joined}", fg=typer.colors.YELLOW))
+
+    if not result.candidates:
+        typer.echo(
+            typer.style(
+                "  No candidate plans were produced. "
+                "Either no eligible donor/recipient pair exists or every "
+                "attempt failed the safety gate. See the saved report for details.",
+                fg=typer.colors.YELLOW,
+            )
+        )
+        return
+
+    typer.echo("")
+    typer.echo(
+        f"  {'Rank':<5} {'Plan':<36} {'Expected outcome':>18} "
+        f"{'Delta vs baseline':>16} {'P(beats)':>10} {'P(loss)':>9}"
+    )
+    for rank, ranked in enumerate(result.rankings, start=1):
+        if ranked.is_baseline:
+            delta_label = "—"
+            p_beats_label = "—"
+            p_loss_label = "—"
+        else:
+            delta_label = f"{ranked.delta_vs_baseline_mean:+,.0f}"
+            p_beats_label = f"{ranked.probability_beats_baseline:.0%}"
+            p_loss_label = f"{ranked.probability_material_loss:.0%}"
+        marker = " (baseline)" if ranked.is_baseline else ""
+        plan_label = (ranked.plan_name + marker)[:36]
+        typer.echo(
+            f"  {rank:<5} {plan_label:<36} "
+            f"{ranked.expected_outcome_mean:>18,.0f} "
+            f"{delta_label:>16} {p_beats_label:>10} {p_loss_label:>9}"
+        )
+
+    typer.echo("")
+    for ranked in result.rankings:
+        typer.echo(f"  {ranked.plan_name}: {ranked.interpretation}")
+
+    if written:
+        typer.echo("")
+        typer.echo(f"  Wrote {len(written)} candidate CSV(s) to {written[0].parent}")
+
+
+def _format_suggest_scenarios_markdown(
+    result: Any,
+    run_id: str,
+    written: list[Path],
+) -> str:
+    """Saved Markdown report for ``suggest-scenarios``.
+
+    Leads with "Constraints used" so the audit context is visible
+    before any ranking, then per-candidate decision text, then the
+    blocked-channel and rejection lists so users see *why* certain
+    intuitive moves were not generated.
+    """
+    from wanamaker.forecast import format_constraints_markdown
+
+    lines: list[str] = []
+    lines.append("# Candidate scenarios")
+    lines.append("")
+    lines.append(
+        "_The model ranks the candidate plans listed below; it does "
+        "not perform constrained optimization. These are bounded "
+        "candidate plans within the explicit constraints in the next "
+        "section._"
+    )
+    lines.append("")
+    lines.append(f"- Run ID: `{run_id}`")
+    lines.append(f"- Baseline plan: `{result.baseline_label}`")
+    lines.append(f"- Candidates produced: {len(result.candidates)}")
+    lines.append("")
+    lines.append(format_constraints_markdown(result.constraints))
+
+    if result.blocked_channels:
+        lines.append("## Channels excluded from reallocation")
+        lines.append("")
+        for channel, reason in sorted(result.blocked_channels.items()):
+            label = _BLOCKED_REASON_LABELS.get(reason, reason)
+            lines.append(f"- `{channel}` — {label}")
+        lines.append("")
+
+    if not result.candidates:
+        lines.append("## No candidate plans produced")
+        lines.append("")
+        lines.append(
+            "Either no eligible donor/recipient pair exists or every "
+            "attempt failed the safety gate. The blocked-channel list "
+            "above and the rejection trail below explain why."
+        )
+        lines.append("")
+        if result.rejections:
+            lines.append("### Rejected attempts")
+            lines.append("")
+            for rejection in result.rejections:
+                lines.append(f"- `{rejection.candidate_label}` — {rejection.reason}")
+            lines.append("")
+        return "\n".join(lines) + "\n"
+
+    lines.append("## Decision ranking")
+    lines.append("")
+    lines.append(
+        "| Rank | Plan | Expected outcome | Delta vs baseline | "
+        "P(beats baseline) | P(material loss) |"
+    )
+    lines.append("|---|---|---:|---:|---:|---:|")
+    for rank, ranked in enumerate(result.rankings, start=1):
+        if ranked.is_baseline:
+            plan_cell = f"`{ranked.plan_name}` (baseline)"
+            delta_cell = "—"
+            p_beats_cell = "—"
+            p_loss_cell = "—"
+        else:
+            plan_cell = f"`{ranked.plan_name}`"
+            delta_cell = f"{ranked.delta_vs_baseline_mean:+,.0f}"
+            p_beats_cell = f"{ranked.probability_beats_baseline:.0%}"
+            p_loss_cell = f"{ranked.probability_material_loss:.0%}"
+        lines.append(
+            f"| {rank} | {plan_cell} | "
+            f"{ranked.expected_outcome_mean:,.0f} | "
+            f"{delta_cell} | {p_beats_cell} | {p_loss_cell} |"
+        )
+    lines.append("")
+
+    lines.append("## How to read each candidate")
+    lines.append("")
+    for ranked in result.rankings:
+        lines.append(f"- **`{ranked.plan_name}`** — {ranked.interpretation}")
+    lines.append("")
+
+    lines.append("## Generated reallocations")
+    lines.append("")
+    lines.append("| Candidate | Donor | Recipient | Moved amount | Moved share |")
+    lines.append("|---|---|---|---:|---:|")
+    for candidate in result.candidates:
+        lines.append(
+            f"| `{candidate.label}` | `{candidate.donor_channel}` | "
+            f"`{candidate.recipient_channel}` | "
+            f"{candidate.moved_amount:,.0f} | "
+            f"{candidate.moved_share:.1%} |"
+        )
+    lines.append("")
+
+    if written:
+        lines.append("## Candidate CSVs")
+        lines.append("")
+        for path in written:
+            lines.append(f"- `{path.name}`")
+        lines.append(
+            "\n_These CSVs are ready to pass into `wanamaker compare-scenarios` "
+            "if you want to drill into a specific subset._"
+        )
+        lines.append("")
+
+    if result.rejections:
+        lines.append("## Rejected attempts")
+        lines.append("")
+        lines.append(
+            "Attempts that failed the fail-closed safety gate. Each "
+            "rejection includes the constraint that the candidate violated."
+        )
+        lines.append("")
+        for rejection in result.rejections:
+            lines.append(f"- `{rejection.candidate_label}` — {rejection.reason}")
+        lines.append("")
+
     return "\n".join(lines) + "\n"
 
 

--- a/src/wanamaker/forecast/__init__.py
+++ b/src/wanamaker/forecast/__init__.py
@@ -19,6 +19,12 @@ from wanamaker.forecast.constraints import (
     resolve_scenario_generation_constraints,
     validate_candidate_spend,
 )
+from wanamaker.forecast.generator import (
+    CandidatePlan,
+    CandidateRejection,
+    CandidateScenarioSet,
+    suggest_scenarios,
+)
 from wanamaker.forecast.posterior_predictive import (
     ExtrapolationFlag,
     ForecastResult,
@@ -27,6 +33,9 @@ from wanamaker.forecast.posterior_predictive import (
 )
 
 __all__ = [
+    "CandidatePlan",
+    "CandidateRejection",
+    "CandidateScenarioSet",
     "ExtrapolationFlag",
     "ForecastResult",
     "PosteriorPredictiveEngine",
@@ -34,5 +43,6 @@ __all__ = [
     "format_constraints_markdown",
     "forecast",
     "resolve_scenario_generation_constraints",
+    "suggest_scenarios",
     "validate_candidate_spend",
 ]

--- a/src/wanamaker/forecast/generator.py
+++ b/src/wanamaker/forecast/generator.py
@@ -1,0 +1,390 @@
+"""Bounded candidate scenario generation (issue #85).
+
+v1 takes a baseline plan plus the run's posterior summary and produces a
+small, ranked set of candidate budget plans that each respect the
+explicit constraint contract from issue #88. It is *not* an optimizer:
+candidates are deterministic donor-to-recipient reallocations between
+eligible channels, every candidate is gated through
+``validate_candidate_spend`` before forecasting, and the surviving plans
+are ranked using the existing ``compare_scenarios`` machinery so deltas
+are paired by draw against the baseline.
+
+Eligibility rules (the safety contract #89 will benchmark):
+
+- Locked channels never change.
+- Excluded channels are never sources or destinations.
+- ``spend_invariant`` channels (FR-3.2) are never sources or destinations.
+- Channels with zero baseline spend are not used because percentage
+  changes are undefined from zero (matches ``validate_candidate_spend``).
+- ``require_historical_support=True`` rejects candidates whose per-period
+  spend would step outside the channel's observed historical range.
+
+Per AGENTS.md "Product terminology": output uses cautious decision
+language. These are *candidate plans*, not "optimal" or "best" budgets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+import pandas as pd
+
+from wanamaker.engine.summary import PosteriorSummary
+from wanamaker.forecast.constraints import (
+    ScenarioGenerationConstraints,
+    validate_candidate_spend,
+)
+from wanamaker.forecast.posterior_predictive import (
+    PosteriorPredictiveEngine,
+    load_plan,
+)
+from wanamaker.forecast.scenarios import (
+    ScenarioComparisonResult,
+    compare_scenarios,
+)
+
+
+@dataclass(frozen=True)
+class CandidateRejection:
+    """Audit record for a candidate that failed the safety gate."""
+
+    candidate_label: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class CandidatePlan:
+    """A bounded candidate plan that survived every constraint check.
+
+    Attributes:
+        label: Stable identifier suitable for filenames and table rows.
+        plan: Wide period-channel DataFrame ready for ``forecast`` /
+            ``compare_scenarios`` consumption.
+        donor_channel: The channel whose spend was reduced.
+        recipient_channel: The channel whose spend was increased.
+        moved_amount: Absolute spend transferred from donor to recipient.
+        moved_share: ``moved_amount`` as a fraction of baseline total spend.
+    """
+
+    label: str
+    plan: pd.DataFrame
+    donor_channel: str
+    recipient_channel: str
+    moved_amount: float
+    moved_share: float
+
+
+@dataclass(frozen=True)
+class CandidateScenarioSet:
+    """The complete result of ``suggest_scenarios``.
+
+    Attributes:
+        baseline_label: Display name used for the baseline plan.
+        constraints: Resolved constraints that shaped this run.
+        candidates: Surviving candidate plans, in generation order.
+        rankings: ``ScenarioComparisonResult`` list including the
+            baseline plus every candidate, sorted as
+            ``compare_scenarios`` returned them.
+        rejections: Candidates that failed the safety gate, with the
+            triggering reason. Useful to surface in the report so users
+            see why some intuitive moves were not produced.
+        blocked_channels: Channels excluded from generation, mapped to
+            the disqualifying reason: ``"locked"``, ``"excluded"``,
+            ``"spend_invariant"``, ``"zero_baseline"``.
+    """
+
+    baseline_label: str
+    constraints: ScenarioGenerationConstraints
+    candidates: list[CandidatePlan] = field(default_factory=list)
+    rankings: list[ScenarioComparisonResult] = field(default_factory=list)
+    rejections: list[CandidateRejection] = field(default_factory=list)
+    blocked_channels: dict[str, str] = field(default_factory=dict)
+
+
+def suggest_scenarios(
+    posterior_summary: PosteriorSummary,
+    baseline: str | Path | pd.DataFrame,
+    constraints: ScenarioGenerationConstraints,
+    seed: int,
+    engine: PosteriorPredictiveEngine,
+    *,
+    baseline_label: str = "baseline",
+) -> CandidateScenarioSet:
+    """Generate up to ``top_n`` bounded candidate budget plans, ranked.
+
+    Args:
+        posterior_summary: Engine-neutral summary from a completed fit.
+            Provides per-channel ROI means, observed spend ranges, and
+            ``spend_invariant`` flags.
+        baseline: Baseline plan as a CSV path or a DataFrame in any of
+            the shapes ``load_plan`` accepts.
+        constraints: Resolved scenario-generation constraints. Generation
+            never violates these; ``validate_candidate_spend`` is the
+            fail-closed gate.
+        seed: Posterior-predictive seed. Reused across all forecasts so
+            ``compare_scenarios`` can pair deltas by draw.
+        engine: Implementation of ``PosteriorPredictiveEngine``.
+        baseline_label: Display name to use for the baseline plan.
+
+    Returns:
+        A ``CandidateScenarioSet`` with every surviving candidate, the
+        ranking, the audit trail of rejections, and the blocked-channel
+        map. ``candidates`` is empty when no eligible donor/recipient
+        pair exists or when every attempt failed the safety gate.
+    """
+    required_channels = [c.channel for c in posterior_summary.channel_contributions]
+    baseline_plan = load_plan(baseline, required_channels)
+    baseline_totals = {
+        channel: float(baseline_plan.data[channel].sum())
+        for channel in required_channels
+    }
+
+    blocked = _compute_blocked_channels(
+        posterior_summary, constraints, baseline_totals
+    )
+    eligible = [
+        contribution.channel
+        for contribution in posterior_summary.channel_contributions
+        if contribution.channel not in blocked
+    ]
+    roi_by_channel = {
+        contribution.channel: contribution.roi_mean
+        for contribution in posterior_summary.channel_contributions
+    }
+    donors_ranked = sorted(eligible, key=lambda ch: (roi_by_channel[ch], ch))
+    recipients_ranked = sorted(eligible, key=lambda ch: (-roi_by_channel[ch], ch))
+
+    candidates: list[CandidatePlan] = []
+    rejections: list[CandidateRejection] = []
+    seen_signatures: set[tuple[tuple[str, float], ...]] = {
+        _plan_signature(baseline_totals)
+    }
+
+    for donor, recipient, fraction in _candidate_moves(
+        donors_ranked, recipients_ranked, constraints
+    ):
+        if len(candidates) >= constraints.top_n:
+            break
+        if donor == recipient:
+            continue
+        amount = baseline_totals[donor] * fraction
+        if amount <= 0:
+            continue
+
+        candidate_totals = dict(baseline_totals)
+        candidate_totals[donor] = baseline_totals[donor] - amount
+        candidate_totals[recipient] = baseline_totals[recipient] + amount
+
+        label = _candidate_label(len(candidates) + 1, donor, recipient)
+
+        try:
+            validate_candidate_spend(baseline_totals, candidate_totals, constraints)
+        except ValueError as exc:
+            rejections.append(CandidateRejection(label, str(exc)))
+            continue
+
+        signature = _plan_signature(candidate_totals)
+        if signature in seen_signatures:
+            continue
+
+        candidate_df = _build_plan_dataframe(
+            baseline_plan.data,
+            baseline_totals,
+            candidate_totals,
+            required_channels,
+        )
+
+        if constraints.require_historical_support and _violates_historical_support(
+            candidate_df, posterior_summary, required_channels
+        ):
+            rejections.append(
+                CandidateRejection(
+                    label,
+                    "candidate exceeds observed historical spend range "
+                    "(require_historical_support is true)",
+                )
+            )
+            continue
+
+        seen_signatures.add(signature)
+        baseline_total = sum(baseline_totals.values())
+        moved_share = amount / baseline_total if baseline_total > 0 else 0.0
+        candidates.append(
+            CandidatePlan(
+                label=label,
+                plan=candidate_df,
+                donor_channel=donor,
+                recipient_channel=recipient,
+                moved_amount=amount,
+                moved_share=moved_share,
+            )
+        )
+
+    rankings = _rank_candidates(
+        posterior_summary,
+        baseline_plan.data,
+        baseline_label,
+        candidates,
+        seed,
+        engine,
+    )
+
+    return CandidateScenarioSet(
+        baseline_label=baseline_label,
+        constraints=constraints,
+        candidates=candidates,
+        rankings=rankings,
+        rejections=rejections,
+        blocked_channels=blocked,
+    )
+
+
+def _compute_blocked_channels(
+    posterior_summary: PosteriorSummary,
+    constraints: ScenarioGenerationConstraints,
+    baseline_totals: dict[str, float],
+) -> dict[str, str]:
+    """Reasons each channel is excluded from reallocation, in priority order.
+
+    Locked first, then excluded, then spend_invariant, then zero_baseline.
+    The first matching reason wins so the caller can show the most
+    actionable explanation (e.g. "you locked this channel" beats "this
+    channel is spend-invariant").
+    """
+    blocked: dict[str, str] = {}
+    locked = set(constraints.locked_channels)
+    excluded = set(constraints.excluded_channels)
+    for contribution in posterior_summary.channel_contributions:
+        channel = contribution.channel
+        if channel in locked:
+            blocked[channel] = "locked"
+        elif channel in excluded:
+            blocked[channel] = "excluded"
+        elif contribution.spend_invariant:
+            blocked[channel] = "spend_invariant"
+        elif baseline_totals.get(channel, 0.0) <= 0:
+            blocked[channel] = "zero_baseline"
+    return blocked
+
+
+def _candidate_moves(
+    donors_ranked: list[str],
+    recipients_ranked: list[str],
+    constraints: ScenarioGenerationConstraints,
+) -> list[tuple[str, str, float]]:
+    """Enumerate (donor, recipient, move_fraction) tuples deterministically.
+
+    The order fans across pairs first, then move sizes, so the first
+    survivors are diverse pairs rather than many sizes of the same pair.
+    """
+    if not donors_ranked or not recipients_ranked:
+        return []
+
+    max_change = constraints.max_channel_change
+    if max_change <= 0:
+        return []
+
+    fractions = (max_change, max_change * 0.5, max_change * 0.25)
+    moves: list[tuple[str, str, float]] = []
+    n_donors = len(donors_ranked)
+    n_recipients = len(recipients_ranked)
+
+    for fraction in fractions:
+        for donor_idx in range(n_donors):
+            for recipient_idx in range(n_recipients):
+                donor = donors_ranked[donor_idx]
+                recipient = recipients_ranked[recipient_idx]
+                if donor == recipient:
+                    continue
+                moves.append((donor, recipient, fraction))
+    return moves
+
+
+def _plan_signature(totals: dict[str, float]) -> tuple[tuple[str, float], ...]:
+    """Stable hashable signature of channel totals for deduplication.
+
+    Rounded so floating-point noise across two equivalent reallocations
+    doesn't slip past the dedupe check.
+    """
+    return tuple(sorted((channel, round(value, 6)) for channel, value in totals.items()))
+
+
+def _build_plan_dataframe(
+    baseline_data: pd.DataFrame,
+    baseline_totals: dict[str, float],
+    candidate_totals: dict[str, float],
+    required_channels: list[str],
+) -> pd.DataFrame:
+    """Scale baseline columns proportionally to hit candidate channel totals.
+
+    Keeps each channel's temporal shape identical to the baseline; only
+    the scale changes. Channels with zero baseline get a uniform spread,
+    but those are blocked upstream so this branch is defensive.
+    """
+    candidate = baseline_data.copy()
+    n_periods = max(len(candidate), 1)
+    for channel in required_channels:
+        baseline_total = baseline_totals[channel]
+        target_total = candidate_totals[channel]
+        if baseline_total > 0:
+            scale = target_total / baseline_total
+            candidate[channel] = candidate[channel].astype(float) * scale
+        else:
+            candidate[channel] = float(target_total) / n_periods
+    return candidate
+
+
+def _violates_historical_support(
+    plan_df: pd.DataFrame,
+    posterior_summary: PosteriorSummary,
+    required_channels: list[str],
+) -> bool:
+    ranges = {
+        contribution.channel: (
+            float(contribution.observed_spend_min),
+            float(contribution.observed_spend_max),
+        )
+        for contribution in posterior_summary.channel_contributions
+    }
+    for channel in required_channels:
+        low, high = ranges[channel]
+        column = plan_df[channel].astype(float)
+        if (column > high).any() or (column < low).any():
+            return True
+    return False
+
+
+def _candidate_label(index: int, donor: str, recipient: str) -> str:
+    return f"candidate_{index}_{donor}_to_{recipient}"
+
+
+def _rank_candidates(
+    posterior_summary: PosteriorSummary,
+    baseline_data: pd.DataFrame,
+    baseline_label: str,
+    candidates: list[CandidatePlan],
+    seed: int,
+    engine: PosteriorPredictiveEngine,
+) -> list[ScenarioComparisonResult]:
+    """Rank baseline + candidates via ``compare_scenarios`` with stable labels.
+
+    ``compare_scenarios`` labels DataFrame inputs ``Plan {i+1}``; we
+    relabel the results to the baseline label and the candidate labels
+    we minted above so the ranking ties back to the candidate CSVs.
+    """
+    if not candidates:
+        return []
+    plans: list[str | Path | pd.DataFrame] = [baseline_data.copy()]
+    plans.extend(candidate.plan.copy() for candidate in candidates)
+
+    raw_rankings = compare_scenarios(posterior_summary, plans, seed, engine)
+    label_for_position = [baseline_label, *(candidate.label for candidate in candidates)]
+    name_map = {
+        f"Plan {position + 1}": label_for_position[position]
+        for position in range(len(label_for_position))
+    }
+    return [
+        replace(result, plan_name=name_map.get(result.plan_name, result.plan_name))
+        for result in raw_rankings
+    ]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -27,6 +27,7 @@ def test_help_lists_public_commands() -> None:
         "forecast",
         "compare-scenarios",
         "compare-calibration",
+        "suggest-scenarios",
         "recommend-ramp",
         "refresh",
     ):

--- a/tests/unit/test_cli_suggest_scenarios.py
+++ b/tests/unit/test_cli_suggest_scenarios.py
@@ -276,6 +276,42 @@ def test_suggest_scenarios_no_candidates_exits_non_zero(
     assert "## No candidate plans produced" in report
 
 
+@pytest.mark.parametrize(
+    ("flag", "value", "match_substring"),
+    [
+        ("--top-n", "0", "top_n"),
+        ("--max-channel-change", "2.0", "max_channel_change"),
+        ("--budget-mode", "nonsense", "budget_mode"),
+    ],
+)
+def test_suggest_scenarios_rejects_invalid_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str,
+    value: str,
+    match_substring: str,
+) -> None:
+    """Invalid CLI overrides must fail closed before any generation runs.
+
+    Pydantic validates the override round-trip; ``--top-n 0``,
+    ``--max-channel-change 2.0``, and ``--budget-mode nonsense`` should
+    each surface as a non-zero exit with an actionable error.
+    """
+    result, run_dir, _ = _invoke(
+        tmp_path, monkeypatch, extra_args=(flag, value),
+    )
+
+    assert result.exit_code == 1, result.output
+    combined = (result.output or "") + (result.stderr or "")
+    assert "invalid scenario_generation override" in combined, combined
+    assert match_substring in combined, combined
+    # Generation must not have run: no candidate CSVs and no report.
+    assert not (run_dir / "candidates").exists() or not list(
+        (run_dir / "candidates").glob("*.csv")
+    )
+    assert not (run_dir / "scenario_suggestions.md").exists()
+
+
 def test_suggest_scenarios_reads_yaml_constraint_block(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_cli_suggest_scenarios.py
+++ b/tests/unit/test_cli_suggest_scenarios.py
@@ -1,0 +1,308 @@
+"""Tests for the ``wanamaker suggest-scenarios`` CLI command (issue #85).
+
+The CLI orchestration mirrors ``forecast`` and ``compare-scenarios``: it
+reconstructs the run, binds a saved posterior to the engine adapter,
+calls the engine-neutral generator core, writes candidate CSVs, and
+saves a deterministic Markdown report. These tests stub
+``PyMCEngine.load_posterior`` and ``PyMCEngine.posterior_predictive``
+so no PyMC sampling is invoked.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from wanamaker.artifacts import serialize_summary
+from wanamaker.engine.base import Posterior
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    ConvergenceSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+
+runner = CliRunner()
+
+DATA_CSV = textwrap.dedent(
+    """\
+    week,revenue,search,tv,affiliate
+    2024-01-01,100,10,50,5
+    2024-01-08,110,12,55,6
+    2024-01-15,120,15,60,7
+    2024-01-22,118,10,58,5
+    """
+)
+
+
+def _write_data_csv(tmp_path: Path) -> Path:
+    path = tmp_path / "data.csv"
+    path.write_text(DATA_CSV)
+    return path
+
+
+def _write_baseline_csv(tmp_path: Path, *, name: str = "baseline.csv") -> Path:
+    path = tmp_path / name
+    path.write_text(
+        "period,search,tv,affiliate\n"
+        "2026-W01,25,25,25\n"
+        "2026-W02,25,25,25\n"
+        "2026-W03,25,25,25\n"
+        "2026-W04,25,25,25\n"
+    )
+    return path
+
+
+def _summary(
+    *, spend_invariant: dict[str, bool] | None = None
+) -> PosteriorSummary:
+    spend_invariant = spend_invariant or {}
+    return PosteriorSummary(
+        parameters=[],
+        channel_contributions=[
+            ChannelContributionSummary(
+                channel="search",
+                mean_contribution=500.0, hdi_low=400.0, hdi_high=600.0,
+                roi_mean=3.0, roi_hdi_low=2.0, roi_hdi_high=4.0,
+                observed_spend_min=10.0, observed_spend_max=200.0,
+                spend_invariant=spend_invariant.get("search", False),
+            ),
+            ChannelContributionSummary(
+                channel="tv",
+                mean_contribution=200.0, hdi_low=150.0, hdi_high=250.0,
+                roi_mean=1.0, roi_hdi_low=0.5, roi_hdi_high=1.5,
+                observed_spend_min=10.0, observed_spend_max=200.0,
+                spend_invariant=spend_invariant.get("tv", False),
+            ),
+            ChannelContributionSummary(
+                channel="affiliate",
+                mean_contribution=80.0, hdi_low=60.0, hdi_high=100.0,
+                roi_mean=0.3, roi_hdi_low=0.1, roi_hdi_high=0.5,
+                observed_spend_min=10.0, observed_spend_max=200.0,
+                spend_invariant=spend_invariant.get("affiliate", False),
+            ),
+        ],
+        convergence=ConvergenceSummary(
+            max_r_hat=1.001,
+            min_ess_bulk=800.0,
+            n_divergences=0,
+            n_chains=4,
+            n_draws=500,
+        ),
+    )
+
+
+def _write_run(
+    tmp_path: Path,
+    *,
+    csv_path: Path,
+    artifact_dir: Path,
+    summary: PosteriorSummary | None = None,
+    scenario_generation_yaml: str | None = None,
+    run_id: str = "00000000_20260101T000000Z",
+) -> Path:
+    run_dir = artifact_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    config_text = textwrap.dedent(
+        f"""\
+        data:
+          csv_path: {csv_path.as_posix()}
+          date_column: week
+          target_column: revenue
+          spend_columns: [search, tv, affiliate]
+        channels:
+          - {{name: search, category: paid_search}}
+          - {{name: tv, category: linear_tv}}
+          - {{name: affiliate, category: affiliate}}
+        run:
+          seed: 7
+          runtime_mode: quick
+        """
+    )
+    if scenario_generation_yaml is not None:
+        config_text += scenario_generation_yaml
+    (run_dir / "config.yaml").write_text(config_text)
+    (run_dir / "summary.json").write_text(serialize_summary(summary or _summary()))
+    (run_dir / "posterior.nc").write_bytes(b"fake")
+    return run_dir
+
+
+def _install_stub_engine(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Linear stub: outcome = 3*search + 1*tv + 0.3*affiliate."""
+    captured: dict[str, Any] = {"seeds": []}
+
+    def _load_posterior(self: Any, run_dir: Any, model_spec: Any, data: Any) -> Any:
+        captured["run_dir"] = run_dir
+        captured["model_spec"] = model_spec
+        captured["data_rows"] = len(data)
+        return Posterior(raw=object())
+
+    def _posterior_predictive(
+        self: Any, posterior: Any, new_data: Any, seed: int  # noqa: ARG001
+    ) -> PredictiveSummary:
+        captured["seeds"].append(seed)
+        df = pd.DataFrame(new_data)
+        means = (
+            df["search"].astype(float).to_numpy() * 3.0
+            + df["tv"].astype(float).to_numpy() * 1.0
+            + df["affiliate"].astype(float).to_numpy() * 0.3
+        )
+        # 50 draws with a small symmetric perturbation around the mean.
+        rng = np.random.default_rng(seed)
+        noise = rng.normal(0.0, 0.05, size=(50, len(df)))
+        draws = means[None, :] * (1.0 + noise)
+        return PredictiveSummary(
+            periods=df["period"].astype(str).tolist(),
+            mean=means.tolist(),
+            hdi_low=np.quantile(draws, 0.025, axis=0).tolist(),
+            hdi_high=np.quantile(draws, 0.975, axis=0).tolist(),
+            draws=draws.tolist(),
+        )
+
+    monkeypatch.setattr(
+        "wanamaker.engine.pymc.PyMCEngine.load_posterior",
+        _load_posterior,
+    )
+    monkeypatch.setattr(
+        "wanamaker.engine.pymc.PyMCEngine.posterior_predictive",
+        _posterior_predictive,
+    )
+    return captured
+
+
+def _invoke(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    extra_args: tuple[str, ...] = (),
+    summary: PosteriorSummary | None = None,
+    scenario_generation_yaml: str | None = None,
+) -> tuple[Any, Path, Path]:
+    artifact_dir = tmp_path / ".wanamaker"
+    csv = _write_data_csv(tmp_path)
+    run_dir = _write_run(
+        tmp_path,
+        csv_path=csv,
+        artifact_dir=artifact_dir,
+        summary=summary,
+        scenario_generation_yaml=scenario_generation_yaml,
+    )
+    baseline = _write_baseline_csv(tmp_path)
+    _install_stub_engine(monkeypatch)
+
+    from wanamaker.cli import app
+
+    args = [
+        "suggest-scenarios",
+        "--run-id",
+        "00000000_20260101T000000Z",
+        "--baseline",
+        str(baseline),
+        "--artifact-dir",
+        str(artifact_dir),
+        *extra_args,
+    ]
+    result = runner.invoke(app, args)
+    return result, run_dir, baseline
+
+
+def test_suggest_scenarios_writes_candidate_csvs_and_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result, run_dir, _ = _invoke(tmp_path, monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    candidates_dir = run_dir / "candidates"
+    assert candidates_dir.is_dir()
+    csvs = sorted(candidates_dir.glob("*.csv"))
+    assert csvs, "expected at least one candidate CSV"
+    for csv in csvs:
+        df = pd.read_csv(csv)
+        assert set(df.columns) == {"period", "search", "tv", "affiliate"}
+        assert len(df) == 4
+
+    report = (run_dir / "scenario_suggestions.md").read_text(encoding="utf-8")
+    assert "# Candidate scenarios" in report
+    assert "## Constraints used" in report
+    assert "## Decision ranking" in report
+
+
+def test_suggest_scenarios_top_n_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result, run_dir, _ = _invoke(
+        tmp_path, monkeypatch, extra_args=("--top-n", "2"),
+    )
+
+    assert result.exit_code == 0, result.output
+    csvs = sorted((run_dir / "candidates").glob("*.csv"))
+    assert len(csvs) <= 2
+
+
+def test_suggest_scenarios_reports_blocked_spend_invariant_channel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result, run_dir, _ = _invoke(
+        tmp_path, monkeypatch,
+        summary=_summary(spend_invariant={"affiliate": True}),
+    )
+
+    assert result.exit_code == 0, result.output
+    report = (run_dir / "scenario_suggestions.md").read_text(encoding="utf-8")
+    assert "## Channels excluded from reallocation" in report
+    assert "affiliate" in report
+    assert "spend-invariant" in report
+
+
+def test_suggest_scenarios_no_candidates_exits_non_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Block all three channels → no donor/recipient pair → exit code 1."""
+    result, run_dir, _ = _invoke(
+        tmp_path, monkeypatch,
+        summary=_summary(
+            spend_invariant={"search": True, "tv": True, "affiliate": True}
+        ),
+    )
+
+    assert result.exit_code == 1
+    report = (run_dir / "scenario_suggestions.md").read_text(encoding="utf-8")
+    assert "## No candidate plans produced" in report
+
+
+def test_suggest_scenarios_reads_yaml_constraint_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Locked channel from YAML survives into the generator's blocked set."""
+    yaml_block = textwrap.dedent(
+        """\
+        scenario_generation:
+          top_n: 3
+          max_channel_change: 0.15
+          max_total_moved_budget: 0.50
+          locked_channels: [tv]
+        """
+    )
+    result, run_dir, _ = _invoke(
+        tmp_path, monkeypatch, scenario_generation_yaml=yaml_block,
+    )
+
+    assert result.exit_code == 0, result.output
+    candidates_dir = run_dir / "candidates"
+    csvs = sorted(candidates_dir.glob("*.csv"))
+    assert csvs
+
+    # Every candidate must leave tv unchanged at the per-channel total.
+    expected_tv_total = 100.0
+    for csv in csvs:
+        df = pd.read_csv(csv)
+        assert df["tv"].sum() == pytest.approx(expected_tv_total, rel=1e-6)
+
+    report = (run_dir / "scenario_suggestions.md").read_text(encoding="utf-8")
+    assert "Locked channels: `tv`" in report

--- a/tests/unit/test_suggest_scenarios.py
+++ b/tests/unit/test_suggest_scenarios.py
@@ -1,0 +1,619 @@
+"""Tests for bounded candidate scenario generation (issue #85).
+
+The generator is engine-neutral: it takes a ``PosteriorPredictiveEngine``
+and a ``PosteriorSummary``, and validates every candidate plan via
+``validate_candidate_spend`` before forecasting. These tests exercise:
+
+- Constraint enforcement: every produced candidate satisfies the
+  baseline-vs-candidate validator (no max-channel-change violation,
+  total budget preserved when ``hold_total``, no movement above
+  ``max_total_moved_budget``, no min/max spend bound violation).
+- Channel blocking: locked, excluded, spend-invariant, and
+  zero-baseline channels never appear as donors or recipients.
+- Deduplication: equivalent plans collapse so ``top_n`` is a count of
+  distinct candidates, not raw enumeration steps.
+- Historical-support gating: when ``require_historical_support`` is
+  on, candidates that step outside observed spend ranges are rejected
+  and surfaced in the rejections audit trail.
+- Ranking integration: ``compare_scenarios`` is called once with the
+  baseline plus every candidate; result labels match the candidate
+  ``label`` (not ``Plan N``).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from wanamaker.config import (
+    ChannelConfig,
+    DataConfig,
+    ScenarioGenerationConfig,
+    WanamakerConfig,
+)
+from wanamaker.engine.summary import (
+    ChannelContributionSummary,
+    PosteriorSummary,
+    PredictiveSummary,
+)
+from wanamaker.forecast import (
+    resolve_scenario_generation_constraints,
+    suggest_scenarios,
+)
+from wanamaker.forecast.constraints import validate_candidate_spend
+
+# ---------------------------------------------------------------------------
+# Stub engine + reusable summary
+# ---------------------------------------------------------------------------
+
+
+class _LinearEngine:
+    """Predictive mean is a fixed linear combination of planned spend.
+
+    Returning a non-trivial ``draws`` matrix lets ``compare_scenarios``
+    compute paired deltas (otherwise it falls back to 0.5 / 0.0
+    placeholders).
+    """
+
+    def __init__(self, coefficients: dict[str, float]) -> None:
+        self.coefficients = dict(coefficients)
+        self.calls = 0
+
+    def posterior_predictive(
+        self,
+        posterior_summary: PosteriorSummary,  # noqa: ARG002
+        new_data: pd.DataFrame,
+        seed: int,  # noqa: ARG002
+    ) -> PredictiveSummary:
+        self.calls += 1
+        per_period_mean = pd.Series(0.0, index=new_data.index, dtype=float)
+        for channel, coef in self.coefficients.items():
+            per_period_mean = per_period_mean + new_data[channel].astype(float) * coef
+        # Two draws: a tight band around the mean. Enough to give
+        # compare_scenarios a real per-draw matrix without making the
+        # test sensitive to sampling noise.
+        draws = [
+            (per_period_mean * 0.95).tolist(),
+            (per_period_mean * 1.05).tolist(),
+        ]
+        return PredictiveSummary(
+            periods=new_data["period"].astype(str).tolist(),
+            mean=per_period_mean.tolist(),
+            hdi_low=(per_period_mean * 0.80).tolist(),
+            hdi_high=(per_period_mean * 1.20).tolist(),
+            draws=draws,
+        )
+
+
+def _summary(
+    *,
+    spend_invariant: dict[str, bool] | None = None,
+    rois: dict[str, float] | None = None,
+    spend_ranges: dict[str, tuple[float, float]] | None = None,
+) -> PosteriorSummary:
+    """Build a posterior summary with three channels: search, tv, affiliate."""
+    spend_invariant = spend_invariant or {}
+    rois = rois or {"search": 3.0, "tv": 1.0, "affiliate": 0.5}
+    spend_ranges = spend_ranges or {
+        "search": (10.0, 200.0),
+        "tv": (10.0, 200.0),
+        "affiliate": (10.0, 200.0),
+    }
+    return PosteriorSummary(
+        channel_contributions=[
+            ChannelContributionSummary(
+                channel=name,
+                mean_contribution=100.0,
+                hdi_low=80.0,
+                hdi_high=120.0,
+                roi_mean=rois[name],
+                observed_spend_min=spend_ranges[name][0],
+                observed_spend_max=spend_ranges[name][1],
+                spend_invariant=spend_invariant.get(name, False),
+            )
+            for name in ("search", "tv", "affiliate")
+        ]
+    )
+
+
+def _baseline(
+    *,
+    search: float = 100.0,
+    tv: float = 100.0,
+    affiliate: float = 100.0,
+    n_periods: int = 4,
+) -> pd.DataFrame:
+    """A flat-across-periods baseline plan."""
+    per_period = {
+        "search": search / n_periods,
+        "tv": tv / n_periods,
+        "affiliate": affiliate / n_periods,
+    }
+    return pd.DataFrame(
+        {
+            "period": [f"2026-W{i + 1:02d}" for i in range(n_periods)],
+            "search": [per_period["search"]] * n_periods,
+            "tv": [per_period["tv"]] * n_periods,
+            "affiliate": [per_period["affiliate"]] * n_periods,
+        }
+    )
+
+
+def _config(
+    tmp_path,
+    *,
+    scenario_generation: ScenarioGenerationConfig | None = None,
+) -> WanamakerConfig:
+    csv = tmp_path / "data.csv"
+    csv.write_text(
+        "week,revenue,search,tv,affiliate\n2024-01-01,100,10,20,5\n",
+        encoding="utf-8",
+    )
+    return WanamakerConfig(
+        data=DataConfig(
+            csv_path=csv,
+            date_column="week",
+            target_column="revenue",
+            spend_columns=["search", "tv", "affiliate"],
+        ),
+        channels=[
+            ChannelConfig(name="search", category="paid_search"),
+            ChannelConfig(name="tv", category="linear_tv"),
+            ChannelConfig(name="affiliate", category="affiliate"),
+        ],
+        scenario_generation=scenario_generation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constraint enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_every_candidate_passes_validate_candidate_spend(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=5,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.20,
+            ),
+        )
+    )
+    baseline = _baseline()
+    summary = _summary()
+
+    result = suggest_scenarios(
+        summary, baseline, constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.candidates, "expected at least one candidate"
+    baseline_totals = {
+        channel: float(baseline[channel].sum())
+        for channel in ("search", "tv", "affiliate")
+    }
+    for candidate in result.candidates:
+        candidate_totals = {
+            channel: float(candidate.plan[channel].sum())
+            for channel in ("search", "tv", "affiliate")
+        }
+        validate_candidate_spend(baseline_totals, candidate_totals, constraints)
+
+
+def test_hold_total_preserved_across_every_candidate(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=5,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+    baseline = _baseline()
+    baseline_total = baseline[["search", "tv", "affiliate"]].sum().sum()
+
+    result = suggest_scenarios(
+        _summary(), baseline, constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.candidates
+    for candidate in result.candidates:
+        candidate_total = candidate.plan[["search", "tv", "affiliate"]].sum().sum()
+        assert candidate_total == pytest.approx(baseline_total, rel=1e-9)
+
+
+def test_max_channel_change_respected_per_channel(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=5,
+                max_channel_change=0.10,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+    baseline = _baseline()
+
+    result = suggest_scenarios(
+        _summary(), baseline, constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.candidates
+    for candidate in result.candidates:
+        for channel in ("search", "tv", "affiliate"):
+            base_total = float(baseline[channel].sum())
+            new_total = float(candidate.plan[channel].sum())
+            relative = abs(new_total - base_total) / base_total
+            assert relative <= constraints.max_channel_change + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Channel blocking
+# ---------------------------------------------------------------------------
+
+
+def test_locked_channel_never_changes(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+                locked_channels=["tv"],
+            ),
+        )
+    )
+    baseline = _baseline()
+
+    result = suggest_scenarios(
+        _summary(), baseline, constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.blocked_channels.get("tv") == "locked"
+    for candidate in result.candidates:
+        assert candidate.donor_channel != "tv"
+        assert candidate.recipient_channel != "tv"
+        assert float(candidate.plan["tv"].sum()) == pytest.approx(
+            float(baseline["tv"].sum()), rel=1e-9
+        )
+
+
+def test_excluded_channel_never_used(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+                excluded_channels=["affiliate"],
+            ),
+        )
+    )
+    result = suggest_scenarios(
+        _summary(), _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.blocked_channels.get("affiliate") == "excluded"
+    for candidate in result.candidates:
+        assert candidate.donor_channel != "affiliate"
+        assert candidate.recipient_channel != "affiliate"
+
+
+def test_spend_invariant_channel_blocked_with_explanation(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+    summary = _summary(spend_invariant={"affiliate": True})
+
+    result = suggest_scenarios(
+        summary, _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.blocked_channels.get("affiliate") == "spend_invariant"
+    for candidate in result.candidates:
+        assert candidate.donor_channel != "affiliate"
+        assert candidate.recipient_channel != "affiliate"
+
+
+def test_zero_baseline_channel_blocked(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+    baseline = _baseline(affiliate=0.0)
+
+    result = suggest_scenarios(
+        _summary(), baseline, constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.blocked_channels.get("affiliate") == "zero_baseline"
+    for candidate in result.candidates:
+        assert candidate.donor_channel != "affiliate"
+        assert candidate.recipient_channel != "affiliate"
+
+
+def test_no_candidates_when_only_one_eligible_channel(tmp_path) -> None:
+    """A single eligible channel can't donate to itself; no candidate is possible."""
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=5,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+                locked_channels=["tv"],
+                excluded_channels=["affiliate"],
+            ),
+        )
+    )
+
+    result = suggest_scenarios(
+        _summary(), _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.candidates == []
+    assert "tv" in result.blocked_channels
+    assert "affiliate" in result.blocked_channels
+
+
+# ---------------------------------------------------------------------------
+# Deduplication and ordering
+# ---------------------------------------------------------------------------
+
+
+def test_distinct_candidates_no_duplicates(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=5,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+
+    result = suggest_scenarios(
+        _summary(), _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    signatures = set()
+    for candidate in result.candidates:
+        signature = tuple(
+            (channel, round(float(candidate.plan[channel].sum()), 6))
+            for channel in ("affiliate", "search", "tv")
+        )
+        assert signature not in signatures, "duplicate candidate plan was emitted"
+        signatures.add(signature)
+
+
+def test_top_n_is_a_hard_cap(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=2,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+
+    result = suggest_scenarios(
+        _summary(), _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert len(result.candidates) <= 2
+
+
+# ---------------------------------------------------------------------------
+# Historical support
+# ---------------------------------------------------------------------------
+
+
+def test_historical_support_gate_records_rejection(tmp_path) -> None:
+    """Tighten the recipient's observed range so a 15% increase steps outside it."""
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+                require_historical_support=True,
+            ),
+        )
+    )
+    summary = _summary(
+        spend_ranges={
+            "search": (10.0, 26.0),  # baseline 25/period; 15% bump = 28.75 > 26
+            "tv": (10.0, 200.0),
+            "affiliate": (10.0, 200.0),
+        }
+    )
+
+    result = suggest_scenarios(
+        summary, _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    rejection_reasons = " ".join(r.reason for r in result.rejections)
+    assert "historical" in rejection_reasons.lower(), (
+        "expected at least one rejection citing historical support"
+    )
+
+
+def test_historical_support_disabled_allows_extrapolation(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+                require_historical_support=False,
+            ),
+        )
+    )
+    summary = _summary(
+        spend_ranges={
+            "search": (10.0, 26.0),
+            "tv": (10.0, 200.0),
+            "affiliate": (10.0, 200.0),
+        }
+    )
+
+    result = suggest_scenarios(
+        summary, _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+    )
+
+    assert result.candidates, (
+        "with historical support disabled, candidates should still be produced"
+    )
+    historical_rejections = [
+        r for r in result.rejections if "historical" in r.reason.lower()
+    ]
+    assert historical_rejections == []
+
+
+# ---------------------------------------------------------------------------
+# Ranking integration
+# ---------------------------------------------------------------------------
+
+
+def test_rankings_use_candidate_labels_not_plan_n(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+
+    result = suggest_scenarios(
+        _summary(), _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+        baseline_label="baseline_plan",
+    )
+
+    ranking_names = {ranked.plan_name for ranked in result.rankings}
+    expected = {"baseline_plan", *(c.label for c in result.candidates)}
+    assert ranking_names == expected
+    assert all(
+        not name.startswith("Plan ") for name in ranking_names
+    ), "candidate ranking still has the placeholder 'Plan N' labels"
+
+
+def test_baseline_present_in_ranking_with_is_baseline_flag(tmp_path) -> None:
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+
+    result = suggest_scenarios(
+        _summary(), _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 3.0, "tv": 1.0, "affiliate": 0.5}),
+        baseline_label="baseline_plan",
+    )
+
+    baseline_rows = [r for r in result.rankings if r.is_baseline]
+    assert len(baseline_rows) == 1
+    assert baseline_rows[0].plan_name == "baseline_plan"
+
+
+def test_higher_roi_recipient_is_preferred(tmp_path) -> None:
+    """First donor->recipient pair should move from lowest-ROI to highest-ROI."""
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=1,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+
+    result = suggest_scenarios(
+        _summary(rois={"search": 5.0, "tv": 1.0, "affiliate": 0.2}),
+        _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 5.0, "tv": 1.0, "affiliate": 0.2}),
+    )
+
+    assert len(result.candidates) == 1
+    candidate = result.candidates[0]
+    assert candidate.donor_channel == "affiliate"
+    assert candidate.recipient_channel == "search"
+
+
+# ---------------------------------------------------------------------------
+# Empty paths
+# ---------------------------------------------------------------------------
+
+
+def test_empty_when_no_eligible_pair_records_no_rejections(tmp_path) -> None:
+    """All channels blocked → no rejections (nothing was attempted), no candidates."""
+    constraints = resolve_scenario_generation_constraints(
+        _config(
+            tmp_path,
+            scenario_generation=ScenarioGenerationConfig(
+                top_n=3,
+                max_channel_change=0.15,
+                max_total_moved_budget=0.50,
+            ),
+        )
+    )
+    summary = _summary(
+        spend_invariant={"search": True, "tv": True, "affiliate": True}
+    )
+
+    result = suggest_scenarios(
+        summary, _baseline(), constraints, seed=0,
+        engine=_LinearEngine({"search": 1.0, "tv": 1.0, "affiliate": 1.0}),
+    )
+
+    assert result.candidates == []
+    assert result.rejections == []
+    assert all(
+        reason == "spend_invariant"
+        for reason in result.blocked_channels.values()
+    )


### PR DESCRIPTION
## Summary

Closes #85.

Adds `suggest-scenarios` — a deterministic, fail-closed candidate-plan generator that builds on the constraint contract from #88. The model evaluates the candidates it generates; it does not perform constrained optimization.

## What changed

- New `wanamaker.forecast.generator` module with `suggest_scenarios()` and `CandidatePlan` / `CandidateScenarioSet` / `CandidateRejection` value objects.
- Channel eligibility is computed up front: `locked`, `excluded`, `spend_invariant` (FR-3.2), and `zero_baseline` channels are excluded from being donors or recipients. The reason is preserved per channel so the report can explain *why* intuitive moves weren't produced.
- Candidate enumeration walks donor/recipient pairs sorted by ROI. Every candidate is validated against `validate_candidate_spend` before forecasting; failures are recorded as `CandidateRejection` so the audit trail is visible.
- Optional `require_historical_support` gate rejects candidates whose per-period spend would step outside the channel's observed historical range.
- Surviving candidates are ranked with the existing `compare_scenarios` machinery (paired-by-draw deltas vs baseline). Ranking labels are rewritten from `Plan N` to the candidate label so the table ties back to the candidate CSV file.

CLI surface:

- `wanamaker suggest-scenarios --run-id X --baseline base.csv` writes candidate CSVs to `<run_dir>/candidates/` and a Markdown report to `<run_dir>/scenario_suggestions.md`.
- The Markdown report leads with the resolved constraints, then the ranked decision table, then the per-candidate interpretation, then the reallocation summary, then the rejection trail.
- CLI flags `--top-n`, `--max-channel-change`, and `--budget-mode` override the run config without re-fitting. Channel-level constraints (`locked_channels`, `excluded_channels`, `min_spend`, `max_spend`) are YAML-only by design.
- Exit code is non-zero when no candidates can be produced (every channel blocked, or every attempt failed the safety gate). The Markdown still records why so the failure is auditable.

## Validation

- `pytest tests/unit/test_suggest_scenarios.py -q` → 16 passed (constraint enforcement, channel blocking, deduplication, ranking integration, historical-support gate)
- `pytest tests/unit/test_cli_suggest_scenarios.py -q` → 5 passed (CSV writing, top-n override, blocked-channel reporting, no-candidates exit code, YAML constraint pass-through)
- `pytest tests/unit -q` → 796 passed (no regressions; +21 vs master)
- `ruff check` on all touched files → clean
- `mkdocs build --strict` → clean

## Notes for the reviewer

- This is the generator only. Issue #89 (safety benchmarks) is the natural follow-up and will exercise the same fail-closed contract end-to-end.
- The channel eligibility logic's priority order (locked > excluded > spend-invariant > zero-baseline) was deliberate so the most actionable explanation wins when multiple reasons apply.
- The donor/recipient enumeration prefers diverse pairs over many sizes of the same pair; the dedupe check still drops equivalent plans that come from different enumeration paths.
- I copied the existing `compare-scenarios` markdown style for consistency. The constraint header (`format_constraints_markdown`) was already shipped in #105 and is reused verbatim.